### PR TITLE
S0C-3A-1A: Add projection_version and stuck_reclaim scenarios

### DIFF
--- a/.github/workflows/failure-drills.yml
+++ b/.github/workflows/failure-drills.yml
@@ -43,6 +43,18 @@ jobs:
   drills:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: >-
+          ${{ fromJSON(
+            inputs.scenario == 'all'
+            && '["es_429_inject","es_write_block_4xx","es_down_connect","collector_down","es_bulk_partial","db_claim_contention","stuck_reclaim","duplicate_delivery","projection_version"]'
+            || format('["{0}"]', inputs.scenario)
+          ) }}
+
+    name: ${{ matrix.scenario }}
+
     defaults:
       run:
         shell: bash
@@ -178,7 +190,7 @@ jobs:
 
       - name: Run → Verify → Export → Clean
         env:
-          FAULT_SCENARIO: ${{ inputs.scenario }}
+          FAULT_SCENARIO: ${{ matrix.scenario }}
           PYTHONPATH: backend
         run: |
           set -euo pipefail
@@ -194,42 +206,25 @@ jobs:
           source "$env_file"
           set +a
 
-          if [ "${{ inputs.scenario }}" = "all" ]; then
-            scenarios=(
-              es_429_inject
-              es_write_block_4xx
-              es_down_connect
-              collector_down
-              es_bulk_partial
-              db_claim_contention
-              stuck_reclaim
-              duplicate_delivery
-              projection_version
-            )
-          else
-            scenarios=("${{ inputs.scenario }}")
-          fi
+          scenario="${{ matrix.scenario }}"
+          run_id="${{ github.run_id }}-${{ github.run_attempt }}-${scenario}"
+          echo "=== scenario=${scenario} run_id=${run_id} ==="
 
-          for scenario in "${scenarios[@]}"; do
-            run_id="${{ github.run_id }}-${{ github.run_attempt }}-${scenario}"
-            echo "=== scenario=${scenario} run_id=${run_id} ==="
+          python backend/scripts/cli.py labs run "$scenario" \
+            --env-file "$env_file" \
+            --duration "${{ inputs.duration }}" \
+            --run-id "$run_id"
 
-            python backend/scripts/cli.py labs run "$scenario" \
-              --env-file "$env_file" \
-              --duration "${{ inputs.duration }}" \
-              --run-id "$run_id"
+          python backend/scripts/cli.py labs verify "$scenario" --run-id "$run_id"
 
-            python backend/scripts/cli.py labs verify "$scenario" --run-id "$run_id"
+          python backend/scripts/cli.py labs export "$scenario" \
+            --run-id "$run_id" \
+            --lookback "${{ inputs.lookback }}"
 
-            python backend/scripts/cli.py labs export "$scenario" \
-              --run-id "$run_id" \
-              --lookback "${{ inputs.lookback }}"
-
-            python backend/scripts/cli.py labs clean "$scenario" --env-file "$env_file" --keep-last "${{ inputs.keep_last }}"
-          done
+          python backend/scripts/cli.py labs clean "$scenario" --env-file "$env_file" --keep-last "${{ inputs.keep_last }}"
 
       - name: Upload evidence bundle
         uses: actions/upload-artifact@v4
         with:
-          name: labs-evidence-${{ inputs.scenario }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: labs-evidence-${{ matrix.scenario }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: docs/labs/_snapshot/auto/

--- a/backend/scripts/cli.py
+++ b/backend/scripts/cli.py
@@ -2316,6 +2316,26 @@ def _cmd_labs_run_es_write_block_4xx(args: argparse.Namespace) -> int:
     run_id = args.run_id or _now_run_id()
     outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_ES_WRITE_BLOCK_4XX, run_id=run_id)
 
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_write_block_4xx.run")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_write_block_4xx.run",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": run_id,
+            "outdir": str(outdir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 2))
+
+    run_id = args.run_id or _now_run_id()
+    outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_ES_WRITE_BLOCK_4XX, run_id=run_id)
+
     logs_dir = outdir / "_logs"
     metrics_dir = outdir / "_metrics"
     exports_dir = outdir / "_exports"
@@ -2495,6 +2515,25 @@ def _resolve_run_dir(*, run_id: str | None, outdir: str | None, scenario: str) -
 
 def _cmd_labs_verify_es_write_block_4xx(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_WRITE_BLOCK_4XX)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_write_block_4xx.verify")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_write_block_4xx.verify",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 10))
+
+    run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_WRITE_BLOCK_4XX)
     metrics_dir = run_dir / "_metrics"
     before_path = metrics_dir / "metrics-before.txt"
     after_path = metrics_dir / "metrics-after.txt"
@@ -2535,6 +2574,25 @@ def _cmd_labs_verify_es_write_block_4xx(args: argparse.Namespace) -> int:
 
 def _cmd_labs_export_es_write_block_4xx(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_WRITE_BLOCK_4XX)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_write_block_4xx.export")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_write_block_4xx.export",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
+    run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_WRITE_BLOCK_4XX)
     exports_dir = run_dir / "_exports"
     _ensure_dir(exports_dir)
 
@@ -2560,6 +2618,26 @@ def _cmd_labs_export_es_write_block_4xx(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_run_es_429_inject(args: argparse.Namespace) -> int:
+    run_id = args.run_id or _now_run_id()
+    outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_ES_429_INJECT, run_id=run_id)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_429_inject.run")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_429_inject.run",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": run_id,
+            "outdir": str(outdir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 2))
+
     run_id = args.run_id or _now_run_id()
     outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_ES_429_INJECT, run_id=run_id)
 
@@ -2720,6 +2798,25 @@ def _cmd_labs_run_es_429_inject(args: argparse.Namespace) -> int:
 
 def _cmd_labs_verify_es_429_inject(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_429_INJECT)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_429_inject.verify")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_429_inject.verify",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 10))
+
+    run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_429_INJECT)
     metrics_dir = run_dir / "_metrics"
     before_path = metrics_dir / "metrics-before.txt"
     after_path = metrics_dir / "metrics-after.txt"
@@ -2769,6 +2866,26 @@ def _cmd_labs_verify_es_429_inject(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_run_es_down_connect(args: argparse.Namespace) -> int:
+    run_id = args.run_id or _now_run_id()
+    outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_ES_DOWN_CONNECT, run_id=run_id)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_down_connect.run")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_down_connect.run",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": run_id,
+            "outdir": str(outdir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 2))
+
     run_id = args.run_id or _now_run_id()
     outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_ES_DOWN_CONNECT, run_id=run_id)
 
@@ -2921,6 +3038,25 @@ def _cmd_labs_run_es_down_connect(args: argparse.Namespace) -> int:
 
 def _cmd_labs_verify_es_down_connect(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_DOWN_CONNECT)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_down_connect.verify")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_down_connect.verify",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 10))
+
+    run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_DOWN_CONNECT)
     metrics_dir = run_dir / "_metrics"
     before_path = metrics_dir / "metrics-before.txt"
     after_path = metrics_dir / "metrics-after.txt"
@@ -2973,6 +3109,25 @@ def _cmd_labs_verify_es_down_connect(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_export_es_down_connect(args: argparse.Namespace) -> int:
+    run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_DOWN_CONNECT)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_down_connect.export")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_down_connect.export",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_DOWN_CONNECT)
     exports_dir = run_dir / "_exports"
     _ensure_dir(exports_dir)
@@ -3100,6 +3255,26 @@ def _cmd_labs_run_duplicate_delivery(args: argparse.Namespace) -> int:
     1) Insert 1 upsert for a fixed entity_id and ensure a search_index row exists.
     2) Insert 2 deletes for the same entity_id (second should be a noop: ES 404).
     """
+
+    run_id = args.run_id or _now_run_id()
+    outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_DUPLICATE_DELIVERY, run_id=run_id)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("duplicate_delivery.run")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "duplicate_delivery.run",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": run_id,
+            "outdir": str(outdir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 2))
 
     run_id = args.run_id or _now_run_id()
     outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_DUPLICATE_DELIVERY, run_id=run_id)
@@ -3291,6 +3466,25 @@ def _cmd_labs_run_duplicate_delivery(args: argparse.Namespace) -> int:
 
 def _cmd_labs_verify_duplicate_delivery(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_DUPLICATE_DELIVERY)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("duplicate_delivery.verify")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "duplicate_delivery.verify",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 10))
+
+    run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_DUPLICATE_DELIVERY)
     metrics_dir = run_dir / "_metrics"
     logs_dir = run_dir / "_logs"
 
@@ -3360,6 +3554,25 @@ def _cmd_labs_verify_duplicate_delivery(args: argparse.Namespace) -> int:
 
 def _cmd_labs_export_duplicate_delivery(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_DUPLICATE_DELIVERY)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("duplicate_delivery.export")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "duplicate_delivery.export",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
+    run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_DUPLICATE_DELIVERY)
     exports_dir = run_dir / "_exports"
     _ensure_dir(exports_dir)
 
@@ -3392,6 +3605,23 @@ def _cmd_labs_export_duplicate_delivery(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_clean_duplicate_delivery(args: argparse.Namespace) -> int:
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("duplicate_delivery.clean")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "duplicate_delivery.clean",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": _now_run_id(),
+            "outdir": str(args.outdir) if args.outdir else None,
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
     # No external state to revert; optionally prune snapshots.
     if args.keep_last is None:
         return 0
@@ -3410,6 +3640,23 @@ def _cmd_labs_clean_duplicate_delivery(args: argparse.Namespace) -> int:
 def _cmd_labs_run_es_bulk_partial(args: argparse.Namespace) -> int:
     run_id = args.run_id or _now_run_id()
     outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_ES_BULK_PARTIAL, run_id=run_id)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_bulk_partial.run")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_bulk_partial.run",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": run_id,
+            "outdir": str(outdir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 2))
 
     logs_dir = outdir / "_logs"
     metrics_dir = outdir / "_metrics"
@@ -3578,6 +3825,23 @@ def _cmd_labs_run_es_bulk_partial(args: argparse.Namespace) -> int:
 
 def _cmd_labs_verify_es_bulk_partial(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_BULK_PARTIAL)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_bulk_partial.verify")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_bulk_partial.verify",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 10))
     metrics_dir = run_dir / "_metrics"
     before_path = metrics_dir / "metrics-before.txt"
     after_path = metrics_dir / "metrics-after.txt"
@@ -3655,6 +3919,23 @@ def _cmd_labs_verify_es_bulk_partial(args: argparse.Namespace) -> int:
 
 def _cmd_labs_export_es_bulk_partial(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_BULK_PARTIAL)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_bulk_partial.export")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_bulk_partial.export",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
     exports_dir = run_dir / "_exports"
     _ensure_dir(exports_dir)
 
@@ -3688,6 +3969,23 @@ def _cmd_labs_export_es_bulk_partial(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_clean_es_bulk_partial(args: argparse.Namespace) -> int:
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_bulk_partial.clean")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_bulk_partial.clean",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": _now_run_id(),
+            "outdir": str(args.outdir) if args.outdir else None,
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
     # No external state to revert: injection is env-only.
     if args.outdir:
         outdir = Path(args.outdir)
@@ -3714,6 +4012,23 @@ def _cmd_labs_clean_es_bulk_partial(args: argparse.Namespace) -> int:
 def _cmd_labs_run_db_claim_contention(args: argparse.Namespace) -> int:
     run_id = args.run_id or _now_run_id()
     outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_DB_CLAIM_CONTENTION, run_id=run_id)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("db_claim_contention.run")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "db_claim_contention.run",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": run_id,
+            "outdir": str(outdir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 2))
 
     logs_dir = outdir / "_logs"
     metrics_dir = outdir / "_metrics"
@@ -3929,6 +4244,23 @@ def _cmd_labs_run_db_claim_contention(args: argparse.Namespace) -> int:
 
 def _cmd_labs_verify_db_claim_contention(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_DB_CLAIM_CONTENTION)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("db_claim_contention.verify")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "db_claim_contention.verify",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 10))
     metrics_dir = run_dir / "_metrics"
 
     before1 = (metrics_dir / "metrics-before-1.txt").read_text(encoding="utf-8") if (metrics_dir / "metrics-before-1.txt").exists() else ""
@@ -3985,6 +4317,23 @@ def _cmd_labs_verify_db_claim_contention(args: argparse.Namespace) -> int:
 
 def _cmd_labs_export_db_claim_contention(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_DB_CLAIM_CONTENTION)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("db_claim_contention.export")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "db_claim_contention.export",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
     exports_dir = run_dir / "_exports"
     _ensure_dir(exports_dir)
 
@@ -4016,6 +4365,23 @@ def _cmd_labs_export_db_claim_contention(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_clean_db_claim_contention(args: argparse.Namespace) -> int:
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("db_claim_contention.clean")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "db_claim_contention.clean",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": _now_run_id(),
+            "outdir": str(args.outdir) if args.outdir else None,
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
     # No external state to revert: injection is env-only.
     if args.outdir:
         outdir = Path(args.outdir)
@@ -4042,6 +4408,23 @@ def _cmd_labs_clean_db_claim_contention(args: argparse.Namespace) -> int:
 def _cmd_labs_run_stuck_reclaim(args: argparse.Namespace) -> int:
     run_id = args.run_id or _now_run_id()
     outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_STUCK_RECLAIM, run_id=run_id)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("stuck_reclaim.run")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "stuck_reclaim.run",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": run_id,
+            "outdir": str(outdir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 2))
 
     logs_dir = outdir / "_logs"
     metrics_dir = outdir / "_metrics"
@@ -4366,6 +4749,23 @@ def _cmd_labs_run_stuck_reclaim(args: argparse.Namespace) -> int:
 
 def _cmd_labs_verify_stuck_reclaim(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_STUCK_RECLAIM)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("stuck_reclaim.verify")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "stuck_reclaim.verify",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 10))
     metrics_dir = run_dir / "_metrics"
     logs_dir = run_dir / "_logs"
 
@@ -4444,6 +4844,23 @@ def _cmd_labs_verify_stuck_reclaim(args: argparse.Namespace) -> int:
 
 def _cmd_labs_export_stuck_reclaim(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_STUCK_RECLAIM)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("stuck_reclaim.export")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "stuck_reclaim.export",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
     exports_dir = run_dir / "_exports"
     _ensure_dir(exports_dir)
 
@@ -4468,6 +4885,23 @@ def _cmd_labs_export_stuck_reclaim(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_clean_stuck_reclaim(args: argparse.Namespace) -> int:
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("stuck_reclaim.clean")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "stuck_reclaim.clean",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": _now_run_id(),
+            "outdir": str(args.outdir) if args.outdir else None,
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
     if args.keep_last is not None:
         base = LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / SCENARIO_STUCK_RECLAIM
         if base.exists():
@@ -4481,6 +4915,23 @@ def _cmd_labs_clean_stuck_reclaim(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_clean_es_down_connect(args: argparse.Namespace) -> int:
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_down_connect.clean")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_down_connect.clean",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": _now_run_id(),
+            "outdir": str(args.outdir) if args.outdir else None,
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
     # 1) Restore ES
     compose_file = str((REPO_ROOT / "docker-compose.infra.yml").resolve())
     start_proc = _docker_compose(args=["-f", compose_file, "start", "es"], cwd=REPO_ROOT)
@@ -4513,6 +4964,25 @@ def _cmd_labs_clean_es_down_connect(args: argparse.Namespace) -> int:
 
 def _cmd_labs_export_es_429_inject(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_429_INJECT)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_429_inject.export")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_429_inject.export",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
+    run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_ES_429_INJECT)
     exports_dir = run_dir / "_exports"
     _ensure_dir(exports_dir)
 
@@ -4538,6 +5008,23 @@ def _cmd_labs_export_es_429_inject(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_clean_es_429_inject(args: argparse.Namespace) -> int:
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_429_inject.clean")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_429_inject.clean",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": _now_run_id(),
+            "outdir": str(args.outdir) if args.outdir else None,
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
     # No external state to revert: injection is env-only.
     if args.outdir:
         outdir = Path(args.outdir)
@@ -4562,6 +5049,23 @@ def _cmd_labs_clean_es_429_inject(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_clean_es_write_block_4xx(args: argparse.Namespace) -> int:
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("es_write_block_4xx.clean")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "es_write_block_4xx.clean",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": _now_run_id(),
+            "outdir": str(args.outdir) if args.outdir else None,
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
     # 1) Revert injection (index.blocks.write=false)
     env = _load_env(env_file=args.env_file)
     es_url = (env.get("ELASTIC_URL") or "http://localhost:19200").strip().rstrip("/")
@@ -4589,6 +5093,24 @@ def _cmd_labs_clean_es_write_block_4xx(args: argparse.Namespace) -> int:
 def _cmd_labs_run_projection_version(args: argparse.Namespace) -> int:
     run_id = args.run_id or _now_run_id()
     outdir = Path(args.outdir) if args.outdir else _default_labs_auto_run_dir(scenario=SCENARIO_PROJECTION_VERSION, run_id=run_id)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("projection_version.run")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "projection_version.run",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": run_id,
+            "outdir": str(outdir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 2))
+
     logs_dir = outdir / "_logs"
     metrics_dir = outdir / "_metrics"
     _ensure_dir(logs_dir)
@@ -4863,6 +5385,24 @@ def _cmd_labs_run_projection_version(args: argparse.Namespace) -> int:
 
 def _cmd_labs_verify_projection_version(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_PROJECTION_VERSION)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("projection_version.verify")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "projection_version.verify",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 2))
+
     if not run_dir.exists():
         print(f"[labs verify {SCENARIO_PROJECTION_VERSION}] run_dir not found: {run_dir}")
         return 2
@@ -4929,6 +5469,24 @@ def _cmd_labs_verify_projection_version(args: argparse.Namespace) -> int:
 
 def _cmd_labs_export_projection_version(args: argparse.Namespace) -> int:
     run_dir = _resolve_run_dir(run_id=args.run_id, outdir=args.outdir, scenario=SCENARIO_PROJECTION_VERSION)
+
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("projection_version.export")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "projection_version.export",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": str(args.run_id or run_dir.name),
+            "outdir": str(run_dir),
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or (0 if drill.ok else 2))
+
     if not run_dir.exists():
         print(f"[labs export {SCENARIO_PROJECTION_VERSION}] run_dir not found: {run_dir}")
         return 2
@@ -4966,6 +5524,23 @@ def _cmd_labs_export_projection_version(args: argparse.Namespace) -> int:
 
 
 def _cmd_labs_clean_projection_version(args: argparse.Namespace) -> int:
+    _wg_registry.load_builtin_scenarios()
+    handler = _wg_registry.get("projection_version.clean")
+
+    input_payload = dict(vars(args))
+    input_payload.pop("func", None)
+    input_payload.update(
+        {
+            "scenario": "projection_version.clean",
+            "scope_id": LAB_ID_S3A_2A_3A,
+            "run_id": _now_run_id(),
+            "outdir": str(args.outdir) if args.outdir else None,
+        }
+    )
+    inputs = DrillInputs.model_validate(input_payload)
+    drill = handler(inputs)
+    return int(drill.meta.get("exit_code") or 0)
+
     if args.keep_last is not None:
         base = LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / SCENARIO_PROJECTION_VERSION
         if base.exists():

--- a/backend/scripts/cli_app/registry.py
+++ b/backend/scripts/cli_app/registry.py
@@ -41,6 +41,14 @@ def load_builtin_scenarios() -> None:
     """Import scenario modules so they can self-register via @register."""
 
     from .scenarios import collector_down  # noqa: F401
+    from .scenarios import es_429_inject  # noqa: F401
+    from .scenarios import es_bulk_partial  # noqa: F401
+    from .scenarios import es_down_connect  # noqa: F401
+    from .scenarios import es_write_block_4xx  # noqa: F401
+    from .scenarios import db_claim_contention  # noqa: F401
+    from .scenarios import stuck_reclaim  # noqa: F401
+    from .scenarios import duplicate_delivery  # noqa: F401
+    from .scenarios import projection_version  # noqa: F401
     from .scenarios import shadow_verify_search_index_write_gate  # noqa: F401
     from .scenarios import shadow_verify_search_index_paging_stability  # noqa: F401
     from .scenarios import shadow_verify_shared_keys  # noqa: F401

--- a/backend/scripts/cli_app/scenarios/_failure_drill_shared.py
+++ b/backend/scripts/cli_app/scenarios/_failure_drill_shared.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from ..common import REPO_ROOT
+
+
+LABS_SNAPSHOT_ROOT = REPO_ROOT / "docs" / "labs" / "_snapshot"
+LAB_ID_S3A_2A_3A = "S3A-2A-3A"
+LEGACY_SCRIPTS_DIR = REPO_ROOT / "backend" / "scripts" / "legacy"
+
+# Keep in sync with backend/scripts/legacy/search_outbox_worker.py
+SEARCH_OUTBOX_OBS_SCHEMA_VERSION = "labs-009-v2"
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def read_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        raise FileNotFoundError(str(path))
+
+    env: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if (len(value) >= 2) and ((value[0] == value[-1] == '"') or (value[0] == value[-1] == "'")):
+            value = value[1:-1]
+        env[key] = value
+    return env
+
+
+def load_env(*, env_file: str | None) -> dict[str, str]:
+    env = os.environ.copy()
+    if env_file:
+        env_path = (REPO_ROOT / env_file).resolve() if not Path(env_file).is_absolute() else Path(env_file)
+        env.update(read_env_file(env_path))
+    return env
+
+
+def with_backend_pythonpath(env: dict[str, str]) -> dict[str, str]:
+    backend_path = str(REPO_ROOT / "backend")
+    existing = env.get("PYTHONPATH") or ""
+    parts = [p for p in existing.split(os.pathsep) if p]
+    if backend_path not in parts:
+        parts.insert(0, backend_path)
+    env["PYTHONPATH"] = os.pathsep.join(parts)
+    return env
+
+
+def default_labs_auto_run_dir(*, scenario: str, run_id: str) -> Path:
+    return LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / scenario / run_id
+
+
+def latest_child_dir(base: Path) -> Path | None:
+    if not base.exists():
+        return None
+    children = [p for p in base.iterdir() if p.is_dir()]
+    if not children:
+        return None
+    return sorted(children, key=lambda p: p.name, reverse=True)[0]
+
+
+def resolve_run_dir(*, run_id: str | None, outdir: str | None, scenario: str) -> Path:
+    if outdir:
+        return Path(outdir)
+    if run_id:
+        return default_labs_auto_run_dir(scenario=scenario, run_id=run_id)
+    latest = latest_child_dir(LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / scenario)
+    if latest is None:
+        raise SystemExit(f"No runs found for scenario={scenario}")
+    return latest
+
+
+def http_json(
+    method: str,
+    url: str,
+    *,
+    body: dict[str, object] | None = None,
+    timeout_s: float = 5.0,
+) -> tuple[int, str]:
+    data = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url=url, data=data, method=method.upper(), headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310
+            payload = resp.read().decode("utf-8", errors="replace")
+            return int(resp.status), payload
+    except urllib.error.HTTPError as exc:
+        payload = exc.read().decode("utf-8", errors="replace") if getattr(exc, "fp", None) else str(exc)
+        return int(getattr(exc, "code", 0) or 0), payload
+
+
+def es_set_index_write_block(*, es_url: str, index: str, enabled: bool) -> tuple[int, str]:
+    es_url = es_url.strip().rstrip("/")
+    index = index.strip()
+    url = f"{es_url}/{index}/_settings"
+    return http_json("PUT", url, body={"index": {"blocks": {"write": bool(enabled)}}}, timeout_s=5.0)
+
+
+def es_create_index_if_missing(*, es_url: str, index: str) -> tuple[int, str]:
+    es_url = es_url.strip().rstrip("/")
+    index = index.strip()
+    url = f"{es_url}/{index}"
+    return http_json("PUT", url, body=None, timeout_s=5.0)
+
+
+def scrape_metrics_text(*, port: int, timeout_s: float = 2.0) -> str:
+    url = f"http://localhost:{int(port)}/metrics"
+    req = urllib.request.Request(url=url, headers={"Accept": "text/plain"})
+    with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def prom_parse_counter_sum(text: str, metric: str, *, labels: dict[str, str] | None = None) -> float:
+    want = labels or {}
+    total = 0.0
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if not line.startswith(metric):
+            continue
+
+        name_and_labels, *rest = line.split(None, 1)
+        if not rest:
+            continue
+        value_str = rest[0].strip().split()[0]
+
+        lbls: dict[str, str] = {}
+        if "{" in name_and_labels and name_and_labels.endswith("}"):
+            inside = name_and_labels.split("{", 1)[1][:-1]
+            for part in inside.split(","):
+                part = part.strip()
+                if not part or "=" not in part:
+                    continue
+                k, v = part.split("=", 1)
+                k = k.strip()
+                v = v.strip()
+                if len(v) >= 2 and v[0] == '"' and v[-1] == '"':
+                    v = v[1:-1]
+                lbls[k] = v
+
+        ok = True
+        for k, v in want.items():
+            if lbls.get(k) != v:
+                ok = False
+                break
+        if not ok:
+            continue
+
+        try:
+            total += float(value_str)
+        except ValueError:
+            continue
+
+    return float(total)
+
+
+def prom_sum_reasons(text: str, metric: str, *, reasons: list[str]) -> float:
+    return float(sum(prom_parse_counter_sum(text, metric, labels={"reason": r}) for r in reasons))
+
+
+def extract_last_claim_batch_id(log_path: Path) -> str | None:
+    if not log_path.exists():
+        return None
+    try:
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except Exception:
+        return None
+    rx = re.compile(r'"claim_batch_id"\s*:\s*"([^"]+)"')
+    for line in reversed(lines):
+        m = rx.search(line)
+        if m:
+            return m.group(1)
+    return None
+
+
+def parse_last_json_line(text: str) -> dict[str, object] | None:
+    if not text:
+        return None
+    for raw in reversed(text.splitlines()):
+        line = (raw or "").strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(obj, dict):
+            return obj
+    return None
+
+
+def read_json_file(path: Path) -> dict[str, object] | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except Exception:
+        return None
+
+
+def python_exe() -> str:
+    if os.getenv("VIRTUAL_ENV"):
+        return sys.executable
+
+    if os.name == "nt":
+        win_venv = REPO_ROOT / ".venv" / "Scripts" / "python.exe"
+        if win_venv.exists():
+            return str(win_venv)
+        return sys.executable
+
+    unix_venv = REPO_ROOT / ".venv" / "bin" / "python"
+    if unix_venv.exists():
+        return str(unix_venv)
+    return sys.executable
+
+
+def run_cmd(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> int:
+    print("[scripts] run:", " ".join(cmd))
+    return subprocess.call(cmd, cwd=str(cwd) if cwd else None, env=env)
+
+
+def docker_compose(*, args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    cmd = ["docker", "compose"] + args
+    print("[scripts] run:", " ".join(cmd))
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)

--- a/backend/scripts/cli_app/scenarios/db_claim_contention.py
+++ b/backend/scripts/cli_app/scenarios/db_claim_contention.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+from ..registry import register
+from ..types import DrillInputs, DrillResult
+from ._failure_drill_shared import (
+    LAB_ID_S3A_2A_3A,
+    SEARCH_OUTBOX_OBS_SCHEMA_VERSION,
+    default_labs_auto_run_dir,
+    ensure_dir,
+    extract_last_claim_batch_id,
+    load_env,
+    prom_parse_counter_sum,
+    python_exe,
+    resolve_run_dir,
+    run_cmd,
+    scrape_metrics_text,
+    with_backend_pythonpath,
+)
+from ._failure_drill_shared import LEGACY_SCRIPTS_DIR, LABS_SNAPSHOT_ROOT, REPO_ROOT
+
+
+SCENARIO_DB_CLAIM_CONTENTION = "db_claim_contention"
+
+
+@register("db_claim_contention.run")
+def run_db_claim_contention(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_id = str(payload.get("run_id") or "").strip()
+    outdir_str = str(payload.get("outdir") or "").strip()
+    outdir = Path(outdir_str) if outdir_str else default_labs_auto_run_dir(scenario=SCENARIO_DB_CLAIM_CONTENTION, run_id=run_id)
+
+    env_file = payload.get("env_file")
+    service = payload.get("service")
+    duration = int(payload.get("duration") or 0)
+
+    metrics_port_1 = int(payload.get("metrics_port_1") or 0)
+    metrics_port_2 = int(payload.get("metrics_port_2") or 0)
+    scrape_delay = float(payload.get("scrape_delay") or 0.0)
+
+    op = payload.get("op")
+    trigger_count = int(payload.get("trigger_count") or 0)
+
+    break_claim_sleep = float(payload.get("break_claim_sleep") or 0.0)
+    poll_interval = float(payload.get("poll_interval") or 0.0)
+    batch_size = int(payload.get("batch_size") or 0)
+
+    worker_id_1 = payload.get("worker_id_1")
+    worker_id_2 = payload.get("worker_id_2")
+
+    logs_dir = outdir / "_logs"
+    metrics_dir = outdir / "_metrics"
+    exports_dir = outdir / "_exports"
+    ensure_dir(logs_dir)
+    ensure_dir(metrics_dir)
+    ensure_dir(exports_dir)
+
+    base_env = with_backend_pythonpath(load_env(env_file=str(env_file) if env_file else None))
+
+    service_name = service
+    base_env.setdefault("WORDLOOM_TRACING_ENABLED", "1")
+    base_env.setdefault("OTEL_SERVICE_NAME", service_name)
+    base_env.setdefault("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    base_env.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    base_env.setdefault("OTEL_TRACES_SAMPLER", "always_on")
+
+    base_env.setdefault("ELASTIC_URL", "http://localhost:19200")
+    base_env.setdefault("ELASTIC_INDEX", "wordloom-test-search-index")
+
+    base_env["LOG_LEVEL"] = "INFO"
+
+    base_env["OUTBOX_EXPERIMENT_ES_429_RATIO"] = "0"
+    base_env.pop("OUTBOX_EXPERIMENT_ES_429_EVERY_N", None)
+    base_env.pop("OUTBOX_EXPERIMENT_ES_BULK_PARTIAL", None)
+
+    base_env["OUTBOX_USE_ES_BULK"] = "0"
+
+    base_env["OUTBOX_EXPERIMENT_BREAK_CLAIM"] = "1"
+    base_env["OUTBOX_EXPERIMENT_BREAK_CLAIM_SLEEP_SECONDS"] = str(float(break_claim_sleep))
+
+    base_env["OUTBOX_EXPERIMENT_PROCESS_SLEEP_SECONDS"] = str(max(1.0, float(break_claim_sleep)))
+
+    base_env["OUTBOX_POLL_INTERVAL_SECONDS"] = str(float(poll_interval))
+    base_env["OUTBOX_BULK_SIZE"] = str(int(batch_size))
+    base_env["OUTBOX_CONCURRENCY"] = "1"
+
+    recipe = {
+        "lab_id": LAB_ID_S3A_2A_3A,
+        "scenario": SCENARIO_DB_CLAIM_CONTENTION,
+        "run_id": run_id,
+        "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "env_file": env_file,
+        "service": service_name,
+        "inject": {
+            "kind": "break_claim_atomicity",
+            "enabled": True,
+            "sleep_seconds": float(break_claim_sleep),
+        },
+        "worker": {
+            "duration_s": int(duration),
+            "metrics_ports": [int(metrics_port_1), int(metrics_port_2)],
+            "poll_interval_seconds": float(poll_interval),
+            "batch_size": int(batch_size),
+        },
+        "trigger": {"op": str(op), "count": int(trigger_count)},
+    }
+    (outdir / "_recipe.json").write_text(json.dumps(recipe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    worker = LEGACY_SCRIPTS_DIR / "search_outbox_worker.py"
+    cmd = [python_exe(), "-u", str(worker)]
+
+    env1 = base_env.copy()
+    env1["OUTBOX_WORKER_ID"] = str(worker_id_1)
+    env1["OUTBOX_METRICS_PORT"] = str(int(metrics_port_1))
+    env1["OUTBOX_HTTP_PORT"] = str(int(metrics_port_1) + 20)
+
+    env2 = base_env.copy()
+    env2["OUTBOX_WORKER_ID"] = str(worker_id_2)
+    env2["OUTBOX_METRICS_PORT"] = str(int(metrics_port_2))
+    env2["OUTBOX_HTTP_PORT"] = str(int(metrics_port_2) + 20)
+
+    log_path_1 = logs_dir / f"worker1-{run_id}.log"
+    log_path_2 = logs_dir / f"worker2-{run_id}.log"
+
+    print(f"[labs run {SCENARIO_DB_CLAIM_CONTENTION}] outdir: {outdir}")
+    print(f"[labs run {SCENARIO_DB_CLAIM_CONTENTION}] worker1 log: {log_path_1} (metrics :{metrics_port_1})")
+    print(f"[labs run {SCENARIO_DB_CLAIM_CONTENTION}] worker2 log: {log_path_2} (metrics :{metrics_port_2})")
+
+    before_1_path = metrics_dir / "metrics-before-1.txt"
+    before_2_path = metrics_dir / "metrics-before-2.txt"
+    after_1_path = metrics_dir / "metrics-after-1.txt"
+    after_2_path = metrics_dir / "metrics-after-2.txt"
+
+    inserter = REPO_ROOT / "backend" / "scripts" / "labs" / "labs_009_insert_search_outbox_pending.py"
+    if not inserter.exists():
+        inserter = LEGACY_SCRIPTS_DIR / "labs_009_insert_search_outbox_pending.py"
+
+    start = time.time()
+    stopped_by_controller = False
+    outbox_event_ids: list[str] = []
+
+    with open(log_path_1, "w", encoding="utf-8") as log_file_1, open(log_path_2, "w", encoding="utf-8") as log_file_2:
+        proc1 = subprocess.Popen(cmd, cwd=str(REPO_ROOT), env=env1, stdout=log_file_1, stderr=subprocess.STDOUT)
+        proc2 = subprocess.Popen(cmd, cwd=str(REPO_ROOT), env=env2, stdout=log_file_2, stderr=subprocess.STDOUT)
+        try:
+            time.sleep(max(0.5, float(scrape_delay)))
+            try:
+                before_1_path.write_text(scrape_metrics_text(port=int(metrics_port_1), timeout_s=4.0), encoding="utf-8")
+            except Exception as exc:  # noqa: BLE001
+                before_1_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+            try:
+                before_2_path.write_text(scrape_metrics_text(port=int(metrics_port_2), timeout_s=4.0), encoding="utf-8")
+            except Exception as exc:  # noqa: BLE001
+                before_2_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+            for i in range(int(trigger_count)):
+                trigger_env = base_env.copy()
+                trigger_env["OUTBOX_OP"] = str(op)
+                trigger_env.setdefault("OUTBOX_CREATE_SEARCH_INDEX_ROW", "1")
+                trigger_env.setdefault("OUTBOX_EVENT_VERSION", "0")
+
+                proc = subprocess.run(
+                    [python_exe(), str(inserter)],
+                    cwd=str(REPO_ROOT),
+                    env=trigger_env,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=False,
+                )
+                (outdir / f"_trigger_insert_outbox_{i+1}.stdout.txt").write_text(proc.stdout or "", encoding="utf-8")
+                (outdir / f"_trigger_insert_outbox_{i+1}.stderr.txt").write_text(proc.stderr or "", encoding="utf-8")
+                if proc.returncode != 0:
+                    print(f"[labs run {SCENARIO_DB_CLAIM_CONTENTION}] failed to insert outbox event #{i+1}: rc={proc.returncode}")
+                    proc1.terminate()
+                    proc2.terminate()
+                    proc1.wait(timeout=30)
+                    proc2.wait(timeout=30)
+                    return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+                outbox_event_id = (proc.stdout or "").strip().splitlines()[-1].strip()
+                outbox_event_ids.append(outbox_event_id)
+
+            (outdir / "_outbox_event_ids.txt").write_text("\n".join(outbox_event_ids) + "\n", encoding="utf-8")
+            print(f"[labs run {SCENARIO_DB_CLAIM_CONTENTION}] outbox_event_ids: {', '.join(outbox_event_ids)}")
+
+            while True:
+                if duration > 0 and (time.time() - start) >= duration:
+                    try:
+                        after_1_path.write_text(scrape_metrics_text(port=int(metrics_port_1), timeout_s=4.0), encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        after_1_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    try:
+                        after_2_path.write_text(scrape_metrics_text(port=int(metrics_port_2), timeout_s=4.0), encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        after_2_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    stopped_by_controller = True
+                    proc1.terminate()
+                    proc2.terminate()
+                    break
+
+                ret1 = proc1.poll()
+                ret2 = proc2.poll()
+                if ret1 is not None or ret2 is not None:
+                    try:
+                        after_1_path.write_text(scrape_metrics_text(port=int(metrics_port_1), timeout_s=4.0), encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        after_1_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    try:
+                        after_2_path.write_text(scrape_metrics_text(port=int(metrics_port_2), timeout_s=4.0), encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        after_2_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    break
+                time.sleep(0.25)
+        except KeyboardInterrupt:
+            stopped_by_controller = True
+            proc1.terminate()
+            proc2.terminate()
+
+        proc1.wait(timeout=30)
+        proc2.wait(timeout=30)
+
+    exit_info = {
+        "worker1": {"returncode": int(proc1.returncode) if proc1.returncode is not None else None},
+        "worker2": {"returncode": int(proc2.returncode) if proc2.returncode is not None else None},
+    }
+    (outdir / "_worker_exit.json").write_text(json.dumps(exit_info, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    combined = (
+        "# metrics-after-1\n\n"
+        + (after_1_path.read_text(encoding="utf-8", errors="replace") if after_1_path.exists() else "")
+        + "\n\n# metrics-after-2\n\n"
+        + (after_2_path.read_text(encoding="utf-8", errors="replace") if after_2_path.exists() else "")
+    )
+    (outdir / "_metrics.txt").write_text(combined, encoding="utf-8")
+
+    claim_batch_ids: list[str] = []
+    for lp in (log_path_1, log_path_2):
+        cid = extract_last_claim_batch_id(lp)
+        if cid:
+            claim_batch_ids.append(cid)
+    if claim_batch_ids:
+        (outdir / "_claim_batch_ids.txt").write_text("\n".join(claim_batch_ids) + "\n", encoding="utf-8")
+
+    if (not stopped_by_controller) and (proc1.returncode not in (None, 0) or proc2.returncode not in (None, 0)):
+        print(
+            f"[labs run {SCENARIO_DB_CLAIM_CONTENTION}] a worker exited early: rc1={proc1.returncode} rc2={proc2.returncode}"
+        )
+        print(f"[labs run {SCENARIO_DB_CLAIM_CONTENTION}] see logs: {log_path_1} {log_path_2}")
+        return DrillResult(ok=False, meta={"exit_code": 4}, summary={}, errors=[])
+
+    print(f"[labs run {SCENARIO_DB_CLAIM_CONTENTION}] done (now run verify/export/clean)")
+    print(f"[labs run {SCENARIO_DB_CLAIM_CONTENTION}] outputs: {outdir}")
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+
+@register("db_claim_contention.verify")
+def verify_db_claim_contention(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_DB_CLAIM_CONTENTION,
+    )
+    metrics_dir = run_dir / "_metrics"
+
+    before1 = (metrics_dir / "metrics-before-1.txt").read_text(encoding="utf-8") if (metrics_dir / "metrics-before-1.txt").exists() else ""
+    before2 = (metrics_dir / "metrics-before-2.txt").read_text(encoding="utf-8") if (metrics_dir / "metrics-before-2.txt").exists() else ""
+    after1 = (metrics_dir / "metrics-after-1.txt").read_text(encoding="utf-8") if (metrics_dir / "metrics-after-1.txt").exists() else ""
+    after2 = (metrics_dir / "metrics-after-2.txt").read_text(encoding="utf-8") if (metrics_dir / "metrics-after-2.txt").exists() else ""
+
+    metric_owner_mismatch = "outbox_owner_mismatch_skips_total"
+    metric_processed = "outbox_processed_total"
+    metric_failed = "outbox_failed_total"
+
+    mismatch_before = prom_parse_counter_sum(before1, metric_owner_mismatch) + prom_parse_counter_sum(before2, metric_owner_mismatch)
+    mismatch_after = prom_parse_counter_sum(after1, metric_owner_mismatch) + prom_parse_counter_sum(after2, metric_owner_mismatch)
+
+    processed_before = prom_parse_counter_sum(before1, metric_processed) + prom_parse_counter_sum(before2, metric_processed)
+    processed_after = prom_parse_counter_sum(after1, metric_processed) + prom_parse_counter_sum(after2, metric_processed)
+
+    failed_before = prom_parse_counter_sum(before1, metric_failed) + prom_parse_counter_sum(before2, metric_failed)
+    failed_after = prom_parse_counter_sum(after1, metric_failed) + prom_parse_counter_sum(after2, metric_failed)
+
+    delta_mismatch = mismatch_after - mismatch_before
+    delta_processed = processed_after - processed_before
+    delta_failed = failed_after - failed_before
+
+    min_owner_mismatch_delta = float(payload.get("min_owner_mismatch_delta") or 0)
+    min_processed_delta = float(payload.get("min_processed_delta") or 0)
+    max_failed_delta = float(payload.get("max_failed_delta") or 0)
+
+    ok = (delta_mismatch >= min_owner_mismatch_delta) and (delta_processed >= min_processed_delta) and (delta_failed <= max_failed_delta)
+
+    result = {
+        "scenario": SCENARIO_DB_CLAIM_CONTENTION,
+        "run_dir": str(run_dir),
+        "checks": {
+            "owner_mismatch_delta_ge": float(min_owner_mismatch_delta),
+            "processed_delta_ge": float(min_processed_delta),
+            "failed_delta_le": float(max_failed_delta),
+        },
+        "observed": {
+            metric_owner_mismatch: {"before": mismatch_before, "after": mismatch_after, "delta": delta_mismatch},
+            metric_processed: {"before": processed_before, "after": processed_after, "delta": delta_processed},
+            metric_failed: {"before": failed_before, "after": failed_after, "delta": delta_failed},
+        },
+        "ok": bool(ok),
+    }
+    (run_dir / "_result.json").write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if ok:
+        print(f"[labs verify {SCENARIO_DB_CLAIM_CONTENTION}] OK")
+        return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+    print(f"[labs verify {SCENARIO_DB_CLAIM_CONTENTION}] FAILED")
+    return DrillResult(ok=False, meta={"exit_code": 10}, summary={}, errors=[])
+
+
+@register("db_claim_contention.export")
+def export_db_claim_contention(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_DB_CLAIM_CONTENTION,
+    )
+    exports_dir = run_dir / "_exports"
+    ensure_dir(exports_dir)
+
+    exporter = LEGACY_SCRIPTS_DIR / "labs_009_export_jaeger.py"
+    base_cmd = [
+        python_exe(),
+        str(exporter),
+        "--outdir",
+        str(exports_dir),
+        "--service",
+        str(payload.get("service")),
+        "--lookback",
+        str(payload.get("lookback")),
+        "--limit",
+        str(payload.get("limit")),
+    ]
+
+    rc = run_cmd(
+        base_cmd
+        + [
+            "--operation",
+            "outbox.claim_batch",
+            "--tags-json",
+            json.dumps({"wordloom.obs_schema": SEARCH_OUTBOX_OBS_SCHEMA_VERSION}, ensure_ascii=False),
+        ],
+        cwd=REPO_ROOT,
+    )
+
+    return DrillResult(ok=(rc == 0), meta={"exit_code": int(rc)}, summary={}, errors=[])
+
+
+@register("db_claim_contention.clean")
+def clean_db_claim_contention(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    outdir = payload.get("outdir")
+    keep_last = payload.get("keep_last")
+
+    if outdir:
+        out_path = Path(str(outdir))
+        ensure_dir(out_path)
+        (out_path / "_clean.txt").write_text(
+            f"scenario={SCENARIO_DB_CLAIM_CONTENTION}\n" "action=noop\n" f"at={time.strftime('%Y-%m-%d %H:%M:%S')}\n",
+            encoding="utf-8",
+        )
+
+    if keep_last is not None:
+        base = LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / SCENARIO_DB_CLAIM_CONTENTION
+        if base.exists():
+            import shutil
+
+            runs = sorted([p for p in base.iterdir() if p.is_dir()], key=lambda p: p.name, reverse=True)
+            for p in runs[int(keep_last) :]:
+                shutil.rmtree(p, ignore_errors=True)
+            print(f"[labs clean {SCENARIO_DB_CLAIM_CONTENTION}] kept_last={keep_last}")
+    else:
+        print(f"[labs clean {SCENARIO_DB_CLAIM_CONTENTION}] noop")
+
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])

--- a/backend/scripts/cli_app/scenarios/duplicate_delivery.py
+++ b/backend/scripts/cli_app/scenarios/duplicate_delivery.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+from ..registry import register
+from ..types import DrillInputs, DrillResult
+from ._failure_drill_shared import (
+    LAB_ID_S3A_2A_3A,
+    SEARCH_OUTBOX_OBS_SCHEMA_VERSION,
+    default_labs_auto_run_dir,
+    ensure_dir,
+    load_env,
+    prom_parse_counter_sum,
+    python_exe,
+    resolve_run_dir,
+    run_cmd,
+    scrape_metrics_text,
+    with_backend_pythonpath,
+)
+from ._failure_drill_shared import LEGACY_SCRIPTS_DIR, LABS_SNAPSHOT_ROOT, REPO_ROOT
+
+
+SCENARIO_DUPLICATE_DELIVERY = "duplicate_delivery"
+
+
+@register("duplicate_delivery.run")
+def run_duplicate_delivery(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_id = str(payload.get("run_id") or "").strip()
+    outdir_str = str(payload.get("outdir") or "").strip()
+    outdir = Path(outdir_str) if outdir_str else default_labs_auto_run_dir(scenario=SCENARIO_DUPLICATE_DELIVERY, run_id=run_id)
+
+    env_file = payload.get("env_file")
+    service = payload.get("service")
+    duration = int(payload.get("duration") or 0)
+    metrics_port = int(payload.get("metrics_port") or 0)
+    scrape_delay = float(payload.get("scrape_delay") or 0.0)
+
+    entity_type = payload.get("entity_type")
+    entity_id = str(payload.get("entity_id") or "").strip() if payload.get("entity_id") else str(uuid.uuid4())
+    delete_count = int(payload.get("delete_count") or 0)
+
+    logs_dir = outdir / "_logs"
+    metrics_dir = outdir / "_metrics"
+    exports_dir = outdir / "_exports"
+    ensure_dir(logs_dir)
+    ensure_dir(metrics_dir)
+    ensure_dir(exports_dir)
+
+    env = with_backend_pythonpath(load_env(env_file=str(env_file) if env_file else None))
+
+    service_name = service
+    env.setdefault("WORDLOOM_TRACING_ENABLED", "1")
+    env.setdefault("OTEL_SERVICE_NAME", service_name)
+    env.setdefault("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    env.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    env.setdefault("OTEL_TRACES_SAMPLER", "always_on")
+
+    env["OUTBOX_USE_ES_BULK"] = "0"
+
+    env.setdefault("ELASTIC_URL", "http://localhost:19200")
+    env.setdefault("ELASTIC_INDEX", "wordloom-test-search-index")
+
+    env["OUTBOX_EXPERIMENT_ES_429_RATIO"] = "0"
+    env.pop("OUTBOX_EXPERIMENT_ES_429_EVERY_N", None)
+    env["OUTBOX_EXPERIMENT_ES_BULK_PARTIAL"] = "0"
+    env["OUTBOX_EXPERIMENT_BREAK_CLAIM"] = "0"
+    env["OUTBOX_EXPERIMENT_PROCESS_SLEEP_SECONDS"] = "0"
+
+    env["OUTBOX_METRICS_PORT"] = str(int(metrics_port))
+
+    (outdir / "_entity_id.txt").write_text(entity_id + "\n", encoding="utf-8")
+
+    recipe = {
+        "lab_id": LAB_ID_S3A_2A_3A,
+        "scenario": SCENARIO_DUPLICATE_DELIVERY,
+        "run_id": run_id,
+        "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "env_file": env_file,
+        "service": service_name,
+        "entity": {"entity_type": str(entity_type), "entity_id": entity_id},
+        "worker": {"duration_s": int(duration), "metrics_port": int(metrics_port)},
+        "trigger": {"upsert_count": 1, "delete_count": int(delete_count)},
+        "expect": {"idempotent_noop": {"kind": "es_delete_404", "count": 1}},
+    }
+    (outdir / "_recipe.json").write_text(json.dumps(recipe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    worker = LEGACY_SCRIPTS_DIR / "search_outbox_worker.py"
+    log_path = logs_dir / f"worker-{run_id}.log"
+    cmd = [python_exe(), "-u", str(worker)]
+
+    print(f"[labs run {SCENARIO_DUPLICATE_DELIVERY}] outdir: {outdir}")
+    print(f"[labs run {SCENARIO_DUPLICATE_DELIVERY}] worker log: {log_path}")
+    print(f"[labs run {SCENARIO_DUPLICATE_DELIVERY}] entity_id: {entity_id}")
+
+    metrics_before_path = metrics_dir / "metrics-before.txt"
+    metrics_after_path = metrics_dir / "metrics-after.txt"
+
+    inserter = REPO_ROOT / "backend" / "scripts" / "labs" / "labs_009_insert_search_outbox_pending.py"
+    if not inserter.exists():
+        inserter = LEGACY_SCRIPTS_DIR / "labs_009_insert_search_outbox_pending.py"
+
+    start = time.time()
+    stopped_by_controller = False
+    outbox_event_ids: list[str] = []
+
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        worker_proc = subprocess.Popen(cmd, cwd=str(REPO_ROOT), env=env, stdout=log_file, stderr=subprocess.STDOUT)
+        try:
+            time.sleep(max(0.5, float(scrape_delay)))
+            try:
+                metrics_before = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                metrics_before_path.write_text(metrics_before, encoding="utf-8")
+            except Exception as exc:  # noqa: BLE001
+                metrics_before_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+            upsert_env = env.copy()
+            upsert_env["OUTBOX_ENTITY_TYPE"] = str(entity_type)
+            upsert_env["OUTBOX_ENTITY_ID"] = entity_id
+            upsert_env["OUTBOX_OP"] = "upsert"
+            upsert_env["OUTBOX_CREATE_SEARCH_INDEX_ROW"] = "1"
+            upsert_env.setdefault("OUTBOX_EVENT_VERSION", "0")
+
+            proc = subprocess.run(
+                [python_exe(), str(inserter)],
+                cwd=str(REPO_ROOT),
+                env=upsert_env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            (outdir / "_trigger_upsert.stdout.txt").write_text(proc.stdout or "", encoding="utf-8")
+            (outdir / "_trigger_upsert.stderr.txt").write_text(proc.stderr or "", encoding="utf-8")
+            if proc.returncode != 0:
+                print(
+                    f"[labs run {SCENARIO_DUPLICATE_DELIVERY}] failed to insert upsert outbox event: rc={proc.returncode}"
+                )
+                worker_proc.terminate()
+                worker_proc.wait(timeout=30)
+                return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+
+            upsert_event_id = (proc.stdout or "").strip().splitlines()[-1].strip()
+            outbox_event_ids.append(upsert_event_id)
+            time.sleep(1.5)
+
+            delete_env = env.copy()
+            delete_env["OUTBOX_ENTITY_TYPE"] = str(entity_type)
+            delete_env["OUTBOX_ENTITY_ID"] = entity_id
+            delete_env["OUTBOX_OP"] = "delete"
+            delete_env.setdefault("OUTBOX_EVENT_VERSION", "0")
+            delete_env["OUTBOX_CREATE_SEARCH_INDEX_ROW"] = "0"
+
+            for idx in range(max(1, int(delete_count))):
+                proc2 = subprocess.run(
+                    [python_exe(), str(inserter)],
+                    cwd=str(REPO_ROOT),
+                    env=delete_env,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=False,
+                )
+                (outdir / f"_trigger_delete_{idx+1}.stdout.txt").write_text(proc2.stdout or "", encoding="utf-8")
+                (outdir / f"_trigger_delete_{idx+1}.stderr.txt").write_text(proc2.stderr or "", encoding="utf-8")
+                if proc2.returncode != 0:
+                    print(
+                        f"[labs run {SCENARIO_DUPLICATE_DELIVERY}] failed to insert delete outbox event #{idx+1}: rc={proc2.returncode}"
+                    )
+                    worker_proc.terminate()
+                    worker_proc.wait(timeout=30)
+                    return DrillResult(ok=False, meta={"exit_code": 4}, summary={}, errors=[])
+                delete_event_id = (proc2.stdout or "").strip().splitlines()[-1].strip()
+                outbox_event_ids.append(delete_event_id)
+
+            (outdir / "_outbox_event_ids.txt").write_text("\n".join(outbox_event_ids) + "\n", encoding="utf-8")
+
+            while True:
+                if duration > 0 and (time.time() - start) >= duration:
+                    try:
+                        metrics_after = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                        metrics_after_path.write_text(metrics_after, encoding="utf-8")
+                        (outdir / "_metrics.txt").write_text(metrics_after, encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        metrics_after_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    stopped_by_controller = True
+                    worker_proc.terminate()
+                    break
+
+                ret = worker_proc.poll()
+                if ret is not None:
+                    try:
+                        metrics_after = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                        metrics_after_path.write_text(metrics_after, encoding="utf-8")
+                        (outdir / "_metrics.txt").write_text(metrics_after, encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        metrics_after_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    break
+                time.sleep(0.25)
+        except KeyboardInterrupt:
+            stopped_by_controller = True
+            worker_proc.terminate()
+
+        worker_proc.wait(timeout=30)
+
+    exit_info = {"returncode": int(worker_proc.returncode) if worker_proc.returncode is not None else None}
+    (outdir / "_worker_exit.json").write_text(
+        json.dumps(exit_info, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    if not metrics_after_path.exists():
+        metrics_after_path.write_text("scrape_failed: missing_metrics_after\n", encoding="utf-8")
+
+    if (not stopped_by_controller) and (worker_proc.returncode not in (None, 0)):
+        print(f"[labs run {SCENARIO_DUPLICATE_DELIVERY}] worker exited early: rc={worker_proc.returncode}")
+        print(f"[labs run {SCENARIO_DUPLICATE_DELIVERY}] see logs: {log_path}")
+        return DrillResult(ok=False, meta={"exit_code": 5}, summary={}, errors=[])
+
+    print(f"[labs run {SCENARIO_DUPLICATE_DELIVERY}] done (now run verify/export/clean)")
+    print(f"[labs run {SCENARIO_DUPLICATE_DELIVERY}] outputs: {outdir}")
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+
+@register("duplicate_delivery.verify")
+def verify_duplicate_delivery(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_DUPLICATE_DELIVERY,
+    )
+    metrics_dir = run_dir / "_metrics"
+    logs_dir = run_dir / "_logs"
+
+    before_path = metrics_dir / "metrics-before.txt"
+    after_path = metrics_dir / "metrics-after.txt"
+
+    before = before_path.read_text(encoding="utf-8") if before_path.exists() else ""
+    after = after_path.read_text(encoding="utf-8") if after_path.exists() else ""
+
+    processed_before = prom_parse_counter_sum(before, "outbox_processed_total")
+    processed_after = prom_parse_counter_sum(after, "outbox_processed_total")
+    failed_before = prom_parse_counter_sum(before, "outbox_failed_total")
+    failed_after = prom_parse_counter_sum(after, "outbox_failed_total")
+    noop_before = prom_parse_counter_sum(before, "outbox_idempotent_noop_total")
+    noop_after = prom_parse_counter_sum(after, "outbox_idempotent_noop_total")
+
+    delta_processed = processed_after - processed_before
+    delta_failed = failed_after - failed_before
+    delta_noop = noop_after - noop_before
+
+    metrics_available = ("scrape_failed" not in before.lower()) and ("scrape_failed" not in after.lower())
+
+    log_paths = sorted([p for p in logs_dir.glob("*.log") if p.is_file()])
+    noop_log_count = 0
+    if log_paths:
+        try:
+            text = log_paths[0].read_text(encoding="utf-8", errors="replace")
+            noop_log_count = len(re.findall(r"Outbox delete: doc .* not found in ES \(noop\)", text))
+        except Exception:
+            noop_log_count = 0
+
+    min_processed_delta = float(payload.get("min_processed_delta") or 0)
+    max_failed_delta = float(payload.get("max_failed_delta") or 0)
+    min_noop_delta = float(payload.get("min_noop_delta") or 0)
+    min_noop_logs = int(payload.get("min_noop_logs") or 0)
+
+    ok = (
+        (delta_processed >= min_processed_delta)
+        and (delta_failed <= max_failed_delta)
+        and ((delta_noop >= min_noop_delta) or (noop_log_count >= min_noop_logs))
+    )
+
+    result = {
+        "scenario": SCENARIO_DUPLICATE_DELIVERY,
+        "run_dir": str(run_dir),
+        "checks": {
+            "min_processed_delta": float(min_processed_delta),
+            "max_failed_delta": float(max_failed_delta),
+            "min_noop_delta": float(min_noop_delta),
+            "min_noop_logs": int(min_noop_logs),
+        },
+        "observed": {
+            "metrics_available": bool(metrics_available),
+            "outbox_processed_total": {"before": processed_before, "after": processed_after, "delta": delta_processed},
+            "outbox_failed_total": {"before": failed_before, "after": failed_after, "delta": delta_failed},
+            "outbox_idempotent_noop_total": {"before": noop_before, "after": noop_after, "delta": delta_noop},
+            "noop_log_count": int(noop_log_count),
+        },
+        "ok": bool(ok),
+    }
+    (run_dir / "_result.json").write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if ok:
+        print(f"[labs verify {SCENARIO_DUPLICATE_DELIVERY}] OK")
+        return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+    print(f"[labs verify {SCENARIO_DUPLICATE_DELIVERY}] FAILED")
+    return DrillResult(ok=False, meta={"exit_code": 10}, summary={}, errors=[])
+
+
+@register("duplicate_delivery.export")
+def export_duplicate_delivery(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_DUPLICATE_DELIVERY,
+    )
+    exports_dir = run_dir / "_exports"
+    ensure_dir(exports_dir)
+
+    entity_id_path = run_dir / "_entity_id.txt"
+    entity_id = entity_id_path.read_text(encoding="utf-8").strip() if entity_id_path.exists() else None
+
+    tags = {
+        "wordloom.obs_schema": SEARCH_OUTBOX_OBS_SCHEMA_VERSION,
+    }
+    if entity_id:
+        tags["wordloom.entity_id"] = str(entity_id)
+
+    cmd = [
+        python_exe(),
+        str(LEGACY_SCRIPTS_DIR / "labs_009_export_jaeger.py"),
+        "--outdir",
+        str(exports_dir),
+        "--service",
+        str(payload.get("service")),
+        "--lookback",
+        str(payload.get("lookback")),
+        "--limit",
+        str(payload.get("limit")),
+        "--operation",
+        "outbox.process",
+        "--tags-json",
+        json.dumps(tags, ensure_ascii=False),
+    ]
+    rc = run_cmd(cmd, cwd=REPO_ROOT)
+    return DrillResult(ok=(rc == 0), meta={"exit_code": int(rc)}, summary={}, errors=[])
+
+
+@register("duplicate_delivery.clean")
+def clean_duplicate_delivery(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    keep_last = payload.get("keep_last")
+
+    if keep_last is None:
+        return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+    base = LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / SCENARIO_DUPLICATE_DELIVERY
+    if not base.exists():
+        return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+    runs = sorted([p for p in base.iterdir() if p.is_dir()], key=lambda p: p.name, reverse=True)
+    for p in runs[int(keep_last) :]:
+        shutil.rmtree(p, ignore_errors=True)
+    print(f"[labs clean {SCENARIO_DUPLICATE_DELIVERY}] kept_last={keep_last}")
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])

--- a/backend/scripts/cli_app/scenarios/es_429_inject.py
+++ b/backend/scripts/cli_app/scenarios/es_429_inject.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+from ..registry import register
+from ..types import DrillInputs, DrillResult
+from ._failure_drill_shared import (
+    LAB_ID_S3A_2A_3A,
+    default_labs_auto_run_dir,
+    ensure_dir,
+    load_env,
+    prom_parse_counter_sum,
+    python_exe,
+    resolve_run_dir,
+    run_cmd,
+    scrape_metrics_text,
+    with_backend_pythonpath,
+)
+from ._failure_drill_shared import LEGACY_SCRIPTS_DIR, LABS_SNAPSHOT_ROOT, REPO_ROOT
+
+
+SCENARIO_ES_429_INJECT = "es_429_inject"
+
+
+@register("es_429_inject.run")
+def run_es_429_inject(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_id = str(payload.get("run_id") or "").strip()
+    outdir_str = str(payload.get("outdir") or "").strip()
+    outdir = Path(outdir_str) if outdir_str else default_labs_auto_run_dir(scenario=SCENARIO_ES_429_INJECT, run_id=run_id)
+
+    env_file = payload.get("env_file")
+    service = payload.get("service")
+    duration = int(payload.get("duration") or 0)
+    metrics_port = int(payload.get("metrics_port") or 0)
+    scrape_delay = float(payload.get("scrape_delay") or 0.0)
+    op = payload.get("op")
+
+    every_n = payload.get("every_n")
+    ratio = payload.get("ratio")
+    ops = payload.get("ops")
+    seed = payload.get("seed")
+
+    logs_dir = outdir / "_logs"
+    metrics_dir = outdir / "_metrics"
+    exports_dir = outdir / "_exports"
+    ensure_dir(logs_dir)
+    ensure_dir(metrics_dir)
+    ensure_dir(exports_dir)
+
+    env = with_backend_pythonpath(load_env(env_file=str(env_file) if env_file else None))
+
+    service_name = service
+    env.setdefault("WORDLOOM_TRACING_ENABLED", "1")
+    env.setdefault("OTEL_SERVICE_NAME", service_name)
+    env.setdefault("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    env.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    env.setdefault("OTEL_TRACES_SAMPLER", "always_on")
+
+    if every_n is not None and int(every_n) > 0:
+        env["OUTBOX_EXPERIMENT_ES_429_EVERY_N"] = str(int(every_n))
+        env.pop("OUTBOX_EXPERIMENT_ES_429_RATIO", None)
+    else:
+        env["OUTBOX_EXPERIMENT_ES_429_RATIO"] = str(float(ratio))
+        env.pop("OUTBOX_EXPERIMENT_ES_429_EVERY_N", None)
+
+    env["OUTBOX_EXPERIMENT_ES_429_OPS"] = str(ops)
+    if seed is not None:
+        env["OUTBOX_EXPERIMENT_ES_429_SEED"] = str(int(seed))
+    else:
+        env.pop("OUTBOX_EXPERIMENT_ES_429_SEED", None)
+
+    env["OUTBOX_METRICS_PORT"] = str(int(metrics_port))
+
+    recipe = {
+        "lab_id": LAB_ID_S3A_2A_3A,
+        "scenario": SCENARIO_ES_429_INJECT,
+        "run_id": run_id,
+        "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "env_file": env_file,
+        "service": service_name,
+        "inject": {
+            "kind": "es_429",
+            "mode": "every_n" if (every_n is not None and int(every_n) > 0) else "ratio",
+            "every_n": int(every_n) if (every_n is not None) else None,
+            "ratio": float(ratio),
+            "ops": str(ops),
+            "seed": int(seed) if seed is not None else None,
+        },
+        "worker": {"duration_s": int(duration), "metrics_port": int(metrics_port)},
+        "trigger": {"op": str(op)},
+    }
+    (outdir / "_recipe.json").write_text(json.dumps(recipe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    worker = LEGACY_SCRIPTS_DIR / "search_outbox_worker.py"
+    log_path = logs_dir / f"worker-{run_id}.log"
+    cmd = [python_exe(), "-u", str(worker)]
+
+    print(f"[labs run {SCENARIO_ES_429_INJECT}] outdir: {outdir}")
+    print(f"[labs run {SCENARIO_ES_429_INJECT}] worker log: {log_path}")
+
+    metrics_before_path = metrics_dir / "metrics-before.txt"
+    metrics_after_path = metrics_dir / "metrics-after.txt"
+
+    inserter = REPO_ROOT / "backend" / "scripts" / "labs" / "labs_009_insert_search_outbox_pending.py"
+    if not inserter.exists():
+        inserter = LEGACY_SCRIPTS_DIR / "labs_009_insert_search_outbox_pending.py"
+
+    start = time.time()
+    stopped_by_controller = False
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        worker_proc = subprocess.Popen(cmd, cwd=str(REPO_ROOT), env=env, stdout=log_file, stderr=subprocess.STDOUT)
+        try:
+            time.sleep(max(0.5, float(scrape_delay)))
+            try:
+                metrics_before = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                metrics_before_path.write_text(metrics_before, encoding="utf-8")
+            except Exception as exc:  # noqa: BLE001
+                metrics_before_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+            trigger_env = env.copy()
+            trigger_env["OUTBOX_OP"] = str(op)
+            trigger_env.setdefault("OUTBOX_CREATE_SEARCH_INDEX_ROW", "1")
+            trigger_env.setdefault("OUTBOX_EVENT_VERSION", "0")
+
+            proc = subprocess.run(
+                [python_exe(), str(inserter)],
+                cwd=str(REPO_ROOT),
+                env=trigger_env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            (outdir / "_trigger_insert_outbox.stdout.txt").write_text(proc.stdout or "", encoding="utf-8")
+            (outdir / "_trigger_insert_outbox.stderr.txt").write_text(proc.stderr or "", encoding="utf-8")
+            if proc.returncode != 0:
+                print(f"[labs run {SCENARIO_ES_429_INJECT}] failed to insert outbox event: rc={proc.returncode}")
+                worker_proc.terminate()
+                worker_proc.wait(timeout=30)
+                return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+
+            outbox_event_id = (proc.stdout or "").strip().splitlines()[-1].strip()
+            (outdir / "_outbox_event_id.txt").write_text(outbox_event_id + "\n", encoding="utf-8")
+            print(f"[labs run {SCENARIO_ES_429_INJECT}] outbox_event_id: {outbox_event_id}")
+
+            while True:
+                if duration > 0 and (time.time() - start) >= duration:
+                    try:
+                        metrics_after = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                        metrics_after_path.write_text(metrics_after, encoding="utf-8")
+                        (outdir / "_metrics.txt").write_text(metrics_after, encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        metrics_after_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    stopped_by_controller = True
+                    worker_proc.terminate()
+                    break
+
+                ret = worker_proc.poll()
+                if ret is not None:
+                    try:
+                        metrics_after = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                        metrics_after_path.write_text(metrics_after, encoding="utf-8")
+                        (outdir / "_metrics.txt").write_text(metrics_after, encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        metrics_after_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    break
+                time.sleep(0.25)
+        except KeyboardInterrupt:
+            stopped_by_controller = True
+            worker_proc.terminate()
+
+        worker_proc.wait(timeout=30)
+
+    exit_info = {"returncode": int(worker_proc.returncode) if worker_proc.returncode is not None else None}
+    (outdir / "_worker_exit.json").write_text(
+        json.dumps(exit_info, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    if not metrics_after_path.exists():
+        metrics_after_path.write_text("scrape_failed: missing_metrics_after\n", encoding="utf-8")
+
+    if (not stopped_by_controller) and (worker_proc.returncode not in (None, 0)):
+        print(f"[labs run {SCENARIO_ES_429_INJECT}] worker exited early: rc={worker_proc.returncode}")
+        print(f"[labs run {SCENARIO_ES_429_INJECT}] see logs: {log_path}")
+        return DrillResult(ok=False, meta={"exit_code": 4}, summary={}, errors=[])
+
+    print(f"[labs run {SCENARIO_ES_429_INJECT}] done (now run verify/export/clean)")
+    print(f"[labs run {SCENARIO_ES_429_INJECT}] outputs: {outdir}")
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+
+@register("es_429_inject.verify")
+def verify_es_429_inject(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_ES_429_INJECT,
+    )
+    metrics_dir = run_dir / "_metrics"
+    before_path = metrics_dir / "metrics-before.txt"
+    after_path = metrics_dir / "metrics-after.txt"
+
+    before = before_path.read_text(encoding="utf-8") if before_path.exists() else ""
+    after = after_path.read_text(encoding="utf-8") if after_path.exists() else ""
+
+    retry_before = prom_parse_counter_sum(before, "outbox_retry_scheduled_total", labels={"reason": "es_429"})
+    retry_after = prom_parse_counter_sum(after, "outbox_retry_scheduled_total", labels={"reason": "es_429"})
+    failed_before = prom_parse_counter_sum(before, "outbox_failed_total", labels={"reason": "es_429"})
+    failed_after = prom_parse_counter_sum(after, "outbox_failed_total", labels={"reason": "es_429"})
+    terminal_before = prom_parse_counter_sum(before, "outbox_terminal_failed_total", labels={"reason": "es_429"})
+    terminal_after = prom_parse_counter_sum(after, "outbox_terminal_failed_total", labels={"reason": "es_429"})
+
+    delta_retry = retry_after - retry_before
+    delta_failed = failed_after - failed_before
+    delta_terminal = terminal_after - terminal_before
+
+    min_retry_delta = float(payload.get("min_retry_delta") or 0)
+    min_failed_delta = float(payload.get("min_failed_delta") or 0)
+    max_terminal_delta = float(payload.get("max_terminal_delta") or 0)
+
+    ok = (delta_retry >= min_retry_delta) and (delta_failed >= min_failed_delta) and (delta_terminal <= max_terminal_delta)
+
+    result = {
+        "scenario": SCENARIO_ES_429_INJECT,
+        "run_dir": str(run_dir),
+        "checks": {
+            "retry_delta_ge": float(min_retry_delta),
+            "failed_delta_ge": float(min_failed_delta),
+            "terminal_delta_le": float(max_terminal_delta),
+        },
+        "observed": {
+            "outbox_retry_scheduled_total_reason_es_429": {"before": retry_before, "after": retry_after, "delta": delta_retry},
+            "outbox_failed_total_reason_es_429": {"before": failed_before, "after": failed_after, "delta": delta_failed},
+            "outbox_terminal_failed_total_reason_es_429": {"before": terminal_before, "after": terminal_after, "delta": delta_terminal},
+        },
+        "ok": bool(ok),
+    }
+    (run_dir / "_result.json").write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if ok:
+        print(f"[labs verify {SCENARIO_ES_429_INJECT}] OK")
+        return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+    print(f"[labs verify {SCENARIO_ES_429_INJECT}] FAILED")
+    return DrillResult(ok=False, meta={"exit_code": 10}, summary={}, errors=[])
+
+
+@register("es_429_inject.export")
+def export_es_429_inject(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_ES_429_INJECT,
+    )
+    exports_dir = run_dir / "_exports"
+    ensure_dir(exports_dir)
+
+    outbox_event_id_path = run_dir / "_outbox_event_id.txt"
+    outbox_event_id = outbox_event_id_path.read_text(encoding="utf-8").strip() if outbox_event_id_path.exists() else None
+
+    cmd = [
+        python_exe(),
+        str(LEGACY_SCRIPTS_DIR / "labs_009_export_jaeger.py"),
+        "--outdir",
+        str(exports_dir),
+        "--service",
+        str(payload.get("service")),
+        "--lookback",
+        str(payload.get("lookback")),
+        "--limit",
+        str(payload.get("limit")),
+    ]
+    if outbox_event_id:
+        cmd += ["--outbox-event-id", outbox_event_id]
+
+    rc = run_cmd(cmd, cwd=REPO_ROOT)
+    return DrillResult(ok=(rc == 0), meta={"exit_code": int(rc)}, summary={}, errors=[])
+
+
+@register("es_429_inject.clean")
+def clean_es_429_inject(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    outdir = payload.get("outdir")
+    keep_last = payload.get("keep_last")
+
+    if outdir:
+        out_path = Path(str(outdir))
+        ensure_dir(out_path)
+        (out_path / "_clean.txt").write_text(
+            f"scenario={SCENARIO_ES_429_INJECT}\n" "action=noop\n" f"at={time.strftime('%Y-%m-%d %H:%M:%S')}\n",
+            encoding="utf-8",
+        )
+
+    if keep_last is not None:
+        base = LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / SCENARIO_ES_429_INJECT
+        if base.exists():
+            import shutil
+
+            runs = sorted([p for p in base.iterdir() if p.is_dir()], key=lambda p: p.name, reverse=True)
+            for p in runs[int(keep_last) :]:
+                shutil.rmtree(p, ignore_errors=True)
+            print(f"[labs clean {SCENARIO_ES_429_INJECT}] kept_last={keep_last}")
+    else:
+        print(f"[labs clean {SCENARIO_ES_429_INJECT}] noop")
+
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])

--- a/backend/scripts/cli_app/scenarios/es_bulk_partial.py
+++ b/backend/scripts/cli_app/scenarios/es_bulk_partial.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from ..registry import register
+from ..types import DrillInputs, DrillResult
+from ._failure_drill_shared import (
+    LAB_ID_S3A_2A_3A,
+    SEARCH_OUTBOX_OBS_SCHEMA_VERSION,
+    default_labs_auto_run_dir,
+    ensure_dir,
+    extract_last_claim_batch_id,
+    load_env,
+    prom_parse_counter_sum,
+    python_exe,
+    resolve_run_dir,
+    run_cmd,
+    scrape_metrics_text,
+    with_backend_pythonpath,
+)
+from ._failure_drill_shared import LEGACY_SCRIPTS_DIR, LABS_SNAPSHOT_ROOT, REPO_ROOT
+
+
+SCENARIO_ES_BULK_PARTIAL = "es_bulk_partial"
+
+
+@register("es_bulk_partial.run")
+def run_es_bulk_partial(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_id = str(payload.get("run_id") or "").strip()
+    outdir_str = str(payload.get("outdir") or "").strip()
+    outdir = Path(outdir_str) if outdir_str else default_labs_auto_run_dir(scenario=SCENARIO_ES_BULK_PARTIAL, run_id=run_id)
+
+    env_file = payload.get("env_file")
+    service = payload.get("service")
+    duration = int(payload.get("duration") or 0)
+    metrics_port = int(payload.get("metrics_port") or 0)
+    scrape_delay = float(payload.get("scrape_delay") or 0.0)
+    op = payload.get("op")
+    trigger_count = int(payload.get("trigger_count") or 0)
+    bulk_size = int(payload.get("bulk_size") or 0)
+    partial_status = int(payload.get("partial_status") or 0)
+
+    logs_dir = outdir / "_logs"
+    metrics_dir = outdir / "_metrics"
+    exports_dir = outdir / "_exports"
+    ensure_dir(logs_dir)
+    ensure_dir(metrics_dir)
+    ensure_dir(exports_dir)
+
+    env = with_backend_pythonpath(load_env(env_file=str(env_file) if env_file else None))
+
+    service_name = service
+    env.setdefault("WORDLOOM_TRACING_ENABLED", "1")
+    env.setdefault("OTEL_SERVICE_NAME", service_name)
+    env.setdefault("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    env.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    env.setdefault("OTEL_TRACES_SAMPLER", "always_on")
+
+    env["OUTBOX_USE_ES_BULK"] = "1"
+    env["OUTBOX_BULK_SIZE"] = str(int(bulk_size))
+    env["OUTBOX_EXPERIMENT_ES_BULK_PARTIAL"] = "1"
+    env["OUTBOX_EXPERIMENT_ES_BULK_PARTIAL_STATUS"] = str(int(partial_status))
+
+    env["OUTBOX_POLL_INTERVAL_SECONDS"] = "5.0"
+
+    env.setdefault("ELASTIC_URL", "http://localhost:19200")
+    env.setdefault("ELASTIC_INDEX", "wordloom-test-search-index")
+
+    env["OUTBOX_EXPERIMENT_ES_429_RATIO"] = "0"
+    env.pop("OUTBOX_EXPERIMENT_ES_429_EVERY_N", None)
+
+    env["OUTBOX_METRICS_PORT"] = str(int(metrics_port))
+
+    recipe = {
+        "lab_id": LAB_ID_S3A_2A_3A,
+        "scenario": SCENARIO_ES_BULK_PARTIAL,
+        "run_id": run_id,
+        "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "env_file": env_file,
+        "service": service_name,
+        "inject": {
+            "kind": "es_bulk_partial",
+            "enabled": True,
+            "status": int(partial_status),
+        },
+        "worker": {
+            "duration_s": int(duration),
+            "metrics_port": int(metrics_port),
+            "use_es_bulk": True,
+            "bulk_size": int(bulk_size),
+        },
+        "trigger": {"op": str(op), "count": int(trigger_count)},
+    }
+    (outdir / "_recipe.json").write_text(json.dumps(recipe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    worker = LEGACY_SCRIPTS_DIR / "search_outbox_worker.py"
+    log_path = logs_dir / f"worker-{run_id}.log"
+    cmd = [python_exe(), "-u", str(worker)]
+
+    print(f"[labs run {SCENARIO_ES_BULK_PARTIAL}] outdir: {outdir}")
+    print(f"[labs run {SCENARIO_ES_BULK_PARTIAL}] worker log: {log_path}")
+
+    metrics_before_path = metrics_dir / "metrics-before.txt"
+    metrics_after_path = metrics_dir / "metrics-after.txt"
+
+    inserter = REPO_ROOT / "backend" / "scripts" / "labs" / "labs_009_insert_search_outbox_pending.py"
+    if not inserter.exists():
+        inserter = LEGACY_SCRIPTS_DIR / "labs_009_insert_search_outbox_pending.py"
+
+    start = time.time()
+    stopped_by_controller = False
+    outbox_event_ids: list[str] = []
+
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        worker_proc = subprocess.Popen(cmd, cwd=str(REPO_ROOT), env=env, stdout=log_file, stderr=subprocess.STDOUT)
+        try:
+            time.sleep(max(0.5, float(scrape_delay)))
+            try:
+                metrics_before = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                metrics_before_path.write_text(metrics_before, encoding="utf-8")
+            except Exception as exc:  # noqa: BLE001
+                metrics_before_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+            trigger_env = env.copy()
+            trigger_env["OUTBOX_OP"] = str(op)
+            trigger_env.setdefault("OUTBOX_CREATE_SEARCH_INDEX_ROW", "1")
+            trigger_env.setdefault("OUTBOX_EVENT_VERSION", "0")
+            trigger_env["OUTBOX_INSERT_COUNT"] = str(int(trigger_count))
+
+            proc = subprocess.run(
+                [python_exe(), str(inserter)],
+                cwd=str(REPO_ROOT),
+                env=trigger_env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+            (outdir / "_trigger_insert_outbox.stdout.txt").write_text(proc.stdout or "", encoding="utf-8")
+            (outdir / "_trigger_insert_outbox.stderr.txt").write_text(proc.stderr or "", encoding="utf-8")
+            if proc.returncode != 0:
+                print(f"[labs run {SCENARIO_ES_BULK_PARTIAL}] failed to insert outbox events: rc={proc.returncode}")
+                return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+
+            outbox_event_ids = [ln.strip() for ln in (proc.stdout or "").splitlines() if ln.strip()]
+            (outdir / "_outbox_event_ids.txt").write_text("\n".join(outbox_event_ids) + "\n", encoding="utf-8")
+            print(f"[labs run {SCENARIO_ES_BULK_PARTIAL}] outbox_event_ids: {', '.join(outbox_event_ids)}")
+
+            while True:
+                if duration > 0 and (time.time() - start) >= duration:
+                    try:
+                        metrics_after = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                        metrics_after_path.write_text(metrics_after, encoding="utf-8")
+                        (outdir / "_metrics.txt").write_text(metrics_after, encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        metrics_after_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    stopped_by_controller = True
+                    worker_proc.terminate()
+                    break
+
+                ret = worker_proc.poll()
+                if ret is not None:
+                    try:
+                        metrics_after = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                        metrics_after_path.write_text(metrics_after, encoding="utf-8")
+                        (outdir / "_metrics.txt").write_text(metrics_after, encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        metrics_after_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    break
+                time.sleep(0.25)
+        except KeyboardInterrupt:
+            stopped_by_controller = True
+            worker_proc.terminate()
+
+        worker_proc.wait(timeout=30)
+
+    exit_info = {"returncode": int(worker_proc.returncode) if worker_proc.returncode is not None else None}
+    (outdir / "_worker_exit.json").write_text(json.dumps(exit_info, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if not metrics_after_path.exists():
+        metrics_after_path.write_text("scrape_failed: missing_metrics_after\n", encoding="utf-8")
+
+    claim_batch_id = extract_last_claim_batch_id(log_path)
+    if claim_batch_id:
+        (outdir / "_claim_batch_id.txt").write_text(claim_batch_id + "\n", encoding="utf-8")
+
+    if (not stopped_by_controller) and (worker_proc.returncode not in (None, 0)):
+        print(f"[labs run {SCENARIO_ES_BULK_PARTIAL}] worker exited early: rc={worker_proc.returncode}")
+        print(f"[labs run {SCENARIO_ES_BULK_PARTIAL}] see logs: {log_path}")
+        return DrillResult(ok=False, meta={"exit_code": 4}, summary={}, errors=[])
+
+    print(f"[labs run {SCENARIO_ES_BULK_PARTIAL}] done (now run verify/export/clean)")
+    print(f"[labs run {SCENARIO_ES_BULK_PARTIAL}] outputs: {outdir}")
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+
+@register("es_bulk_partial.verify")
+def verify_es_bulk_partial(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_ES_BULK_PARTIAL,
+    )
+    metrics_dir = run_dir / "_metrics"
+    before_path = metrics_dir / "metrics-before.txt"
+    after_path = metrics_dir / "metrics-after.txt"
+
+    before = before_path.read_text(encoding="utf-8") if before_path.exists() else ""
+    after = after_path.read_text(encoding="utf-8") if after_path.exists() else ""
+
+    partial_before = prom_parse_counter_sum(before, "outbox_es_bulk_requests_total", labels={"result": "partial"})
+    partial_after = prom_parse_counter_sum(after, "outbox_es_bulk_requests_total", labels={"result": "partial"})
+
+    success_items_before = (
+        prom_parse_counter_sum(before, "outbox_es_bulk_items_total", labels={"op": "index", "result": "success"})
+        + prom_parse_counter_sum(before, "outbox_es_bulk_items_total", labels={"op": "delete", "result": "success"})
+    )
+    success_items_after = (
+        prom_parse_counter_sum(after, "outbox_es_bulk_items_total", labels={"op": "index", "result": "success"})
+        + prom_parse_counter_sum(after, "outbox_es_bulk_items_total", labels={"op": "delete", "result": "success"})
+    )
+
+    failed_items_before = (
+        prom_parse_counter_sum(before, "outbox_es_bulk_items_total", labels={"op": "index", "result": "failed"})
+        + prom_parse_counter_sum(before, "outbox_es_bulk_items_total", labels={"op": "delete", "result": "failed"})
+    )
+    failed_items_after = (
+        prom_parse_counter_sum(after, "outbox_es_bulk_items_total", labels={"op": "index", "result": "failed"})
+        + prom_parse_counter_sum(after, "outbox_es_bulk_items_total", labels={"op": "delete", "result": "failed"})
+    )
+
+    failed_4xx_before = (
+        prom_parse_counter_sum(before, "outbox_es_bulk_item_failures_total", labels={"op": "index", "failure_class": "4xx"})
+        + prom_parse_counter_sum(before, "outbox_es_bulk_item_failures_total", labels={"op": "delete", "failure_class": "4xx"})
+    )
+    failed_4xx_after = (
+        prom_parse_counter_sum(after, "outbox_es_bulk_item_failures_total", labels={"op": "index", "failure_class": "4xx"})
+        + prom_parse_counter_sum(after, "outbox_es_bulk_item_failures_total", labels={"op": "delete", "failure_class": "4xx"})
+    )
+
+    delta_partial = partial_after - partial_before
+    delta_success_items = success_items_after - success_items_before
+    delta_failed_items = failed_items_after - failed_items_before
+    delta_failed_4xx = failed_4xx_after - failed_4xx_before
+
+    min_partial_delta = float(payload.get("min_partial_delta") or 0)
+    min_success_items_delta = float(payload.get("min_success_items_delta") or 0)
+    min_failed_items_delta = float(payload.get("min_failed_items_delta") or 0)
+    min_failed_4xx_delta = float(payload.get("min_failed_4xx_delta") or 0)
+
+    ok = (
+        (delta_partial >= min_partial_delta)
+        and (delta_success_items >= min_success_items_delta)
+        and (delta_failed_items >= min_failed_items_delta)
+        and (delta_failed_4xx >= min_failed_4xx_delta)
+    )
+
+    result = {
+        "scenario": SCENARIO_ES_BULK_PARTIAL,
+        "run_dir": str(run_dir),
+        "checks": {
+            "partial_delta_ge": float(min_partial_delta),
+            "success_items_delta_ge": float(min_success_items_delta),
+            "failed_items_delta_ge": float(min_failed_items_delta),
+            "failed_4xx_delta_ge": float(min_failed_4xx_delta),
+        },
+        "observed": {
+            "outbox_es_bulk_requests_total_result_partial": {"before": partial_before, "after": partial_after, "delta": delta_partial},
+            "outbox_es_bulk_items_total_success_sum": {"before": success_items_before, "after": success_items_after, "delta": delta_success_items},
+            "outbox_es_bulk_items_total_failed_sum": {"before": failed_items_before, "after": failed_items_after, "delta": delta_failed_items},
+            "outbox_es_bulk_item_failures_total_failure_class_4xx_sum": {"before": failed_4xx_before, "after": failed_4xx_after, "delta": delta_failed_4xx},
+        },
+        "ok": bool(ok),
+    }
+    (run_dir / "_result.json").write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if ok:
+        print(f"[labs verify {SCENARIO_ES_BULK_PARTIAL}] OK")
+        return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+    print(f"[labs verify {SCENARIO_ES_BULK_PARTIAL}] FAILED")
+    return DrillResult(ok=False, meta={"exit_code": 10}, summary={}, errors=[])
+
+
+@register("es_bulk_partial.export")
+def export_es_bulk_partial(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_ES_BULK_PARTIAL,
+    )
+    exports_dir = run_dir / "_exports"
+    ensure_dir(exports_dir)
+
+    claim_batch_id_path = run_dir / "_claim_batch_id.txt"
+    claim_batch_id = claim_batch_id_path.read_text(encoding="utf-8").strip() if claim_batch_id_path.exists() else None
+
+    exporter = LEGACY_SCRIPTS_DIR / "labs_009_export_jaeger.py"
+    base_cmd = [
+        python_exe(),
+        str(exporter),
+        "--outdir",
+        str(exports_dir),
+        "--service",
+        str(payload.get("service")),
+        "--lookback",
+        str(payload.get("lookback")),
+        "--limit",
+        str(payload.get("limit")),
+    ]
+
+    if claim_batch_id:
+        rc = run_cmd(base_cmd + ["--claim-batch-id", claim_batch_id], cwd=REPO_ROOT)
+        return DrillResult(ok=(rc == 0), meta={"exit_code": int(rc)}, summary={}, errors=[])
+
+    rc = run_cmd(
+        base_cmd
+        + ["--tags-json", json.dumps({"wordloom.obs_schema": SEARCH_OUTBOX_OBS_SCHEMA_VERSION}, ensure_ascii=False)],
+        cwd=REPO_ROOT,
+    )
+    return DrillResult(ok=(rc == 0), meta={"exit_code": int(rc)}, summary={}, errors=[])
+
+
+@register("es_bulk_partial.clean")
+def clean_es_bulk_partial(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    outdir = payload.get("outdir")
+    keep_last = payload.get("keep_last")
+
+    if outdir:
+        out_path = Path(str(outdir))
+        ensure_dir(out_path)
+        (out_path / "_clean.txt").write_text(
+            f"scenario={SCENARIO_ES_BULK_PARTIAL}\n" "action=noop\n" f"at={time.strftime('%Y-%m-%d %H:%M:%S')}\n",
+            encoding="utf-8",
+        )
+
+    if keep_last is not None:
+        base = LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / SCENARIO_ES_BULK_PARTIAL
+        if base.exists():
+            runs = sorted([p for p in base.iterdir() if p.is_dir()], key=lambda p: p.name, reverse=True)
+            for p in runs[int(keep_last) :]:
+                shutil.rmtree(p, ignore_errors=True)
+            print(f"[labs clean {SCENARIO_ES_BULK_PARTIAL}] kept_last={keep_last}")
+    else:
+        print(f"[labs clean {SCENARIO_ES_BULK_PARTIAL}] noop")
+
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])

--- a/backend/scripts/cli_app/scenarios/es_down_connect.py
+++ b/backend/scripts/cli_app/scenarios/es_down_connect.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+from ..registry import register
+from ..types import DrillInputs, DrillResult
+from ._failure_drill_shared import (
+    LAB_ID_S3A_2A_3A,
+    default_labs_auto_run_dir,
+    docker_compose,
+    ensure_dir,
+    load_env,
+    prom_sum_reasons,
+    python_exe,
+    resolve_run_dir,
+    run_cmd,
+    scrape_metrics_text,
+    with_backend_pythonpath,
+)
+from ._failure_drill_shared import LEGACY_SCRIPTS_DIR, LABS_SNAPSHOT_ROOT, REPO_ROOT
+
+
+SCENARIO_ES_DOWN_CONNECT = "es_down_connect"
+
+
+@register("es_down_connect.run")
+def run_es_down_connect(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_id = str(payload.get("run_id") or "").strip()
+    outdir_str = str(payload.get("outdir") or "").strip()
+    outdir = Path(outdir_str) if outdir_str else default_labs_auto_run_dir(scenario=SCENARIO_ES_DOWN_CONNECT, run_id=run_id)
+
+    env_file = payload.get("env_file")
+    service = payload.get("service")
+    duration = int(payload.get("duration") or 0)
+    metrics_port = int(payload.get("metrics_port") or 0)
+    scrape_delay = float(payload.get("scrape_delay") or 0.0)
+    op = payload.get("op")
+
+    logs_dir = outdir / "_logs"
+    metrics_dir = outdir / "_metrics"
+    exports_dir = outdir / "_exports"
+    ensure_dir(logs_dir)
+    ensure_dir(metrics_dir)
+    ensure_dir(exports_dir)
+
+    env = with_backend_pythonpath(load_env(env_file=str(env_file) if env_file else None))
+
+    service_name = service
+    env.setdefault("WORDLOOM_TRACING_ENABLED", "1")
+    env.setdefault("OTEL_SERVICE_NAME", service_name)
+    env.setdefault("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    env.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    env.setdefault("OTEL_TRACES_SAMPLER", "always_on")
+
+    env["OUTBOX_EXPERIMENT_ES_429_RATIO"] = "0"
+    env.pop("OUTBOX_EXPERIMENT_ES_429_EVERY_N", None)
+
+    env["OUTBOX_METRICS_PORT"] = str(int(metrics_port))
+
+    compose_file = str((REPO_ROOT / "docker-compose.infra.yml").resolve())
+    recipe = {
+        "lab_id": LAB_ID_S3A_2A_3A,
+        "scenario": SCENARIO_ES_DOWN_CONNECT,
+        "run_id": run_id,
+        "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "env_file": env_file,
+        "service": service_name,
+        "inject": {"kind": "es_down", "compose": {"file": compose_file, "service": "es", "action": "stop"}},
+        "worker": {"duration_s": int(duration), "metrics_port": int(metrics_port)},
+        "trigger": {"op": str(op)},
+    }
+    (outdir / "_recipe.json").write_text(json.dumps(recipe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    print(f"[labs run {SCENARIO_ES_DOWN_CONNECT}] outdir: {outdir}")
+
+    stop_proc = docker_compose(args=["-f", compose_file, "stop", "es"], cwd=REPO_ROOT)
+    (outdir / "_inject_es_stop.stdout.txt").write_text(stop_proc.stdout or "", encoding="utf-8")
+    (outdir / "_inject_es_stop.stderr.txt").write_text(stop_proc.stderr or "", encoding="utf-8")
+    (outdir / "_inject_es_stop.exitcode.txt").write_text(str(int(stop_proc.returncode)) + "\n", encoding="utf-8")
+    if stop_proc.returncode != 0:
+        print(f"[labs run {SCENARIO_ES_DOWN_CONNECT}] failed to stop es: rc={stop_proc.returncode}")
+        return DrillResult(ok=False, meta={"exit_code": 2}, summary={}, errors=[])
+
+    worker = LEGACY_SCRIPTS_DIR / "search_outbox_worker.py"
+    log_path = logs_dir / f"worker-{run_id}.log"
+    cmd = [python_exe(), "-u", str(worker)]
+
+    print(f"[labs run {SCENARIO_ES_DOWN_CONNECT}] worker log: {log_path}")
+
+    metrics_before_path = metrics_dir / "metrics-before.txt"
+    metrics_after_path = metrics_dir / "metrics-after.txt"
+
+    inserter = REPO_ROOT / "backend" / "scripts" / "labs" / "labs_009_insert_search_outbox_pending.py"
+    if not inserter.exists():
+        inserter = LEGACY_SCRIPTS_DIR / "labs_009_insert_search_outbox_pending.py"
+
+    start = time.time()
+    stopped_by_controller = False
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        worker_proc = subprocess.Popen(cmd, cwd=str(REPO_ROOT), env=env, stdout=log_file, stderr=subprocess.STDOUT)
+        try:
+            time.sleep(max(0.5, float(scrape_delay)))
+            try:
+                metrics_before = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                metrics_before_path.write_text(metrics_before, encoding="utf-8")
+            except Exception as exc:  # noqa: BLE001
+                metrics_before_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+            trigger_env = env.copy()
+            trigger_env["OUTBOX_OP"] = str(op)
+            trigger_env.setdefault("OUTBOX_CREATE_SEARCH_INDEX_ROW", "1")
+            trigger_env.setdefault("OUTBOX_EVENT_VERSION", "0")
+
+            proc = subprocess.run(
+                [python_exe(), str(inserter)],
+                cwd=str(REPO_ROOT),
+                env=trigger_env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            (outdir / "_trigger_insert_outbox.stdout.txt").write_text(proc.stdout or "", encoding="utf-8")
+            (outdir / "_trigger_insert_outbox.stderr.txt").write_text(proc.stderr or "", encoding="utf-8")
+            if proc.returncode != 0:
+                print(f"[labs run {SCENARIO_ES_DOWN_CONNECT}] failed to insert outbox event: rc={proc.returncode}")
+                worker_proc.terminate()
+                worker_proc.wait(timeout=30)
+                return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+
+            outbox_event_id = (proc.stdout or "").strip().splitlines()[-1].strip()
+            (outdir / "_outbox_event_id.txt").write_text(outbox_event_id + "\n", encoding="utf-8")
+            print(f"[labs run {SCENARIO_ES_DOWN_CONNECT}] outbox_event_id: {outbox_event_id}")
+
+            while True:
+                if duration > 0 and (time.time() - start) >= duration:
+                    try:
+                        metrics_after = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                        metrics_after_path.write_text(metrics_after, encoding="utf-8")
+                        (outdir / "_metrics.txt").write_text(metrics_after, encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        metrics_after_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    stopped_by_controller = True
+                    worker_proc.terminate()
+                    break
+
+                ret = worker_proc.poll()
+                if ret is not None:
+                    try:
+                        metrics_after = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                        metrics_after_path.write_text(metrics_after, encoding="utf-8")
+                        (outdir / "_metrics.txt").write_text(metrics_after, encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        metrics_after_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    break
+                time.sleep(0.25)
+        except KeyboardInterrupt:
+            stopped_by_controller = True
+            worker_proc.terminate()
+
+        worker_proc.wait(timeout=30)
+
+    exit_info = {"returncode": int(worker_proc.returncode) if worker_proc.returncode is not None else None}
+    (outdir / "_worker_exit.json").write_text(
+        json.dumps(exit_info, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    if not metrics_after_path.exists():
+        metrics_after_path.write_text("scrape_failed: missing_metrics_after\n", encoding="utf-8")
+
+    if (not stopped_by_controller) and (worker_proc.returncode not in (None, 0)):
+        print(f"[labs run {SCENARIO_ES_DOWN_CONNECT}] worker exited early: rc={worker_proc.returncode}")
+        print(f"[labs run {SCENARIO_ES_DOWN_CONNECT}] see logs: {log_path}")
+        return DrillResult(ok=False, meta={"exit_code": 4}, summary={}, errors=[])
+
+    print(f"[labs run {SCENARIO_ES_DOWN_CONNECT}] done (now run verify/export/clean)")
+    print(f"[labs run {SCENARIO_ES_DOWN_CONNECT}] outputs: {outdir}")
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+
+@register("es_down_connect.verify")
+def verify_es_down_connect(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_ES_DOWN_CONNECT,
+    )
+    metrics_dir = run_dir / "_metrics"
+    before_path = metrics_dir / "metrics-before.txt"
+    after_path = metrics_dir / "metrics-after.txt"
+
+    before = before_path.read_text(encoding="utf-8") if before_path.exists() else ""
+    after = after_path.read_text(encoding="utf-8") if after_path.exists() else ""
+
+    reasons = ["es_connect", "es_unreachable"]
+
+    retry_before = prom_sum_reasons(before, "outbox_retry_scheduled_total", reasons=reasons)
+    retry_after = prom_sum_reasons(after, "outbox_retry_scheduled_total", reasons=reasons)
+    failed_before = prom_sum_reasons(before, "outbox_failed_total", reasons=reasons)
+    failed_after = prom_sum_reasons(after, "outbox_failed_total", reasons=reasons)
+    terminal_before = prom_sum_reasons(before, "outbox_terminal_failed_total", reasons=reasons)
+    terminal_after = prom_sum_reasons(after, "outbox_terminal_failed_total", reasons=reasons)
+
+    delta_retry = retry_after - retry_before
+    delta_failed = failed_after - failed_before
+    delta_terminal = terminal_after - terminal_before
+
+    min_retry_delta = float(payload.get("min_retry_delta") or 0)
+    min_failed_delta = float(payload.get("min_failed_delta") or 0)
+    max_terminal_delta = float(payload.get("max_terminal_delta") or 0)
+
+    ok = (delta_retry >= min_retry_delta) and (delta_failed >= min_failed_delta) and (delta_terminal <= max_terminal_delta)
+
+    result = {
+        "scenario": SCENARIO_ES_DOWN_CONNECT,
+        "run_dir": str(run_dir),
+        "checks": {
+            "reasons": reasons,
+            "retry_delta_ge": float(min_retry_delta),
+            "failed_delta_ge": float(min_failed_delta),
+            "terminal_delta_le": float(max_terminal_delta),
+        },
+        "observed": {
+            "outbox_retry_scheduled_total_reason_es_connect_or_unreachable": {"before": retry_before, "after": retry_after, "delta": delta_retry},
+            "outbox_failed_total_reason_es_connect_or_unreachable": {"before": failed_before, "after": failed_after, "delta": delta_failed},
+            "outbox_terminal_failed_total_reason_es_connect_or_unreachable": {"before": terminal_before, "after": terminal_after, "delta": delta_terminal},
+        },
+        "ok": bool(ok),
+    }
+    (run_dir / "_result.json").write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if ok:
+        print(f"[labs verify {SCENARIO_ES_DOWN_CONNECT}] OK")
+        return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+    print(f"[labs verify {SCENARIO_ES_DOWN_CONNECT}] FAILED")
+    return DrillResult(ok=False, meta={"exit_code": 10}, summary={}, errors=[])
+
+
+@register("es_down_connect.export")
+def export_es_down_connect(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_ES_DOWN_CONNECT,
+    )
+    exports_dir = run_dir / "_exports"
+    ensure_dir(exports_dir)
+
+    outbox_event_id_path = run_dir / "_outbox_event_id.txt"
+    outbox_event_id = outbox_event_id_path.read_text(encoding="utf-8").strip() if outbox_event_id_path.exists() else None
+
+    cmd = [
+        python_exe(),
+        str(LEGACY_SCRIPTS_DIR / "labs_009_export_jaeger.py"),
+        "--outdir",
+        str(exports_dir),
+        "--service",
+        str(payload.get("service")),
+        "--lookback",
+        str(payload.get("lookback")),
+        "--limit",
+        str(payload.get("limit")),
+    ]
+    if outbox_event_id:
+        cmd += ["--outbox-event-id", outbox_event_id]
+
+    rc = run_cmd(cmd, cwd=REPO_ROOT)
+    return DrillResult(ok=(rc == 0), meta={"exit_code": int(rc)}, summary={}, errors=[])
+
+
+@register("es_down_connect.clean")
+def clean_es_down_connect(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    outdir = payload.get("outdir")
+    keep_last = payload.get("keep_last")
+
+    compose_file = str((REPO_ROOT / "docker-compose.infra.yml").resolve())
+    start_proc = docker_compose(args=["-f", compose_file, "start", "es"], cwd=REPO_ROOT)
+    print(f"[labs clean {SCENARIO_ES_DOWN_CONNECT}] start es: rc={start_proc.returncode}")
+
+    if outdir:
+        out_path = Path(str(outdir))
+        ensure_dir(out_path)
+        (out_path / "_clean.txt").write_text(
+            f"scenario={SCENARIO_ES_DOWN_CONNECT}\n" "action=start_es\n" f"at={time.strftime('%Y-%m-%d %H:%M:%S')}\n",
+            encoding="utf-8",
+        )
+        (out_path / "_clean_es_start.stdout.txt").write_text(start_proc.stdout or "", encoding="utf-8")
+        (out_path / "_clean_es_start.stderr.txt").write_text(start_proc.stderr or "", encoding="utf-8")
+        (out_path / "_clean_es_start.exitcode.txt").write_text(str(int(start_proc.returncode)) + "\n", encoding="utf-8")
+
+    if keep_last is not None:
+        base = LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / SCENARIO_ES_DOWN_CONNECT
+        if base.exists():
+            import shutil
+
+            runs = sorted([p for p in base.iterdir() if p.is_dir()], key=lambda p: p.name, reverse=True)
+            for p in runs[int(keep_last) :]:
+                shutil.rmtree(p, ignore_errors=True)
+            print(f"[labs clean {SCENARIO_ES_DOWN_CONNECT}] kept_last={keep_last}")
+
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])

--- a/backend/scripts/cli_app/scenarios/es_write_block_4xx.py
+++ b/backend/scripts/cli_app/scenarios/es_write_block_4xx.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+from ..registry import register
+from ..types import DrillInputs, DrillResult
+from ._failure_drill_shared import (
+    LAB_ID_S3A_2A_3A,
+    default_labs_auto_run_dir,
+    ensure_dir,
+    es_create_index_if_missing,
+    es_set_index_write_block,
+    load_env,
+    prom_parse_counter_sum,
+    python_exe,
+    resolve_run_dir,
+    run_cmd,
+    scrape_metrics_text,
+    with_backend_pythonpath,
+)
+from ._failure_drill_shared import LABS_SNAPSHOT_ROOT, LEGACY_SCRIPTS_DIR, REPO_ROOT
+
+
+SCENARIO_ES_WRITE_BLOCK_4XX = "es_write_block_4xx"
+
+
+@register("es_write_block_4xx.run")
+def run_es_write_block_4xx(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_id = str(payload.get("run_id") or "").strip()
+    outdir_str = str(payload.get("outdir") or "").strip()
+    outdir = Path(outdir_str) if outdir_str else default_labs_auto_run_dir(scenario=SCENARIO_ES_WRITE_BLOCK_4XX, run_id=run_id)
+
+    env_file = payload.get("env_file")
+    service = payload.get("service")
+    duration = int(payload.get("duration") or 0)
+    metrics_port = int(payload.get("metrics_port") or 0)
+    scrape_delay = float(payload.get("scrape_delay") or 0.0)
+
+    logs_dir = outdir / "_logs"
+    metrics_dir = outdir / "_metrics"
+    exports_dir = outdir / "_exports"
+    ensure_dir(logs_dir)
+    ensure_dir(metrics_dir)
+    ensure_dir(exports_dir)
+
+    env = with_backend_pythonpath(load_env(env_file=str(env_file) if env_file else None))
+
+    es_url = (env.get("ELASTIC_URL") or "http://localhost:19200").strip().rstrip("/")
+    es_index = (env.get("ELASTIC_INDEX") or "wordloom-search-index").strip()
+
+    service_name = service
+    env.setdefault("WORDLOOM_TRACING_ENABLED", "1")
+    env.setdefault("OTEL_SERVICE_NAME", service_name)
+    env.setdefault("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    env.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    env.setdefault("OTEL_TRACES_SAMPLER", "always_on")
+
+    env["LOG_LEVEL"] = "INFO"
+    env["OUTBOX_EXPERIMENT_ES_429_RATIO"] = "0"
+    env["OUTBOX_METRICS_PORT"] = str(int(metrics_port))
+
+    recipe = {
+        "lab_id": LAB_ID_S3A_2A_3A,
+        "scenario": SCENARIO_ES_WRITE_BLOCK_4XX,
+        "run_id": run_id,
+        "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "env_file": env_file,
+        "service": service_name,
+        "es": {"url": es_url, "index": es_index, "inject": {"index.blocks.write": True}},
+        "worker": {"duration_s": int(duration), "metrics_port": int(metrics_port)},
+    }
+    (outdir / "_recipe.json").write_text(json.dumps(recipe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    worker = LEGACY_SCRIPTS_DIR / "search_outbox_worker.py"
+    log_path = logs_dir / f"worker-{run_id}.log"
+    cmd = [python_exe(), "-u", str(worker)]
+
+    print(f"[labs run {SCENARIO_ES_WRITE_BLOCK_4XX}] outdir: {outdir}")
+    print(f"[labs run {SCENARIO_ES_WRITE_BLOCK_4XX}] worker log: {log_path}")
+
+    metrics_before_path = metrics_dir / "metrics-before.txt"
+    metrics_after_path = metrics_dir / "metrics-after.txt"
+
+    start = time.time()
+    stopped_by_controller = False
+
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        worker_proc = subprocess.Popen(cmd, cwd=str(REPO_ROOT), env=env, stdout=log_file, stderr=subprocess.STDOUT)
+        try:
+            time.sleep(max(0.5, float(scrape_delay)))
+            try:
+                metrics_before = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                metrics_before_path.write_text(metrics_before, encoding="utf-8")
+            except Exception as exc:  # noqa: BLE001
+                metrics_before_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+            status, response_payload = es_set_index_write_block(es_url=es_url, index=es_index, enabled=True)
+            if status == 404:
+                c_status, c_payload = es_create_index_if_missing(es_url=es_url, index=es_index)
+                (outdir / "_inject_es_create_index.response.txt").write_text(
+                    f"status={c_status}\n\n{c_payload}\n", encoding="utf-8"
+                )
+                if c_status not in (200, 201, 400):
+                    print(f"[labs run {SCENARIO_ES_WRITE_BLOCK_4XX}] failed to create index: http {c_status}")
+                    worker_proc.terminate()
+                    worker_proc.wait(timeout=30)
+                    return DrillResult(ok=False, meta={"exit_code": 2}, summary={}, errors=[])
+
+                status, response_payload = es_set_index_write_block(es_url=es_url, index=es_index, enabled=True)
+
+            (outdir / "_inject_es_write_block.response.txt").write_text(
+                f"status={status}\n\n{response_payload}\n", encoding="utf-8"
+            )
+            if status < 200 or status >= 300:
+                print(f"[labs run {SCENARIO_ES_WRITE_BLOCK_4XX}] failed to enable write block: http {status}")
+                worker_proc.terminate()
+                worker_proc.wait(timeout=30)
+                return DrillResult(ok=False, meta={"exit_code": 2}, summary={}, errors=[])
+
+            inserter = REPO_ROOT / "backend" / "scripts" / "labs" / "labs_009_insert_search_outbox_pending.py"
+            if not inserter.exists():
+                inserter = LEGACY_SCRIPTS_DIR / "labs_009_insert_search_outbox_pending.py"
+            trigger_env = env.copy()
+            trigger_env.setdefault("OUTBOX_OP", "upsert")
+            trigger_env.setdefault("OUTBOX_CREATE_SEARCH_INDEX_ROW", "1")
+
+            proc = subprocess.run(
+                [python_exe(), str(inserter)],
+                cwd=str(REPO_ROOT),
+                env=trigger_env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            (outdir / "_trigger_insert_outbox.stdout.txt").write_text(proc.stdout or "", encoding="utf-8")
+            (outdir / "_trigger_insert_outbox.stderr.txt").write_text(proc.stderr or "", encoding="utf-8")
+            if proc.returncode != 0:
+                print(f"[labs run {SCENARIO_ES_WRITE_BLOCK_4XX}] failed to insert outbox event: rc={proc.returncode}")
+                worker_proc.terminate()
+                worker_proc.wait(timeout=30)
+                return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+
+            outbox_event_id = (proc.stdout or "").strip().splitlines()[-1].strip()
+            (outdir / "_outbox_event_id.txt").write_text(outbox_event_id + "\n", encoding="utf-8")
+            print(f"[labs run {SCENARIO_ES_WRITE_BLOCK_4XX}] outbox_event_id: {outbox_event_id}")
+
+            while True:
+                if duration > 0 and (time.time() - start) >= duration:
+                    try:
+                        metrics_after = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                        metrics_after_path.write_text(metrics_after, encoding="utf-8")
+                        (outdir / "_metrics.txt").write_text(metrics_after, encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        metrics_after_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    stopped_by_controller = True
+                    worker_proc.terminate()
+                    break
+
+                ret = worker_proc.poll()
+                if ret is not None:
+                    try:
+                        metrics_after = scrape_metrics_text(port=int(metrics_port), timeout_s=4.0)
+                        metrics_after_path.write_text(metrics_after, encoding="utf-8")
+                        (outdir / "_metrics.txt").write_text(metrics_after, encoding="utf-8")
+                    except Exception as exc:  # noqa: BLE001
+                        metrics_after_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+                    break
+                time.sleep(0.25)
+        except KeyboardInterrupt:
+            stopped_by_controller = True
+            worker_proc.terminate()
+
+        worker_proc.wait(timeout=30)
+
+    exit_info = {"returncode": int(worker_proc.returncode) if worker_proc.returncode is not None else None}
+    (outdir / "_worker_exit.json").write_text(
+        json.dumps(exit_info, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    if not metrics_after_path.exists():
+        metrics_after_path.write_text("scrape_failed: missing_metrics_after\n", encoding="utf-8")
+
+    if (not stopped_by_controller) and (worker_proc.returncode not in (None, 0)):
+        print(f"[labs run {SCENARIO_ES_WRITE_BLOCK_4XX}] worker exited early: rc={worker_proc.returncode}")
+        print(f"[labs run {SCENARIO_ES_WRITE_BLOCK_4XX}] see logs: {log_path}")
+        return DrillResult(ok=False, meta={"exit_code": 4}, summary={}, errors=[])
+
+    print(f"[labs run {SCENARIO_ES_WRITE_BLOCK_4XX}] done (now run verify/export/clean)")
+    print(f"[labs run {SCENARIO_ES_WRITE_BLOCK_4XX}] outputs: {outdir}")
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+
+@register("es_write_block_4xx.verify")
+def verify_es_write_block_4xx(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_id = payload.get("run_id")
+    outdir = payload.get("outdir")
+
+    min_failed_delta = float(payload.get("min_failed_delta") or 0)
+    max_retry_delta = float(payload.get("max_retry_delta") or 0)
+
+    run_dir = resolve_run_dir(run_id=str(run_id) if run_id else None, outdir=str(outdir) if outdir else None, scenario=SCENARIO_ES_WRITE_BLOCK_4XX)
+    metrics_dir = run_dir / "_metrics"
+    before_path = metrics_dir / "metrics-before.txt"
+    after_path = metrics_dir / "metrics-after.txt"
+
+    before = before_path.read_text(encoding="utf-8") if before_path.exists() else ""
+    after = after_path.read_text(encoding="utf-8") if after_path.exists() else ""
+
+    failed_before = prom_parse_counter_sum(before, "outbox_failed_total", labels={"reason": "es_4xx"})
+    failed_after = prom_parse_counter_sum(after, "outbox_failed_total", labels={"reason": "es_4xx"})
+    retry_before = prom_parse_counter_sum(before, "outbox_retry_scheduled_total", labels={"reason": "es_4xx"})
+    retry_after = prom_parse_counter_sum(after, "outbox_retry_scheduled_total", labels={"reason": "es_4xx"})
+
+    delta_failed = failed_after - failed_before
+    delta_retry = retry_after - retry_before
+
+    ok = (delta_failed >= float(min_failed_delta)) and (delta_retry <= float(max_retry_delta))
+    result = {
+        "scenario": SCENARIO_ES_WRITE_BLOCK_4XX,
+        "run_dir": str(run_dir),
+        "checks": {
+            "failed_delta_ge": float(min_failed_delta),
+            "retry_delta_le": float(max_retry_delta),
+        },
+        "observed": {
+            "outbox_failed_total_reason_es_4xx": {"before": failed_before, "after": failed_after, "delta": delta_failed},
+            "outbox_retry_scheduled_total_reason_es_4xx": {"before": retry_before, "after": retry_after, "delta": delta_retry},
+        },
+        "ok": bool(ok),
+    }
+    (run_dir / "_result.json").write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if ok:
+        print(f"[labs verify {SCENARIO_ES_WRITE_BLOCK_4XX}] OK")
+        return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+    print(f"[labs verify {SCENARIO_ES_WRITE_BLOCK_4XX}] FAILED")
+    return DrillResult(ok=False, meta={"exit_code": 10}, summary={}, errors=[])
+
+
+@register("es_write_block_4xx.export")
+def export_es_write_block_4xx(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_ES_WRITE_BLOCK_4XX,
+    )
+    exports_dir = run_dir / "_exports"
+    ensure_dir(exports_dir)
+
+    outbox_event_id_path = run_dir / "_outbox_event_id.txt"
+    outbox_event_id = outbox_event_id_path.read_text(encoding="utf-8").strip() if outbox_event_id_path.exists() else None
+
+    cmd = [
+        python_exe(),
+        str(LEGACY_SCRIPTS_DIR / "labs_009_export_jaeger.py"),
+        "--outdir",
+        str(exports_dir),
+        "--service",
+        str(payload.get("service")),
+        "--lookback",
+        str(payload.get("lookback")),
+        "--limit",
+        str(payload.get("limit")),
+    ]
+    if outbox_event_id:
+        cmd += ["--outbox-event-id", outbox_event_id]
+
+    rc = run_cmd(cmd, cwd=REPO_ROOT)
+    return DrillResult(ok=(rc == 0), meta={"exit_code": int(rc)}, summary={}, errors=[])
+
+
+@register("es_write_block_4xx.clean")
+def clean_es_write_block_4xx(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    env_file = payload.get("env_file")
+    outdir = payload.get("outdir")
+    keep_last = payload.get("keep_last")
+
+    env = load_env(env_file=str(env_file) if env_file else None)
+    es_url = (env.get("ELASTIC_URL") or "http://localhost:19200").strip().rstrip("/")
+    es_index = (env.get("ELASTIC_INDEX") or "wordloom-search-index").strip()
+
+    status, response_payload = es_set_index_write_block(es_url=es_url, index=es_index, enabled=False)
+    print(f"[labs clean {SCENARIO_ES_WRITE_BLOCK_4XX}] disable write block: http {status}")
+    if outdir:
+        out_path = Path(str(outdir))
+        ensure_dir(out_path)
+        (out_path / "_clean_es_write_block.response.txt").write_text(
+            f"status={status}\n\n{response_payload}\n", encoding="utf-8"
+        )
+
+    if keep_last is not None:
+        base = LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / SCENARIO_ES_WRITE_BLOCK_4XX
+        if base.exists():
+            runs = sorted([p for p in base.iterdir() if p.is_dir()], key=lambda p: p.name, reverse=True)
+            for p in runs[int(keep_last) :]:
+                import shutil
+
+                shutil.rmtree(p, ignore_errors=True)
+            print(f"[labs clean {SCENARIO_ES_WRITE_BLOCK_4XX}] kept_last={keep_last}")
+
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])

--- a/backend/scripts/cli_app/scenarios/projection_version.py
+++ b/backend/scripts/cli_app/scenarios/projection_version.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+from ..registry import register
+from ..types import DrillInputs, DrillResult
+from ._failure_drill_shared import (
+    LAB_ID_S3A_2A_3A,
+    default_labs_auto_run_dir,
+    ensure_dir,
+    load_env,
+    parse_last_json_line,
+    python_exe,
+    read_json_file,
+    resolve_run_dir,
+    run_cmd,
+    scrape_metrics_text,
+    with_backend_pythonpath,
+)
+from ._failure_drill_shared import LEGACY_SCRIPTS_DIR, LABS_SNAPSHOT_ROOT, REPO_ROOT
+
+
+SCENARIO_PROJECTION_VERSION = "projection_version"
+
+
+@register("projection_version.run")
+def run_projection_version(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_id = str(payload.get("run_id") or "").strip()
+    outdir_str = str(payload.get("outdir") or "").strip()
+    outdir = Path(outdir_str) if outdir_str else default_labs_auto_run_dir(scenario=SCENARIO_PROJECTION_VERSION, run_id=run_id)
+
+    env_file = payload.get("env_file")
+    service = payload.get("service")
+
+    duration = int(payload.get("duration") or 0)
+    poll_interval = float(payload.get("poll_interval") or 0.0)
+    batch_size = int(payload.get("batch_size") or 0)
+    lease_seconds = int(payload.get("lease_seconds") or 0)
+    reclaim_interval = float(payload.get("reclaim_interval") or 0.0)
+    max_processing_seconds = int(payload.get("max_processing_seconds") or 0)
+
+    projection_version_1 = int(payload.get("projection_version_1") or 0)
+    projection_version_2 = int(payload.get("projection_version_2") or 0)
+
+    metrics_port = int(payload.get("metrics_port") or 0)
+    scrape_delay = float(payload.get("scrape_delay") or 0.0)
+
+    logs_dir = outdir / "_logs"
+    metrics_dir = outdir / "_metrics"
+    ensure_dir(logs_dir)
+    ensure_dir(metrics_dir)
+
+    env = with_backend_pythonpath(load_env(env_file=str(env_file) if env_file else None))
+
+    env["OUTBOX_RUN_SECONDS"] = str(int(duration))
+    env["OUTBOX_POLL_INTERVAL_SECONDS"] = str(float(poll_interval))
+    env["OUTBOX_BATCH_SIZE"] = str(int(batch_size))
+    env["OUTBOX_LEASE_SECONDS"] = str(int(lease_seconds))
+    env["OUTBOX_RECLAIM_INTERVAL_SECONDS"] = str(float(reclaim_interval))
+    env["OUTBOX_MAX_PROCESSING_SECONDS"] = str(int(max_processing_seconds))
+    env["LOG_LEVEL"] = "INFO"
+
+    env.pop("OUTBOX_EXPERIMENT_PROCESS_SLEEP_SECONDS", None)
+
+    recipe = {
+        "lab_id": LAB_ID_S3A_2A_3A,
+        "scenario": SCENARIO_PROJECTION_VERSION,
+        "run_id": run_id,
+        "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "env_file": env_file,
+        "service": service,
+        "phase": {
+            "v1": int(projection_version_1),
+            "v2": int(projection_version_2),
+        },
+        "worker": {
+            "duration_s": int(duration),
+            "preferred_metrics_port": int(metrics_port),
+            "poll_interval_seconds": float(poll_interval),
+            "batch_size": int(batch_size),
+            "lease_seconds": int(lease_seconds),
+            "reclaim_interval_seconds": float(reclaim_interval),
+            "max_processing_seconds": int(max_processing_seconds),
+        },
+    }
+    (outdir / "_recipe.json").write_text(json.dumps(recipe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    worker = LEGACY_SCRIPTS_DIR / "chronicle_outbox_worker.py"
+    cmd = [python_exe(), "-u", str(worker)]
+
+    inserter = REPO_ROOT / "backend" / "scripts" / "labs" / "labs_009_insert_chronicle_outbox_pending.py"
+    if not inserter.exists():
+        inserter = LEGACY_SCRIPTS_DIR / "labs_009_insert_chronicle_outbox_pending.py"
+
+    prober = REPO_ROOT / "backend" / "scripts" / "labs" / "labs_009_probe_chronicle_entry.py"
+    if not prober.exists():
+        prober = LEGACY_SCRIPTS_DIR / "labs_009_probe_chronicle_entry.py"
+
+    def _spawn_worker_with_retry(
+        *,
+        preferred_metrics_port: int,
+        log_path: Path,
+        extra_env: dict[str, str] | None = None,
+        max_attempts: int = 4,
+    ) -> tuple[subprocess.Popen, dict[str, str], int, int]:
+        candidate_ports: list[int] = []
+        for i in range(max_attempts):
+            p = int(preferred_metrics_port) + (i * 10_000)
+            if 1024 <= p <= 65_000:
+                candidate_ports.append(p)
+        if not candidate_ports:
+            candidate_ports = [19110, 29110, 39110, 49110]
+
+        last_proc: subprocess.Popen | None = None
+        last_env: dict[str, str] | None = None
+        last_metrics_port = int(preferred_metrics_port)
+        last_http_port = int(preferred_metrics_port) + 2
+
+        for attempt, metrics_port_candidate in enumerate(candidate_ports, start=1):
+            http_port = int(metrics_port_candidate) + 2
+            run_env = env.copy()
+            run_env["OUTBOX_METRICS_PORT"] = str(int(metrics_port_candidate))
+            run_env["OUTBOX_HTTP_PORT"] = str(int(http_port))
+            if extra_env:
+                run_env.update({str(k): str(v) for k, v in extra_env.items()})
+
+            header = (
+                f"\n\n# controller: spawn attempt {attempt}/{len(candidate_ports)} "
+                f"metrics_port={metrics_port_candidate} http_port={http_port}\n"
+            )
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(log_path, "a", encoding="utf-8") as log_file:
+                log_file.write(header)
+                log_file.flush()
+                proc = subprocess.Popen(cmd, cwd=str(REPO_ROOT), env=run_env, stdout=log_file, stderr=subprocess.STDOUT)
+                time.sleep(0.75)
+                if proc.poll() is None:
+                    return proc, run_env, int(metrics_port_candidate), int(http_port)
+
+            try:
+                tail = log_path.read_text(encoding="utf-8", errors="replace")[-4000:]
+            except Exception:
+                tail = ""
+            if "WinError 10013" in tail or "PermissionError" in tail:
+                last_proc = proc
+                last_env = run_env
+                last_metrics_port = int(metrics_port_candidate)
+                last_http_port = int(http_port)
+                continue
+
+            return proc, run_env, int(metrics_port_candidate), int(http_port)
+
+        assert last_proc is not None
+        assert last_env is not None
+        return last_proc, last_env, int(last_metrics_port), int(last_http_port)
+
+    def _run_probe(*, chronicle_event_id: str, out_path: Path) -> None:
+        probe_env = env.copy()
+        probe_env["OUTBOX_CHRONICLE_EVENT_ID"] = chronicle_event_id
+        proc = subprocess.run(
+            [python_exe(), str(prober)],
+            cwd=str(REPO_ROOT),
+            env=probe_env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        out_path.write_text((proc.stdout or "").strip() + "\n", encoding="utf-8")
+        if proc.returncode != 0:
+            (out_path.parent / (out_path.name + ".stderr.txt")).write_text(proc.stderr or "", encoding="utf-8")
+
+    print(f"[labs run {SCENARIO_PROJECTION_VERSION}] outdir: {outdir}")
+
+    insert_env = env.copy()
+    insert_proc_1 = subprocess.run(
+        [python_exe(), str(inserter)],
+        cwd=str(REPO_ROOT),
+        env=insert_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    (outdir / "_trigger_insert_v1.stdout.txt").write_text(insert_proc_1.stdout or "", encoding="utf-8")
+    (outdir / "_trigger_insert_v1.stderr.txt").write_text(insert_proc_1.stderr or "", encoding="utf-8")
+    if insert_proc_1.returncode != 0:
+        print(f"[labs run {SCENARIO_PROJECTION_VERSION}] failed to insert v1 outbox: rc={insert_proc_1.returncode}")
+        return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+
+    insert_obj_1 = parse_last_json_line(insert_proc_1.stdout or "") or {}
+    chronicle_event_id = str(insert_obj_1.get("chronicle_event_id") or "").strip()
+    outbox_event_id_1 = str(insert_obj_1.get("outbox_event_id") or "").strip()
+    if not chronicle_event_id or not outbox_event_id_1:
+        print(f"[labs run {SCENARIO_PROJECTION_VERSION}] unexpected inserter output; see _trigger_insert_v1.stdout.txt")
+        return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+
+    (outdir / "_chronicle_event_id.txt").write_text(chronicle_event_id + "\n", encoding="utf-8")
+    (outdir / "_outbox_event_id_v1.txt").write_text(outbox_event_id_1 + "\n", encoding="utf-8")
+
+    log_v1 = logs_dir / f"worker-v1-{run_id}.log"
+    log_v1.write_text("", encoding="utf-8")
+    before_v1 = metrics_dir / "metrics-before-v1.txt"
+    after_v1 = metrics_dir / "metrics-after-v1.txt"
+
+    proc1, _env1, actual_metrics_port_1, _http1 = _spawn_worker_with_retry(
+        preferred_metrics_port=int(metrics_port),
+        log_path=log_v1,
+        extra_env={"CHRONICLE_PROJECTION_VERSION": str(int(projection_version_1))},
+    )
+    try:
+        time.sleep(max(0.5, float(scrape_delay)))
+        try:
+            before_v1.write_text(scrape_metrics_text(port=int(actual_metrics_port_1), timeout_s=2.0), encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            before_v1.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+        proc1.wait(timeout=max(10, int(duration) + 20))
+    except Exception:
+        try:
+            proc1.terminate()
+        except Exception:
+            pass
+        try:
+            proc1.wait(timeout=30)
+        except Exception:
+            pass
+    finally:
+        try:
+            after_v1.write_text(scrape_metrics_text(port=int(actual_metrics_port_1), timeout_s=2.0), encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            after_v1.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+    _run_probe(chronicle_event_id=chronicle_event_id, out_path=(outdir / "_probe_entry_v1.json"))
+
+    insert_env_2 = env.copy()
+    insert_env_2["OUTBOX_CHRONICLE_EVENT_ID"] = chronicle_event_id
+    insert_proc_2 = subprocess.run(
+        [python_exe(), str(inserter)],
+        cwd=str(REPO_ROOT),
+        env=insert_env_2,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    (outdir / "_trigger_insert_v2.stdout.txt").write_text(insert_proc_2.stdout or "", encoding="utf-8")
+    (outdir / "_trigger_insert_v2.stderr.txt").write_text(insert_proc_2.stderr or "", encoding="utf-8")
+    if insert_proc_2.returncode != 0:
+        print(f"[labs run {SCENARIO_PROJECTION_VERSION}] failed to insert v2 outbox: rc={insert_proc_2.returncode}")
+        return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+
+    insert_obj_2 = parse_last_json_line(insert_proc_2.stdout or "") or {}
+    outbox_event_id_2 = str(insert_obj_2.get("outbox_event_id") or "").strip()
+    if not outbox_event_id_2:
+        print(f"[labs run {SCENARIO_PROJECTION_VERSION}] unexpected v2 inserter output; see _trigger_insert_v2.stdout.txt")
+        return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+    (outdir / "_outbox_event_id_v2.txt").write_text(outbox_event_id_2 + "\n", encoding="utf-8")
+
+    log_v2 = logs_dir / f"worker-v2-{run_id}.log"
+    log_v2.write_text("", encoding="utf-8")
+    before_v2 = metrics_dir / "metrics-before-v2.txt"
+    after_v2 = metrics_dir / "metrics-after-v2.txt"
+
+    proc2, _env2, actual_metrics_port_2, _http2 = _spawn_worker_with_retry(
+        preferred_metrics_port=int(metrics_port) + 1,
+        log_path=log_v2,
+        extra_env={"CHRONICLE_PROJECTION_VERSION": str(int(projection_version_2))},
+    )
+    try:
+        time.sleep(max(0.5, float(scrape_delay)))
+        try:
+            before_v2.write_text(scrape_metrics_text(port=int(actual_metrics_port_2), timeout_s=2.0), encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            before_v2.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+        proc2.wait(timeout=max(10, int(duration) + 20))
+    except Exception:
+        try:
+            proc2.terminate()
+        except Exception:
+            pass
+        try:
+            proc2.wait(timeout=30)
+        except Exception:
+            pass
+    finally:
+        try:
+            after_v2.write_text(scrape_metrics_text(port=int(actual_metrics_port_2), timeout_s=2.0), encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            after_v2.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+    _run_probe(chronicle_event_id=chronicle_event_id, out_path=(outdir / "_probe_entry_v2.json"))
+
+    result = {
+        "scenario": SCENARIO_PROJECTION_VERSION,
+        "run_id": run_id,
+        "chronicle_event_id": chronicle_event_id,
+        "outbox_event_ids": {"v1": outbox_event_id_1, "v2": outbox_event_id_2},
+        "worker_logs": {
+            "v1": str(log_v1.relative_to(REPO_ROOT)),
+            "v2": str(log_v2.relative_to(REPO_ROOT)),
+        },
+        "probe": {
+            "v1": read_json_file(outdir / "_probe_entry_v1.json"),
+            "v2": read_json_file(outdir / "_probe_entry_v2.json"),
+        },
+    }
+    (outdir / "_run.json").write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    print(f"[labs run {SCENARIO_PROJECTION_VERSION}] chronicle_event_id: {chronicle_event_id}")
+    print(f"[labs run {SCENARIO_PROJECTION_VERSION}] done (now run verify/export/clean)")
+    print(f"[labs run {SCENARIO_PROJECTION_VERSION}] outputs: {outdir}")
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+
+@register("projection_version.verify")
+def verify_projection_version(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_PROJECTION_VERSION,
+    )
+    if not run_dir.exists():
+        print(f"[labs verify {SCENARIO_PROJECTION_VERSION}] run_dir not found: {run_dir}")
+        return DrillResult(ok=False, meta={"exit_code": 2}, summary={}, errors=[])
+
+    probe1 = read_json_file(run_dir / "_probe_entry_v1.json") or {}
+    probe2 = read_json_file(run_dir / "_probe_entry_v2.json") or {}
+
+    want1 = int(payload.get("projection_version_1") or 0)
+    want2 = int(payload.get("projection_version_2") or 0)
+    got1 = probe1.get("projection_version")
+    got2 = probe2.get("projection_version")
+
+    ok = True
+    errors: list[str] = []
+    if got1 != want1:
+        ok = False
+        errors.append(f"probe v1 projection_version mismatch: got={got1!r} want={want1}")
+    if got2 != want2:
+        ok = False
+        errors.append(f"probe v2 projection_version mismatch: got={got2!r} want={want2}")
+
+    checks = [
+        {
+            "name": "probe v1 projection_version match",
+            "expected": want1,
+            "observed": got1,
+            "ok": bool(got1 == want1),
+        },
+        {
+            "name": "probe v2 projection_version match",
+            "expected": want2,
+            "observed": got2,
+            "ok": bool(got2 == want2),
+        },
+    ]
+
+    why = "ok" if ok else (errors[0] if errors else "verify failed")
+
+    result = {
+        "scenario": SCENARIO_PROJECTION_VERSION,
+        "run_id": run_dir.name,
+        "ok": bool(ok),
+        "why": why,
+        "checks": checks,
+        "expected": {"v1": want1, "v2": want2},
+        "observed": {"v1": got1, "v2": got2},
+        "errors": errors,
+    }
+
+    (run_dir / "_result.json").write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    (run_dir / "_verify_result.json").write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if ok:
+        print(f"[labs verify {SCENARIO_PROJECTION_VERSION}] OK")
+        return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+    print(f"[labs verify {SCENARIO_PROJECTION_VERSION}] FAILED")
+    for e in errors:
+        print("  -", e)
+    return DrillResult(ok=False, meta={"exit_code": 2}, summary={}, errors=[])
+
+
+@register("projection_version.export")
+def export_projection_version(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_PROJECTION_VERSION,
+    )
+    if not run_dir.exists():
+        print(f"[labs export {SCENARIO_PROJECTION_VERSION}] run_dir not found: {run_dir}")
+        return DrillResult(ok=False, meta={"exit_code": 2}, summary={}, errors=[])
+
+    event_id_path = run_dir / "_chronicle_event_id.txt"
+    if not event_id_path.exists():
+        print(f"[labs export {SCENARIO_PROJECTION_VERSION}] missing: {event_id_path}")
+        return DrillResult(ok=False, meta={"exit_code": 2}, summary={}, errors=[])
+    chronicle_event_id = (event_id_path.read_text(encoding="utf-8", errors="replace") or "").strip()
+    if not chronicle_event_id:
+        print(f"[labs export {SCENARIO_PROJECTION_VERSION}] empty chronicle_event_id")
+        return DrillResult(ok=False, meta={"exit_code": 2}, summary={}, errors=[])
+
+    exports_dir = run_dir / "_exports"
+    ensure_dir(exports_dir)
+
+    script = LEGACY_SCRIPTS_DIR / "labs_009_export_jaeger.py"
+    cmd = [
+        python_exe(),
+        str(script),
+        "--outdir",
+        str(exports_dir),
+        "--service",
+        str(payload.get("service")),
+        "--lookback",
+        str(payload.get("lookback")),
+        "--limit",
+        str(int(payload.get("limit") or 0)),
+        "--operation",
+        "outbox.process",
+        "--tags-json",
+        json.dumps({"wordloom.entity.id": chronicle_event_id}, ensure_ascii=False),
+    ]
+    rc = run_cmd(cmd, cwd=REPO_ROOT)
+    return DrillResult(ok=(rc == 0), meta={"exit_code": int(rc)}, summary={}, errors=[])
+
+
+@register("projection_version.clean")
+def clean_projection_version(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    keep_last = payload.get("keep_last")
+
+    if keep_last is not None:
+        base = LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / SCENARIO_PROJECTION_VERSION
+        if base.exists():
+            import shutil
+
+            runs = sorted([p for p in base.iterdir() if p.is_dir()], key=lambda p: p.name, reverse=True)
+            for p in runs[int(keep_last) :]:
+                shutil.rmtree(p, ignore_errors=True)
+            print(f"[labs clean {SCENARIO_PROJECTION_VERSION}] kept_last={keep_last}")
+    else:
+        print(f"[labs clean {SCENARIO_PROJECTION_VERSION}] noop")
+
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])

--- a/backend/scripts/cli_app/scenarios/stuck_reclaim.py
+++ b/backend/scripts/cli_app/scenarios/stuck_reclaim.py
@@ -1,0 +1,505 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from ..registry import register
+from ..types import DrillInputs, DrillResult
+from ._failure_drill_shared import (
+    LAB_ID_S3A_2A_3A,
+    SEARCH_OUTBOX_OBS_SCHEMA_VERSION,
+    default_labs_auto_run_dir,
+    ensure_dir,
+    extract_last_claim_batch_id,
+    load_env,
+    prom_parse_counter_sum,
+    python_exe,
+    resolve_run_dir,
+    run_cmd,
+    scrape_metrics_text,
+    with_backend_pythonpath,
+)
+from ._failure_drill_shared import LEGACY_SCRIPTS_DIR, LABS_SNAPSHOT_ROOT, REPO_ROOT
+
+
+SCENARIO_STUCK_RECLAIM = "stuck_reclaim"
+
+
+@register("stuck_reclaim.run")
+def run_stuck_reclaim(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_id = str(payload.get("run_id") or "").strip()
+    outdir_str = str(payload.get("outdir") or "").strip()
+    outdir = Path(outdir_str) if outdir_str else default_labs_auto_run_dir(scenario=SCENARIO_STUCK_RECLAIM, run_id=run_id)
+
+    env_file = payload.get("env_file")
+    service = payload.get("service")
+
+    duration = int(payload.get("duration") or 0)
+    scrape_delay = float(payload.get("scrape_delay") or 0.0)
+
+    metrics_port_1 = int(payload.get("metrics_port_1") or 0)
+    metrics_port_2 = int(payload.get("metrics_port_2") or 0)
+
+    lease_seconds = int(payload.get("lease_seconds") or 0)
+    reclaim_interval = float(payload.get("reclaim_interval") or 0.0)
+    max_processing_seconds = int(payload.get("max_processing_seconds") or 0)
+    poll_interval = float(payload.get("poll_interval") or 0.0)
+    batch_size = int(payload.get("batch_size") or 0)
+
+    op = payload.get("op")
+    trigger_count = int(payload.get("trigger_count") or 0)
+
+    worker_id_1 = payload.get("worker_id_1")
+    worker_id_2 = payload.get("worker_id_2")
+
+    claim_timeout = float(payload.get("claim_timeout") or 0.0)
+
+    logs_dir = outdir / "_logs"
+    metrics_dir = outdir / "_metrics"
+    exports_dir = outdir / "_exports"
+    ensure_dir(logs_dir)
+    ensure_dir(metrics_dir)
+    ensure_dir(exports_dir)
+
+    base_env = with_backend_pythonpath(load_env(env_file=str(env_file) if env_file else None))
+
+    service_name = service
+    base_env.setdefault("WORDLOOM_TRACING_ENABLED", "1")
+    base_env.setdefault("OTEL_SERVICE_NAME", service_name)
+    base_env.setdefault("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    base_env.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    base_env.setdefault("OTEL_TRACES_SAMPLER", "always_on")
+
+    base_env.setdefault("ELASTIC_URL", "http://localhost:19200")
+    base_env.setdefault("ELASTIC_INDEX", "wordloom-test-search-index")
+
+    base_env["LOG_LEVEL"] = "INFO"
+
+    base_env["OUTBOX_EXPERIMENT_ES_429_RATIO"] = "0"
+    base_env.pop("OUTBOX_EXPERIMENT_ES_429_EVERY_N", None)
+    base_env.pop("OUTBOX_EXPERIMENT_ES_BULK_PARTIAL", None)
+    base_env.pop("OUTBOX_EXPERIMENT_BREAK_CLAIM", None)
+    base_env.pop("OUTBOX_EXPERIMENT_BREAK_CLAIM_SLEEP_SECONDS", None)
+
+    base_env["OUTBOX_USE_ES_BULK"] = "0"
+
+    base_env["OUTBOX_LEASE_SECONDS"] = str(int(lease_seconds))
+    base_env["OUTBOX_RECLAIM_INTERVAL_SECONDS"] = str(float(reclaim_interval))
+    base_env["OUTBOX_MAX_PROCESSING_SECONDS"] = str(int(max_processing_seconds))
+    base_env["OUTBOX_POLL_INTERVAL_SECONDS"] = str(float(poll_interval))
+    base_env["OUTBOX_BULK_SIZE"] = str(int(batch_size))
+    base_env["OUTBOX_CONCURRENCY"] = "1"
+
+    recipe = {
+        "lab_id": LAB_ID_S3A_2A_3A,
+        "scenario": SCENARIO_STUCK_RECLAIM,
+        "run_id": run_id,
+        "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "env_file": env_file,
+        "service": service_name,
+        "worker": {
+            "duration_s": int(duration),
+            "metrics_ports": [int(metrics_port_1), int(metrics_port_2)],
+            "lease_seconds": int(lease_seconds),
+            "reclaim_interval_seconds": float(reclaim_interval),
+            "max_processing_seconds": int(max_processing_seconds),
+            "poll_interval_seconds": float(poll_interval),
+            "batch_size": int(batch_size),
+        },
+        "trigger": {"op": str(op), "count": int(trigger_count)},
+        "crash": {"kind": "process_kill", "target": "worker1", "claim_timeout_s": float(claim_timeout)},
+    }
+    (outdir / "_recipe.json").write_text(json.dumps(recipe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    worker = LEGACY_SCRIPTS_DIR / "search_outbox_worker.py"
+    cmd = [python_exe(), "-u", str(worker)]
+
+    inserter = REPO_ROOT / "backend" / "scripts" / "labs" / "labs_009_insert_search_outbox_pending.py"
+    if not inserter.exists():
+        inserter = LEGACY_SCRIPTS_DIR / "labs_009_insert_search_outbox_pending.py"
+
+    outbox_event_ids: list[str] = []
+    for i in range(int(trigger_count)):
+        trigger_env = base_env.copy()
+        trigger_env["OUTBOX_OP"] = str(op)
+        trigger_env.setdefault("OUTBOX_CREATE_SEARCH_INDEX_ROW", "1")
+        trigger_env.setdefault("OUTBOX_EVENT_VERSION", "0")
+
+        proc = subprocess.run(
+            [python_exe(), str(inserter)],
+            cwd=str(REPO_ROOT),
+            env=trigger_env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        (outdir / f"_trigger_insert_outbox_{i+1}.stdout.txt").write_text(proc.stdout or "", encoding="utf-8")
+        (outdir / f"_trigger_insert_outbox_{i+1}.stderr.txt").write_text(proc.stderr or "", encoding="utf-8")
+        if proc.returncode != 0:
+            print(f"[labs run {SCENARIO_STUCK_RECLAIM}] failed to insert outbox event #{i+1}: rc={proc.returncode}")
+            return DrillResult(ok=False, meta={"exit_code": 3}, summary={}, errors=[])
+        outbox_event_id = (proc.stdout or "").strip().splitlines()[-1].strip()
+        outbox_event_ids.append(outbox_event_id)
+
+    (outdir / "_outbox_event_ids.txt").write_text("\n".join(outbox_event_ids) + "\n", encoding="utf-8")
+    print(f"[labs run {SCENARIO_STUCK_RECLAIM}] outbox_event_ids: {', '.join(outbox_event_ids)}")
+
+    def _spawn_worker_with_retry(
+        *,
+        worker_id: str,
+        preferred_metrics_port: int,
+        log_path: Path,
+        max_attempts: int = 4,
+        extra_env: dict[str, str] | None = None,
+    ) -> tuple[subprocess.Popen, dict[str, str], int, int]:
+        candidate_ports: list[int] = []
+        for i in range(max_attempts):
+            p = int(preferred_metrics_port) + (i * 10_000)
+            if 1024 <= p <= 65_000:
+                candidate_ports.append(p)
+        if not candidate_ports:
+            candidate_ports = [19128, 29128, 39128, 49128]
+
+        last_proc: subprocess.Popen | None = None
+        last_env: dict[str, str] | None = None
+        last_metrics_port = int(preferred_metrics_port)
+        last_http_port = int(preferred_metrics_port) + 20
+
+        for attempt, metrics_port in enumerate(candidate_ports, start=1):
+            http_port = int(metrics_port) + 20
+            env = base_env.copy()
+            env["OUTBOX_WORKER_ID"] = str(worker_id)
+            env["OUTBOX_METRICS_PORT"] = str(int(metrics_port))
+            env["OUTBOX_HTTP_PORT"] = str(int(http_port))
+            if extra_env:
+                env.update({str(k): str(v) for k, v in extra_env.items()})
+
+            header = (
+                f"\n\n# controller: spawn attempt {attempt}/{len(candidate_ports)} "
+                f"metrics_port={metrics_port} http_port={http_port}\n"
+            )
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(log_path, "a", encoding="utf-8") as log_file:
+                log_file.write(header)
+                log_file.flush()
+                proc = subprocess.Popen(cmd, cwd=str(REPO_ROOT), env=env, stdout=log_file, stderr=subprocess.STDOUT)
+
+                time.sleep(0.75)
+
+                if proc.poll() is None:
+                    return proc, env, int(metrics_port), int(http_port)
+
+            try:
+                tail = log_path.read_text(encoding="utf-8", errors="replace")[-4000:]
+            except Exception:
+                tail = ""
+            if "WinError 10013" in tail or "PermissionError" in tail:
+                last_proc = proc
+                last_env = env
+                last_metrics_port = int(metrics_port)
+                last_http_port = int(http_port)
+                continue
+            return proc, env, int(metrics_port), int(http_port)
+
+        assert last_proc is not None
+        assert last_env is not None
+        return last_proc, last_env, int(last_metrics_port), int(last_http_port)
+
+    log_path_1 = logs_dir / f"worker1-{run_id}.log"
+    log_path_2 = logs_dir / f"worker2-{run_id}.log"
+
+    before_1_path = metrics_dir / "metrics-before-1.txt"
+    before_2_path = metrics_dir / "metrics-before-2.txt"
+    after_1_path = metrics_dir / "metrics-after-1.txt"
+    after_2_path = metrics_dir / "metrics-after-2.txt"
+
+    print(f"[labs run {SCENARIO_STUCK_RECLAIM}] outdir: {outdir}")
+    print(f"[labs run {SCENARIO_STUCK_RECLAIM}] worker1 log: {log_path_1} (metrics :{metrics_port_1})")
+    print(f"[labs run {SCENARIO_STUCK_RECLAIM}] worker2 log: {log_path_2} (metrics :{metrics_port_2})")
+
+    killed_worker1 = False
+    observed_claim = False
+    worker2_exited_early = False
+    worker2_terminated_by_controller = False
+
+    rx_claimed = re.compile(r'"event"\s*:\s*"outbox\\.claim_batch".*?"claimed"\s*:\s*([1-9][0-9]*)')
+
+    log_path_1.write_text("", encoding="utf-8")
+    log_path_2.write_text("", encoding="utf-8")
+
+    worker1_sleep_after_claim_s = max(3.0, float(int(lease_seconds)) + 1.0)
+
+    proc1, env1, actual_metrics_port_1, actual_http_port_1 = _spawn_worker_with_retry(
+        worker_id=str(worker_id_1),
+        preferred_metrics_port=int(metrics_port_1),
+        log_path=log_path_1,
+        extra_env={"OUTBOX_EXPERIMENT_PROCESS_SLEEP_SECONDS": str(worker1_sleep_after_claim_s)},
+    )
+    try:
+        time.sleep(max(0.5, float(scrape_delay)))
+        try:
+            before_1_path.write_text(scrape_metrics_text(port=int(actual_metrics_port_1), timeout_s=2.0), encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            before_1_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+        claim_deadline = time.time() + float(claim_timeout)
+        while time.time() < claim_deadline:
+            if proc1.poll() is not None:
+                break
+            try:
+                text = log_path_1.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                text = ""
+            if rx_claimed.search(text):
+                observed_claim = True
+                break
+            time.sleep(0.1)
+
+        if proc1.poll() is None:
+            killed_worker1 = True
+            proc1.kill()
+    except KeyboardInterrupt:
+        killed_worker1 = True
+        try:
+            proc1.kill()
+        except Exception:
+            pass
+    finally:
+        try:
+            proc1.wait(timeout=30)
+        except Exception:
+            pass
+
+    after_1_path.write_text(
+        f"note: worker1 was {'killed' if killed_worker1 else 'not_killed'} by controller\n"
+        f"note: observed_claim={observed_claim}\n",
+        encoding="utf-8",
+    )
+
+    proc2, env2, actual_metrics_port_2, actual_http_port_2 = _spawn_worker_with_retry(
+        worker_id=str(worker_id_2),
+        preferred_metrics_port=int(metrics_port_2),
+        log_path=log_path_2,
+        extra_env={"OUTBOX_EXPERIMENT_PROCESS_SLEEP_SECONDS": "0"},
+    )
+    try:
+        time.sleep(max(0.5, float(scrape_delay)))
+        try:
+            before_2_path.write_text(scrape_metrics_text(port=int(actual_metrics_port_2), timeout_s=2.0), encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            before_2_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+        start2 = time.time()
+        while True:
+            if duration > 0 and (time.time() - start2) >= duration:
+                break
+            if proc2.poll() is not None:
+                worker2_exited_early = True
+                break
+            time.sleep(0.25)
+
+        try:
+            after_2_path.write_text(scrape_metrics_text(port=int(actual_metrics_port_2), timeout_s=2.0), encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            after_2_path.write_text(f"scrape_failed: {type(exc).__name__}: {exc}\n", encoding="utf-8")
+
+        if proc2.poll() is None:
+            worker2_terminated_by_controller = True
+            proc2.terminate()
+    except KeyboardInterrupt:
+        try:
+            proc2.terminate()
+        except Exception:
+            pass
+    finally:
+        try:
+            proc2.wait(timeout=30)
+        except Exception:
+            pass
+
+    exit_info = {
+        "worker1": {
+            "returncode": int(proc1.returncode) if proc1.returncode is not None else None,
+            "killed_by_controller": bool(killed_worker1),
+            "observed_claim": bool(observed_claim),
+        },
+        "worker2": {
+            "returncode": int(proc2.returncode) if proc2.returncode is not None else None,
+            "exited_early": bool(worker2_exited_early),
+            "terminated_by_controller": bool(worker2_terminated_by_controller),
+        },
+    }
+    (outdir / "_worker_exit.json").write_text(json.dumps(exit_info, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    ports_info = {
+        "worker1": {"metrics_port": int(actual_metrics_port_1), "http_port": int(actual_http_port_1)},
+        "worker2": {"metrics_port": int(actual_metrics_port_2), "http_port": int(actual_http_port_2)},
+    }
+    (outdir / "_ports.json").write_text(json.dumps(ports_info, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    combined = (
+        "# metrics-before-1\n\n"
+        + (before_1_path.read_text(encoding="utf-8", errors="replace") if before_1_path.exists() else "")
+        + "\n\n# metrics-before-2\n\n"
+        + (before_2_path.read_text(encoding="utf-8", errors="replace") if before_2_path.exists() else "")
+        + "\n\n# metrics-after-2\n\n"
+        + (after_2_path.read_text(encoding="utf-8", errors="replace") if after_2_path.exists() else "")
+    )
+    (outdir / "_metrics.txt").write_text(combined, encoding="utf-8")
+
+    claim_batch_ids: list[str] = []
+    for lp in (log_path_1, log_path_2):
+        cid = extract_last_claim_batch_id(lp)
+        if cid:
+            claim_batch_ids.append(cid)
+    if claim_batch_ids:
+        (outdir / "_claim_batch_ids.txt").write_text("\n".join(claim_batch_ids) + "\n", encoding="utf-8")
+
+    if worker2_exited_early and (proc2.returncode not in (None, 0)):
+        print(f"[labs run {SCENARIO_STUCK_RECLAIM}] worker2 exited early: rc={proc2.returncode}")
+        print(f"[labs run {SCENARIO_STUCK_RECLAIM}] see logs: {log_path_2}")
+        return DrillResult(ok=False, meta={"exit_code": 4}, summary={}, errors=[])
+
+    print(f"[labs run {SCENARIO_STUCK_RECLAIM}] done (now run verify/export/clean)")
+    print(f"[labs run {SCENARIO_STUCK_RECLAIM}] outputs: {outdir}")
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+
+@register("stuck_reclaim.verify")
+def verify_stuck_reclaim(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_STUCK_RECLAIM,
+    )
+    metrics_dir = run_dir / "_metrics"
+    logs_dir = run_dir / "_logs"
+
+    before2 = (metrics_dir / "metrics-before-2.txt").read_text(encoding="utf-8") if (metrics_dir / "metrics-before-2.txt").exists() else ""
+    after2 = (metrics_dir / "metrics-after-2.txt").read_text(encoding="utf-8") if (metrics_dir / "metrics-after-2.txt").exists() else ""
+
+    metric_processed = "outbox_processed_total"
+    metric_failed = "outbox_failed_total"
+
+    metrics_available = (not before2.strip().startswith("scrape_failed")) and (not after2.strip().startswith("scrape_failed"))
+
+    processed_before = prom_parse_counter_sum(before2, metric_processed) if metrics_available else 0.0
+    processed_after = prom_parse_counter_sum(after2, metric_processed) if metrics_available else 0.0
+    failed_before = prom_parse_counter_sum(before2, metric_failed) if metrics_available else 0.0
+    failed_after = prom_parse_counter_sum(after2, metric_failed) if metrics_available else 0.0
+
+    delta_processed = processed_after - processed_before
+    delta_failed = failed_after - failed_before
+
+    reclaimed_count = 0
+    reclaim_log_found = False
+    worker2_log_path: Path | None = (logs_dir / f"worker2-{payload.get('run_id')}.log") if payload.get("run_id") else None
+    if not (worker2_log_path and worker2_log_path.exists()):
+        worker2_logs = sorted([p for p in logs_dir.glob("worker2-*.log") if p.is_file()], key=lambda p: p.name, reverse=True)
+        worker2_log_path = worker2_logs[0] if worker2_logs else None
+
+    worker2_text = ""
+    if worker2_log_path and worker2_log_path.exists():
+        worker2_text = worker2_log_path.read_text(encoding="utf-8", errors="replace")
+
+    m = re.search(r"Reclaimed\s+(\d+)\s+stuck\s+outbox\s+events", worker2_text)
+    if m:
+        reclaim_log_found = True
+        reclaimed_count = int(m.group(1))
+
+    processed_log_count = len(re.findall(r"Outbox\s+(upsert|delete):", worker2_text))
+
+    min_processed_delta = float(payload.get("min_processed_delta") or 0)
+    max_failed_delta = float(payload.get("max_failed_delta") or 0)
+    min_reclaimed = int(payload.get("min_reclaimed") or 0)
+
+    processed_ok = (metrics_available and (delta_processed >= min_processed_delta)) or (processed_log_count >= 1)
+    ok = processed_ok and ((delta_failed <= max_failed_delta) if metrics_available else True) and (reclaim_log_found and reclaimed_count >= min_reclaimed)
+
+    result = {
+        "scenario": SCENARIO_STUCK_RECLAIM,
+        "run_dir": str(run_dir),
+        "checks": {
+            "processed_delta_ge": float(min_processed_delta),
+            "failed_delta_le": float(max_failed_delta),
+            "reclaimed_ge": int(min_reclaimed),
+        },
+        "observed": {
+            "metrics_available": bool(metrics_available),
+            metric_processed: {"before": processed_before, "after": processed_after, "delta": delta_processed},
+            metric_failed: {"before": failed_before, "after": failed_after, "delta": delta_failed},
+            "reclaimed": {"count": int(reclaimed_count), "log_found": bool(reclaim_log_found)},
+            "processed_log_count": int(processed_log_count),
+            "worker2_log": str(worker2_log_path) if worker2_log_path else None,
+        },
+        "ok": bool(ok),
+    }
+    (run_dir / "_result.json").write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if ok:
+        print(f"[labs verify {SCENARIO_STUCK_RECLAIM}] OK")
+        return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])
+
+    print(f"[labs verify {SCENARIO_STUCK_RECLAIM}] FAILED")
+    return DrillResult(ok=False, meta={"exit_code": 10}, summary={}, errors=[])
+
+
+@register("stuck_reclaim.export")
+def export_stuck_reclaim(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    run_dir = resolve_run_dir(
+        run_id=str(payload.get("run_id") or "").strip() or None,
+        outdir=str(payload.get("outdir") or "").strip() or None,
+        scenario=SCENARIO_STUCK_RECLAIM,
+    )
+    exports_dir = run_dir / "_exports"
+    ensure_dir(exports_dir)
+
+    exporter = LEGACY_SCRIPTS_DIR / "labs_009_export_jaeger.py"
+    cmd = [
+        python_exe(),
+        str(exporter),
+        "--outdir",
+        str(exports_dir),
+        "--service",
+        str(payload.get("service")),
+        "--lookback",
+        str(payload.get("lookback")),
+        "--limit",
+        str(int(payload.get("limit") or 0)),
+        "--operation",
+        "outbox.claim_batch",
+        "--tags-json",
+        json.dumps({"wordloom.obs_schema": SEARCH_OUTBOX_OBS_SCHEMA_VERSION}),
+    ]
+    rc = int(run_cmd(cmd, cwd=REPO_ROOT, env=load_env(env_file=None)))
+    return DrillResult(ok=(rc == 0), meta={"exit_code": int(rc)}, summary={}, errors=[])
+
+
+@register("stuck_reclaim.clean")
+def clean_stuck_reclaim(inputs: DrillInputs) -> DrillResult:
+    payload = inputs.model_dump()
+
+    keep_last = payload.get("keep_last")
+
+    if keep_last is not None:
+        base = LABS_SNAPSHOT_ROOT / "auto" / LAB_ID_S3A_2A_3A / SCENARIO_STUCK_RECLAIM
+        if base.exists():
+            runs = sorted([p for p in base.iterdir() if p.is_dir()], key=lambda p: p.name, reverse=True)
+            for p in runs[int(keep_last) :]:
+                shutil.rmtree(p, ignore_errors=True)
+        print(f"[labs clean {SCENARIO_STUCK_RECLAIM}] kept_last={keep_last}")
+    else:
+        print(f"[labs clean {SCENARIO_STUCK_RECLAIM}] noop")
+
+    return DrillResult(ok=True, meta={"exit_code": 0}, summary={}, errors=[])


### PR DESCRIPTION
- Implemented the projection_version scenario with run, verify, export, and clean functionalities.
- Added the stuck_reclaim scenario with run, verify, export, and clean functionalities.
- Both scenarios include detailed logging, metrics scraping, and environment setup for testing outbox processing.
- Introduced error handling and result reporting for each scenario to ensure robustness.
- For more details, see: #83 & #84 