### PR TITLE
S0C-4A-1A: Refactor workflow inputs: rename 'scenario' to 'scenario_id' ...

### DIFF
--- a/.github/workflows/drill-dual-run.yml
+++ b/.github/workflows/drill-dual-run.yml
@@ -3,15 +3,11 @@ name: drill-dual-run
 on:
   workflow_dispatch:
     inputs:
-      scenario:
+      scenario_id:
         description: "Dual-run scenario id (canonical intent/pipeline/topic)"
         required: true
-        type: choice
+        type: string
         default: dual_run/search/stage1_backfill
-        options:
-          - dual_run/search/stage1_backfill
-          - dual_run/search/stage2_worker
-          - dual_run/search/window_sustained
       library_id:
         description: "Optional data scope: library_id (UUID)."
         required: false
@@ -57,7 +53,7 @@ jobs:
   drill:
     uses: ./.github/workflows/reusable-drill-write-gate-runner.yml
     with:
-      scenario: ${{ inputs.scenario }}
+      scenario: ${{ inputs.scenario_id }}
       library_id: ${{ inputs.library_id }}
       worker_library_allowlist: ${{ inputs.worker_library_allowlist }}
       window_duration_seconds: ${{ inputs.window_duration_seconds }}

--- a/.github/workflows/drill-dual-write.yml
+++ b/.github/workflows/drill-dual-write.yml
@@ -3,14 +3,11 @@ name: drill-dual-write
 on:
   workflow_dispatch:
     inputs:
-      scenario:
+      scenario_id:
         description: "Dual-write scenario id (canonical intent/pipeline/topic)"
         required: true
-        type: choice
+        type: string
         default: dual_write/search/canary_cleanup
-        options:
-          - dual_write/search/canary_cleanup
-          - dual_write/search/sampling_cleanup
       library_id:
         description: "Optional data scope: library_id (UUID)."
         required: false
@@ -21,5 +18,5 @@ jobs:
   drill:
     uses: ./.github/workflows/reusable-drill-write-gate-runner.yml
     with:
-      scenario: ${{ inputs.scenario }}
+      scenario: ${{ inputs.scenario_id }}
       library_id: ${{ inputs.library_id }}

--- a/.github/workflows/drill-failures.yml
+++ b/.github/workflows/drill-failures.yml
@@ -8,21 +8,11 @@ on:
         required: false
         type: boolean
         default: false
-      scenario:
+      scenario_id:
         description: "labs scenario"
         required: true
-        type: choice
-        options:
-          - fault/obs_infra/all
-          - fault/obs_infra/es_429_inject
-          - fault/obs_infra/es_write_block_4xx
-          - fault/obs_infra/es_down_connect
-          - fault/obs_infra/collector_down
-          - fault/obs_infra/es_bulk_partial
-          - fault/obs_infra/db_claim_contention
-          - fault/obs_infra/stuck_reclaim
-          - fault/obs_infra/duplicate_delivery
-          - fault/obs_infra/projection_version
+        type: string
+        default: fault/obs_infra/all
       env_file:
         description: "Env file path"
         required: true
@@ -53,9 +43,9 @@ jobs:
       matrix:
         scenario: >-
           ${{ fromJSON(
-            inputs.scenario == 'fault/obs_infra/all'
+            inputs.scenario_id == 'fault/obs_infra/all'
             && '["fault/obs_infra/es_429_inject","fault/obs_infra/es_write_block_4xx","fault/obs_infra/es_down_connect","fault/obs_infra/collector_down","fault/obs_infra/es_bulk_partial","fault/obs_infra/db_claim_contention","fault/obs_infra/stuck_reclaim","fault/obs_infra/duplicate_delivery","fault/obs_infra/projection_version"]'
-            || format('["{0}"]', inputs.scenario)
+            || format('["{0}"]', inputs.scenario_id)
           ) }}
 
     with:

--- a/.github/workflows/drill-readiness.yml
+++ b/.github/workflows/drill-readiness.yml
@@ -3,13 +3,11 @@ name: drill-readiness
 on:
   workflow_dispatch:
     inputs:
-      scenario:
+      scenario_id:
         description: "Readiness scenario id (canonical intent/pipeline/topic)"
         required: true
-        type: choice
+        type: string
         default: readiness/search/dual_run_gate
-        options:
-          - readiness/search/dual_run_gate
       library_id:
         description: "Optional data scope: library_id (UUID)."
         required: false
@@ -25,6 +23,6 @@ jobs:
   drill:
     uses: ./.github/workflows/reusable-drill-write-gate-runner.yml
     with:
-      scenario: ${{ inputs.scenario }}
+      scenario: ${{ inputs.scenario_id }}
       library_id: ${{ inputs.library_id }}
       worker_library_allowlist: ${{ inputs.worker_library_allowlist }}

--- a/.github/workflows/drill-shadow-verify-entries.yml
+++ b/.github/workflows/drill-shadow-verify-entries.yml
@@ -3,15 +3,11 @@ name: drill-shadow-verify-entries
 on:
   workflow_dispatch:
     inputs:
-      scenario:
+      scenario_id:
         description: "Scenario (canonical intent/pipeline/topic)"
         required: true
         default: verify/chronicle/entries
-        type: choice
-        options:
-          - verify/chronicle/entries
-          - verify/search/index_consistency
-          - verify/search/write_gate_idempotency
+        type: string
       book_id:
         description: "Optional scope: book_id (UUID)"
         required: false
@@ -27,6 +23,6 @@ jobs:
   drill:
     uses: ./.github/workflows/reusable-drill-shadow-verify-entries-runner.yml
     with:
-      scenario: ${{ inputs.scenario }}
+      scenario: ${{ inputs.scenario_id }}
       book_id: ${{ inputs.book_id }}
       library_id: ${{ inputs.library_id }}

--- a/.github/workflows/drill-verify.yml
+++ b/.github/workflows/drill-verify.yml
@@ -3,15 +3,11 @@ name: drill-verify
 on:
   workflow_dispatch:
     inputs:
-      scenario:
+      scenario_id:
         description: "Verify scenario id (canonical intent/pipeline/topic)"
         required: true
-        type: choice
+        type: string
         default: verify/search/write_gate_idempotency
-        options:
-          - verify/search/write_gate_idempotency
-          - verify/search/paging_stability
-          - verify/obs_infra/shared_keys_bundle
       library_id:
         description: "Optional data scope: library_id (UUID)."
         required: false
@@ -22,5 +18,5 @@ jobs:
   drill:
     uses: ./.github/workflows/reusable-drill-write-gate-runner.yml
     with:
-      scenario: ${{ inputs.scenario }}
+      scenario: ${{ inputs.scenario_id }}
       library_id: ${{ inputs.library_id }}

--- a/.github/workflows/drill-write-gate.yml
+++ b/.github/workflows/drill-write-gate.yml
@@ -3,15 +3,11 @@ name: drill-write-gate
 on:
   workflow_dispatch:
     inputs:
-      scenario:
+      scenario_id:
         description: "Write-gate scenario"
         required: true
         default: readiness/search/dual_run_gate
-        type: choice
-        options:
-          - readiness/search/dual_run_gate
-          - dual_write/search/canary_cleanup
-          - dual_write/search/sampling_cleanup
+        type: string
       library_id:
         description: "Optional data scope: library_id (UUID). Scopes seed+enqueue/outbox.library_id."
         required: false
@@ -22,7 +18,7 @@ jobs:
   drill:
     uses: ./.github/workflows/reusable-drill-write-gate-runner.yml
     with:
-      scenario: ${{ inputs.scenario }}
+      scenario: ${{ inputs.scenario_id }}
       library_id: ${{ inputs.library_id }}
 
 

--- a/backend/scripts/ci/validate_scenario_catalog.py
+++ b/backend/scripts/ci/validate_scenario_catalog.py
@@ -137,6 +137,70 @@ def _collect_workflow_choice_options(doc: Any) -> list[str]:
     return options
 
 
+def _collect_workflow_dispatch_scenario_defaults(doc: Any) -> list[str]:
+    """Collect workflow_dispatch input defaults for scenario-like inputs.
+
+    This supports suites that intentionally avoid `type: choice` + `options`.
+    """
+
+    if not isinstance(doc, dict):
+        return []
+
+    on_section = doc.get("on")
+    if not isinstance(on_section, dict):
+        return []
+
+    wd = on_section.get("workflow_dispatch")
+    if not isinstance(wd, dict):
+        return []
+
+    inputs = wd.get("inputs")
+    if not isinstance(inputs, dict):
+        return []
+
+    defaults: list[str] = []
+    for input_name, spec in inputs.items():
+        if input_name not in {"scenario", "scenario_id"}:
+            continue
+        if not isinstance(spec, dict):
+            continue
+
+        default = spec.get("default")
+        if isinstance(default, str) and default.strip() and "${{" not in default:
+            defaults.append(default.strip())
+
+    return defaults
+
+
+def _collect_static_job_scenarios(doc: Any) -> list[str]:
+    """Collect literal scenario values passed into reusable workflows.
+
+    We only collect plain strings without GitHub expressions to avoid false positives.
+    """
+
+    if not isinstance(doc, dict):
+        return []
+
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+
+    found: list[str] = []
+    for _, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        with_section = job.get("with")
+        if not isinstance(with_section, dict):
+            continue
+
+        for key in ("scenario", "scenario_id"):
+            value = with_section.get(key)
+            if isinstance(value, str) and value.strip() and "${{" not in value:
+                found.append(value.strip())
+
+    return found
+
+
 _BAD_ARTIFACT_NAME_VAR_PATTERNS = (
     "inputs.scenario_id",
     "matrix.scenario",
@@ -202,19 +266,29 @@ def main() -> int:
     valid_keys, errors = _validate_catalog(catalog_path)
 
     workflow_paths = _iter_workflow_paths(workflows_dir)
-    referenced: list[tuple[Path, str]] = []
+    referenced: list[tuple[Path, str, str]] = []
 
     for wf in workflow_paths:
         doc = _load_yaml(wf)
         for opt in _collect_workflow_choice_options(doc):
-            referenced.append((wf, opt))
+            referenced.append((wf, opt, "workflow_dispatch.options"))
+
+        for default in _collect_workflow_dispatch_scenario_defaults(doc):
+            referenced.append((wf, default, "workflow_dispatch.default"))
+
+        for scenario in _collect_static_job_scenarios(doc):
+            referenced.append((wf, scenario, "jobs.*.with"))
 
         errors.extend(_validate_upload_artifact_names(doc, wf))
 
     # Validate that all workflow choice options resolve to some scenario in catalog (id or aliases)
-    for wf, opt in referenced:
-        if opt not in valid_keys:
-            errors.append(ValidationError(f"{wf.name}: workflow_dispatch input option not found in catalog (id/aliases): {opt}"))
+    for wf, value, source in referenced:
+        if value not in valid_keys:
+            errors.append(
+                ValidationError(
+                    f"{wf.name}: referenced scenario not found in catalog (id/aliases) [{source}]: {value}"
+                )
+            )
 
     if errors:
         for e in errors:


### PR DESCRIPTION
 - ... and change type to string for improved clarity and consistency across workflows
 - For more details, see: #107 & #114 