### PR TITLE
S5A: promote logs to stable + entry commands

### DIFF
--- a/docs/logs/log-S5A-3A-backup-sanitization.md
+++ b/docs/logs/log-S5A-3A-backup-sanitization.md
@@ -5,7 +5,7 @@
 **id**: `S5A-3A`
 **kind**: `log`               # log | lab | runbook | adr | note
 **title**: `dev/test recoverable backup + restore drill + sanitization (masking) v1`
-**status**: `draft`           # draft | stable | archived
+**status**: `stable`          # draft | stable | archived
 **scope**: `S5`
 **tags**: `EVOLUTION, Security, Governance, MultiTenant, Backup, Restore, Sanitization, Masking, Postgres, Drills, Evidence, epic/s5, sub/3a`
 **links**: ``
@@ -16,7 +16,7 @@
   **parent_log**: `docs/logs/log-S5A-security-governance.md`
   **previous_log**: `docs/logs/log-S5A-2A-library-membership-roles-policy-audit.md`
 **created**: `2026-03-03`
-**updated**: `2026-03-03`
+**updated**: `2026-03-04`
 
 ---
 
@@ -75,6 +75,14 @@
   - 至少 2 个 drills，产出 artifacts（JSON）：
     - backup+restore drill
     - restore+sanitize drill
+
+## Stability（stable 口径）
+
+- 本 log 标记为 `stable` 表示：P0-P3 的脚本与 drills 已跑通，并在 Evidence 区记录了 headSha + artifacts 路径。
+- drills 入口：
+  - backup：`python scripts/drills/s5a3a_p1c1s2_backup_drill.py`
+  - restore+verify：`python scripts/drills/s5a3a_p2c1s2_restore_verify_drill.py`
+  - restore+sanitize+verify：`python scripts/drills/s5a3a_p3c1s2_sanitize_verify_drill.py`
 
 ## P0（Contract｜v1）
 

--- a/docs/logs/log-S5A-3B-object-storage-backup.md
+++ b/docs/logs/log-S5A-3B-object-storage-backup.md
@@ -5,7 +5,7 @@
 **id**: `S5A-3B`
 **kind**: `log`               # log | lab | runbook | adr | note
 **title**: `dev/test backup artifacts to object storage (minio/S3) + lifecycle + drill evidence v1`
-**status**: `draft`           # draft | stable | archived
+**status**: `stable`          # draft | stable | archived
 **scope**: `S5`
 **tags**: `EVOLUTION, Security, Governance, Backup, ObjectStorage, S3, MinIO, Lifecycle, Drills, Evidence, epic/s5, sub/3b`
 **links**: ``
@@ -16,7 +16,7 @@
   **parent_log**: `docs/logs/log-S5A-security-governance.md`
   **previous_log**: `docs/logs/log-S5A-3A-backup-sanitization.md`
 **created**: `2026-03-03`
-**updated**: `2026-03-03`
+**updated**: `2026-03-04`
 
 ---
 
@@ -65,6 +65,13 @@
 - 能把 dump 上传到对象存储，并记录 sha256/size/object_key。
 - 能从对象存储下载 dump 并完成 restore+verify drill。
 - 能为上述 drill 产出 evidence JSON，并在本 log 记录 headSha + artifacts 路径。
+
+## Stability（stable 口径）
+
+- 本 log 标记为 `stable` 表示：P0-P4 的 contract + 脚本 + drills 已跑通，并且 Evidence 区有可追溯的 headSha + artifacts 路径。
+- 最小入口（单命令端到端演练）：
+  - `python scripts/drills/s5a3b_p4c1s1_pipeline_drill.py`
+  - 期望输出：打印 1 行 evidence 路径（`artifacts/_tmp_s5a3b_p4c1s1/drills_<ts>.json`）
 
 ## P0（Contract｜v1）
 

--- a/docs/logs/log-S5A-security-governance.md
+++ b/docs/logs/log-S5A-security-governance.md
@@ -5,7 +5,7 @@
 **id**: `S5A-security-governance`
 **kind**: `log`               # log | lab | runbook | adr | note
 **title**: `security & governance (AuthContext, tenant boundary, policy, audit, drills, membership/roles)`
-**status**: `draft`           # draft | stable | archived
+**status**: `stable`          # draft | stable | archived
 **scope**: `S5`
 **tags**: `EVOLUTION, Security, Governance, MultiTenant, Auth, Authorization, Policy, Audit, Drills, epic/s5, epic/s5a`
 **links**: ``
@@ -21,7 +21,7 @@
   **phase_log_3**: `docs/logs/log-S5A-3A-backup-sanitization.md`
   **phase_log_4**: `docs/logs/log-S5A-3B-object-storage-backup.md`
 **created**: `2026-03-02`
-**updated**: `2026-03-03`
+**updated**: `2026-03-04`
 
 ---
 
@@ -84,3 +84,10 @@
 
 - 默认 404 优先于 403（用于越权读场景，减少信息泄露）；但需要统一口径并产出审计。
 - audit 记录点优先：policy deny / allow + 关键写操作成功（最小闭环）。
+
+## Stability（stable 口径）
+
+- 本 log 标记为 `stable` 表示：S5A epic 的 phase 拆分、默认 contract 与证据口径已稳定；具体实现与 evidence 以各 phase log 为准。
+- 端到端入口（备份/恢复/脱敏 + 对象存储化）：
+  - 见 phase log：`docs/logs/log-S5A-3B-object-storage-backup.md`
+  - 单命令 drill：`python scripts/drills/s5a3b_p4c1s1_pipeline_drill.py`


### PR DESCRIPTION
- For more details, see: #149 
- About the log itself, read: `log-S5A-security-governance`