### PR TITLE
S2D-3A/P2P3: add adoption rules, skip/waiver controls, and onboarding coverage contract

### DIFF
--- a/docs/logs/log-S2D-2A-onboarding-coverage-and-catalog-rules.md
+++ b/docs/logs/log-S2D-2A-onboarding-coverage-and-catalog-rules.md
@@ -1,0 +1,171 @@
+# log-S2D-2A-onboarding-coverage-and-catalog-rules（Phase 2：Onboarding coverage metrics & catalog rules）
+
+---
+
+**id**: `S2D-2A`
+**kind**: `log`               # log | lab | runbook | adr | note
+**title**: `onboarding coverage metrics & catalog rules (drills/evidence) v1`
+**status**: `draft`           # draft | stable | archived
+**scope**: `S2D`
+**tags**: `EVOLUTION, Projection, Onboarding, Catalog, Drills, Evidence, epic/s2d, sub/2`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **adr**: ``
+  **runbook**: ``
+  **parent_log**: `docs/logs/log-S2D-projection-onboarding-hard-gates.md`
+  **previous_log**: `docs/logs/log-S2D-1A-projection-onboarding-contract-and-sample.md`
+  **reference_log_1**: `docs/logs/log-S2C-projection-framework-platformization.md`
+  **reference_log_2**: `docs/logs/log-S6A-4A-hard-gate-evidence-json.md`
+**created**: `2026-03-10`
+**updated**: `2026-03-10`
+
+---
+
+## Decision / Outcome（结论区）
+
+**Decision**:
+
+- 为 S2D 定义一套“onboarding coverage & catalog 规则”：在 projection catalog 中显式标记哪些投影已经按 S2D onboarding 落地（platformized），哪些仍为 legacy/experimental。
+- 提供可重复的 drills/queries，用 JSON/SQL 方式统计 onboarding 覆盖率，并为 S2D hard gate（S2D-3A）提供 required/optional suites 的决策依据。
+
+**Default choices（本 phase 默认决策 / v1）**：
+
+- 以 dev/test catalog 为主（例如 projection registry / catalog tables），优先在非生产环境中验证规则与查询口径。
+- 首批仅覆盖少量示范投影（例如 S2D-1A 的 sample projection），其余投影默认视为 legacy 或 optional，不强行纳入 required 集。
+- 覆盖率计算口径尽量简单、可机械判定：例如“满足 onboarding contract + drills + 在 catalog 中标记为 platformized”即可认定为已 onboarding。
+
+## Definitions（概念定义）
+
+- **Platformized projection**：在 S2C/S2D 框架下，满足 onboarding contract、具备 drills/CI hard gate，并在 catalog 中显式标记为 platformized 的 projection。
+- **Legacy projection**：尚未按 S2D onboarding contract 重构的既有 projection，可以通过 skip/waiver 机制暂时绕过 hard gate。
+- **Coverage metrics**：用于衡量 onboarding 进度的度量，例如“platformized 投影数量 / 全部投影数量”、“按业务域/团队的覆盖率”等。
+
+## Constraints（约束）
+
+- 不直接修改生产 catalog 的语义；v1 仅在 dev/test 或 shadow catalog 中试跑规则与统计口径。
+- 覆盖率口径必须与 S2D-1A/S2D-3A 的 contract 保持一致：只认“真的按 S2D onboarding 跑通并有 Evidence 记账”的 projection，不接受手动勾选。
+- 所有关联脚本与查询应能通过单命令或 notebook 复跑，输出 JSON/表格，便于在 S0D/S6A 的汇总报表中引用。
+
+## Scope（本 log 范围）
+
+- `P0`：contract（定义 onboarding coverage 的统计口径、catalog 标记字段与 JSON/SQL 输出结构）。
+- `P1`：implementation（在 catalog/registry 层面补充标记字段与查询脚本）。
+- `P2`：drills（在 dev/test 环境定期跑 coverage drills，并记录 Evidence）。
+- `P3`：integration（将 coverage 结果回填到 S2D-3A 的 SUITE_CATALOG / hard gate 默认 required 集中）。
+
+## Success Criteria（DoD）
+
+- 有一份明确的 onboarding coverage contract：
+  - catalog 中用于标记 platformized/legacy 的字段或标签约定；
+  - 至少 1 条用于统计覆盖率的 SQL/JSON 查询模板；
+  - 输出 schema 能够被 S0D/S6A 的报表或自动化消费。
+- 至少 1 次 coverage drill 在 dev/test 环境成功执行：
+  - 能枚举出 S2D-1A sample projection 这一条 platformized projection；
+  - 对其它 projection 给出明确的 legacy/unknown 状态。
+- Evidence 区记录至少 1 条 coverage drill run：包含 headSha、查询脚本/路径、输出 JSON 或快照路径。
+
+## Stability（stable 口径）
+
+- 本 log 标记为 `stable` 表示：
+  - P0-P2 的 coverage contract + catalog 字段 + drills 已经稳定，并可通过单命令复跑；
+  - P3 已将 coverage 结果集成进 S2D-3A 的 required/optional suites 决策流程（例如自动生成 SUITE_CATALOG 或校验配置）。
+
+## P0（Contract｜v1）
+
+### P0-C1-S1（Catalog 标记与枚举规则）
+
+- 在 projection catalog/registry 中为每条 projection 增加 S2D 相关标记字段（示意）：
+  - `onboarding_status`：`platformized | legacy | experimental | unknown`；
+  - `onboarding_phase`：`S2D-1A | S2D-2A | S2D-3A | none`；
+  - `owner_team`：可选，用于按团队维度汇总覆盖率。
+- 规定“认定为 platformized”的最小条件：
+  - 具备 S2D-1A 要求的 onboarding contract（spec/adapter/writer/rebuild/backfill/drills）；
+  - 在 S2D-1A/S2D-3A 的 Evidence 中出现过至少 1 条 green run 记录；
+  - catalog 中 `onboarding_status=platformized`。
+
+### P0-C1-S2（Coverage metrics & 输出 schema）
+
+- 定义最小 coverage metrics：
+  - `total_projections`：catalog 中全部投影数量；
+  - `platformized_projections`：`onboarding_status=platformized` 的投影数量；
+  - `legacy_projections`：`onboarding_status=legacy` 的投影数量；
+  - 以及可选的按业务域/团队聚合指标。
+- 约定 coverage drill 的 JSON 输出 schema（示意）：
+  - `generated_at`：UTC 时间戳；
+  - `total_projections` / `platformized_projections` / `legacy_projections`；
+  - `by_team`：按团队聚合的覆盖率列表；
+  - `projections`：每条投影的 `name/onboarding_status/onboarding_phase/owner_team` 摘要列表。
+
+### P0-C1-S3（Evidence JSON contract）
+
+- 每次 coverage drill 至少需要写出：
+  - 1 份 JSON 快照文件（例如 `artifacts/s2d-coverage-YYYYMMDD-HHMMSS.json`），包含上述 schema；
+  - 可选的表格/metrics 导出（例如 CSV 或 metrics 表）。
+- Evidence 记录需包含：headSha、drill 脚本路径、输出 JSON 路径，以及 key metrics 的摘要（例如 platformized 数量）。
+
+## Numbering（编号约定）
+
+- `S<n>`：Step（步骤）。
+- `C<n>`：Cycle（循环轮次）。
+
+**Commit / PR 命名**:
+
+- `S2D-2A/P<phase>-C<cycle>-S<steps>: <summary>`，例如：`S2D-2A/P0-C1-S1: scaffold onboarding coverage contract`。
+
+## Plan（draft）
+
+### P1（Implementation：catalog 字段与查询脚本）
+
+- P1-C1-S1：在 projection catalog/registry 中增加 `onboarding_status/onboarding_phase/owner_team` 字段或标签，并为现有 sample projection（chronicle_daily_stats）写入 `platformized` 标记。
+- P1-C1-S2：新增 1~2 条 SQL/JSON 查询脚本，用于导出 coverage metrics 与逐 projection 摘要。
+
+### P2（Drills：定期 coverage 统计）
+
+- P2-C1-S1：在 devtest 环境运行 coverage drill（例如 `scripts/labs/s2d_2a_p2c1s1_coverage_snapshot.py`），产出 `artifacts/s2d-coverage-*.json`。
+- P2-C1-S2：为 coverage drill 增加简单的 CI 或定时任务入口（可选），并在本 log 的 Evidence 区记录首次 run。
+
+### P3（Integration：回填 hard gate 决策）
+
+- P3-C1-S1：定义从 coverage JSON 映射到 S2D-3A `SUITE_CATALOG` 的规则，例如：哪些 projection 需要新增 suite，哪些可以继续作为 optional/legacy。
+- P3-C1-S2：在后续 phase（或 S2D-3A 的演进）中，将 coverage 结果实际接入 hard gate 配置（本 log 仅定义 contract 与计划）。
+
+## Execution Checklist（unchecked）
+
+### P0（Contract）
+
+- [x] `P0-C1-S1`：定义 catalog 标记字段与 platformized/legacy 枚举规则
+- [x] `P0-C1-S2`：定义 coverage metrics 与 JSON 输出 schema
+- [x] `P0-C1-S3`：定义 coverage drill 的 Evidence JSON contract
+
+### P1（Implementation：catalog & queries）
+
+- [ ] `P1-C1-S1`：在 catalog/registry 中增加字段/标签并填充示例数据
+- [ ] `P1-C1-S2`：实现导出 coverage metrics 的查询脚本
+
+### P2（Drills）
+
+- [ ] `P2-C1-S1`：实现并跑通首个 coverage drill，产出 JSON 快照
+- [ ] `P2-C1-S2`：在本 log 的 Evidence 区记录 coverage drill 首次 run
+
+### P3（Integration）
+
+- [ ] `P3-C1-S1`：定义 coverage → hard gate 决策映射规则的具体实现方案
+- [ ] `P3-C1-S2`：在后续 phase 中将 coverage 结果写回 S2D-3A 的 SUITE_CATALOG/配置
+
+## Evidence（预留）
+
+- Evidence 以 artifacts 为事实源；本 log 记录：headSha + 关键参数 + artifacts 路径（或 CI run URL）。
+
+### P2-C1-S1（onboarding coverage drill snapshot｜YYYY-MM-DD）
+
+- headSha：`<git sha>`
+- artifacts：`artifacts/s2d-coverage-YYYYMMDD-HHMMSS.json`
+- 期望（expected）：
+-  - 至少包含 1 条 platformized projection（例如 S2D-1A 的 sample projection），其余 projection 标记为 legacy/unknown；
+- 观测（observed）：
+-  - （首轮 run 完成后补充）。
+
+## Recent changes（for traceability，可选）
+
+- 2026-03-10：scaffold S2D-2A log，定义 onboarding coverage metrics & catalog rules 的 contract 与计划，等待后续 P1/P2/P3 实现。

--- a/docs/logs/log-S2D-3A-projection-onboarding-hard-gate-entrypoint+CI.md
+++ b/docs/logs/log-S2D-3A-projection-onboarding-hard-gate-entrypoint+CI.md
@@ -125,8 +125,8 @@
 
 ### P3（Adoption：catalog & guardrails）
 
-- P3-C1-S1：在 docs/logs 与 runbook 中记录哪些 projection/onboarding suites 已纳入 S2D hard gate required 集，哪些仍处于 optional/experimental 状态。
-- P3-C1-S2：为 legacy projection 设计合理的 skip/waiver 机制（例如基于标签或配置），并约定升级路径。
+- P3-C1-S1：在 docs/logs 与 runbook 中记录哪些 projection/onboarding suites 已纳入 S2D hard gate required 集，哪些仍处于 optional/experimental 状态；v1 中通过 `scripts/s2d_hard_gate.py` 内部的 `SUITE_CATALOG` 标记 `required=true/false`，目前仅 S2D-1A sample onboarding 标记为 required，其它后续新增 suites 默认从 optional/experimental 起步，再按 S2D spine 升级为 required。
+- P3-C1-S2：为 legacy projection 设计合理的 skip/waiver 机制（例如基于标签或配置），并约定升级路径；v1 中通过环境变量 `S2D_HARD_GATE_SKIP_SUITES`（跳过指定 suite）与 `S2D_HARD_GATE_WAIVE_SUITES`（对指定 suite 的失败做 waiver，不阻塞 CI）实现，可按 suite id（如 `s2d-1a-sample-onboarding`）以逗号分隔配置。
 
 ## Execution Checklist（unchecked）
 
@@ -148,8 +148,8 @@
 
 ### P3（Adoption & guardrails）
 
-- [ ] `P3-C1-S1`：在文档中记录 required/optional suites 与升级路径
-- [ ] `P3-C1-S2`：实现并记录 skip/waiver 机制
+- [x] `P3-C1-S1`：在文档中记录 required/optional suites 与升级路径（v1：通过本 log + S2D spine 描述 `SUITE_CATALOG` 中 required/optional 语义，当前仅 S2D-1A sample 为 required）
+- [x] `P3-C1-S2`：实现并记录 skip/waiver 机制（v1：在 `scripts/s2d_hard_gate.py` 中落地 `S2D_HARD_GATE_SKIP_SUITES`/`S2D_HARD_GATE_WAIVE_SUITES` 行为）
 
 ## Evidence（预留）
 

--- a/docs/logs/log-S2D-projection-onboarding-hard-gates.md
+++ b/docs/logs/log-S2D-projection-onboarding-hard-gates.md
@@ -17,7 +17,7 @@
   **reference_log_1**: `docs/logs/log-S2C-projection-framework-platformization.md`
   **reference_log_2**: `docs/logs/log-S6A-4A-hard-gate-evidence-json.md`
   **phase_log_1**: `docs/logs/log-S2D-1A-projection-onboarding-contract-and-sample.md`
-  **phase_log_2**: ``
+  **phase_log_2**: `docs/logs/log-S2D-2A-onboarding-coverage-and-catalog-rules.md`
   **phase_log_3**: `docs/logs/log-S2D-3A-projection-onboarding-hard-gate-entrypoint+CI.md`
 **created**: `2026-03-08`
 **updated**: `2026-03-09`
@@ -75,8 +75,8 @@
 
 - `S2D-1A`（Phase 1）：Projection onboarding contract + first sample projection（用一条新投影跑通 S2D onboarding 全链路）
   - 详见：`docs/logs/log-S2D-1A-projection-onboarding-contract-and-sample.md`
-- `S2D-2A`（Phase 2，预留）：Onboarding coverage metrics & catalog rules（统计多少 projection 已按 S2D 落地，并在 catalog 中收紧规则）
-  - 详见：`docs/logs/log-S2D-2A-onboarding-coverage-and-catalog-rules.md`（预留）
+- `S2D-2A`（Phase 2）：Onboarding coverage metrics & catalog rules（统计多少 projection 已按 S2D 落地，并在 catalog 中收紧规则）
+  - 详见：`docs/logs/log-S2D-2A-onboarding-coverage-and-catalog-rules.md`
 - `S2D-3A`（Phase 3）：S2D hard gate entrypoint & CI wiring（把 S2D onboarding 检查挂到统一 hard gate 和 CI workflow）
   - 详见：`docs/logs/log-S2D-3A-projection-onboarding-hard-gate-entrypoint+CI.md`
 
@@ -85,7 +85,7 @@
 - [x] `P0`：S2D contract/indexing（目标边界 + 默认基线 + links/index）
 - [x] `P1`：Phase 1（projection onboarding contract + first sample projection 落地）
 - [ ] `P2`：Phase 2（onboarding coverage & catalog 规则；区分 legacy vs platformized）
-- [ ] `P3`：Phase 3（S2D hard gate 入口脚本 + CI workflow）
+- [x] `P3`：Phase 3（S2D hard gate 入口脚本 + CI workflow + 基本 adoption/skip/waiver 规则）
 
 ## Evidence（示范 Phase 记录）
 
@@ -101,12 +101,37 @@
     - 本次为 S2D-1A onboarding 套餐脚本的首次集成运行，成功写入 Evidence JSON；
     - 运行结果为 red（`ok=false`），失败原因为 harness drill 在导入 `api.app.shared.deps`/`api.app.config.security` 时触发 circular import（`ImportError: cannot import name 'get_db' ...`）。
 
+- `2026-03-09` / Phase 3（S2D-3A local hard gate dry run）
+  - headSha：`2fd5d5e8bfb92c2ca92c12bcdc2d27ac0058badf`
+  - log_id/phase/cycle/step：`S2D-3A / P1 / C1 / S1`
+  - runner：`scripts/s2d_hard_gate.py`
+  - run_id：`20260309-194740`
+  - artifacts：
+    - 汇总记录：`artifacts/s2d-runs.json`（追加记录，`log_id="S2D-1A"`，`run_id="20260309-194740"`，`ok=true`）
+    - backfill smoke：`docs/labs/_snapshot/auto/s2d1a_chronicle_daily_stats_backfill_smoke/20260309-194740`
+    - harness drill：`docs/labs/_snapshot/auto/s2d1a_chronicle_daily_stats_harness_drill/20260309-194740`
+  - 说明：
+    - 通过 `python scripts/s2d_hard_gate.py --database-url $DATABASE_URL` 在 devtest DB 下调用 S2D-1A onboarding 套餐，完成首个 green dry run；
+    - hard gate 根据 `artifacts/s2d-runs.json` 中的记录计算 `overall_ok=true` 并以 `exit_code=0` 结束，为后续 CI hard gate 提供本地基线。
+
+- `2026-03-09 ~ 2026-03-10` / Phase 3（S2D-3A CI hard gate workflow red → green）
+  - log_id/phase/cycle/step：`S2D-3A / P2 / C1 / S1`
+  - 首轮 CI run（red）：
+    - headSha：`5ccf5bb96fd6669282ddc46079414b3e942d8c88`
+    - CI run：`https://github.com/samuelhu324-dev/wordloom-v3/actions/runs/22852965555`
+    - 说明：首轮 `s2d-hard-gate` workflow 在 Start DB / artifacts 上传阶段失败，未能产出预期的 `_snapshot/auto` 与 `artifacts/s2d-runs.json`，`hard_gate` job `exit_code=2`。
+  - first green CI run：
+    - headSha：`894e6bad7554f53ae9ac39bc6770b256568ea271`
+    - CI run：`https://github.com/samuelhu324-dev/wordloom-v3/actions/runs/22853943302`
+    - artifacts：`s2d-hard-gate-22853943302-1`（包含本次 hard gate 运行生成的 `_snapshot/auto/...` 与 `artifacts/s2d-runs.json` 片段）
+    - 说明：修复 DB wait loop 语法后，`s2d-hard-gate` workflow 在 CI 中成功跑通，完成首个 green CI hard gate run，并作为后续扩展多投影时的基线样板；具体细节见 `docs/logs/log-S2D-3A-projection-onboarding-hard-gate-entrypoint+CI.md` 的 Evidence 区。
+
 ## Current Status（进展摘要）
 
 - S2C 已经提供 spec/registry/harness/writer/rebuild/backfill/drills 模板以及 Search harness migration，具备 Route A 的平台化前置条件，但缺少“新增 projection 必须按模板 & 有 CI gate”的约束层。
-- S2D-1A 已在代码与文档层面完成 P0-P3：定义 onboarding contract、接入 sample projection（`chronicle_daily_stats`）、补齐 drills/labs，并提供单命令 onboarding 套餐脚本与 runbook。
-- 2026-03-09 已通过 `scripts/projections/s2d_1a_p3c1s1_sample_onboarding.py` 在 devtest DB 上完成首次 Phase 1 onboarding 套餐运行，并将结果写入 `artifacts/s2d-runs.json`；本次 run 为 red（`ok=false`），失败原因为 harness drill 触发 `api.app.shared.deps`/`api.app.config.security` 之间的 circular import（`ImportError: cannot import name 'get_db'`）。
-- 后续 S2D-1A/S2D-3A 需要在修复该 circular import 并获得首个 green run 后，进一步把 S2D onboarding 套餐挂载到统一 hard gate / CI workflow 上。
+- S2D-1A 已在代码与文档层面完成 P0-P3：定义 onboarding contract、接入 sample projection（`chronicle_daily_stats`）、补齐 drills/labs，并提供单命令 onboarding 套餐脚本与 runbook；其 rebuild/backfill/drills 与 onboarding package 已在 devtest DB 中完成 red → green 的首轮演练，Evidence 记录在 `docs/logs/log-S2D-1A-projection-onboarding-contract-and-sample.md`。
+- S2D-3A 已完成 P0-P3 v1：实现本地 hard gate runner（`scripts/s2d_hard_gate.py`）、`s2d-hard-gate` CI workflow 以及基于 `SUITE_CATALOG` 的 required/optional 标记；同时提供 `S2D_HARD_GATE_SKIP_SUITES`/`S2D_HARD_GATE_WAIVE_SUITES` 环境变量，用于 legacy projection 的 skip/waiver 升级路径，首个 CI hard gate 已在 PR `#197` 上获得 green run。
+- Phase 2（S2D-2A）尚处于 contract/scaffolding 阶段：需在 catalog 层面标记哪些 projection 已按 S2D onboarding 落地，并在后续阶段逐步收紧 required 集、减少 skip/waiver 依赖。
 
 ## Notes（落地原则）
 

--- a/scripts/s2d_hard_gate.py
+++ b/scripts/s2d_hard_gate.py
@@ -36,6 +36,16 @@ S2D_RUNS_PATH = Path("artifacts/s2d-runs.json")
 S2D_1A_LOG_ID = "S2D-1A"
 S2D_1A_SUITE_ID = "s2d-1a-sample-onboarding"
 
+HARD_GATE_SKIP_ENV = "S2D_HARD_GATE_SKIP_SUITES"
+HARD_GATE_WAIVE_ENV = "S2D_HARD_GATE_WAIVE_SUITES"
+
+SUITE_CATALOG: dict[str, dict[str, Any]] = {
+    S2D_1A_SUITE_ID: {
+        "log_id": S2D_1A_LOG_ID,
+        "required": True,
+    },
+}
+
 
 def _utc_now_str() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
@@ -56,6 +66,8 @@ class SuiteResult:
     exit_code: int
     reason: str
     record: dict[str, Any] | None
+    required: bool
+    waived: bool
 
 
 @dataclass(frozen=True)
@@ -68,6 +80,18 @@ class HardGateSummary:
     database_url: str
     overall_ok: bool
     suites: list[SuiteResult]
+
+
+def _parse_suite_list_env(raw: str | None) -> set[str]:
+    values: set[str] = set()
+    if not raw:
+        return values
+
+    for part in raw.split(","):
+        suite = part.strip()
+        if suite:
+            values.add(suite)
+    return values
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -115,7 +139,13 @@ def _find_record(records: list[dict[str, Any]], *, log_id: str, run_id: str) -> 
     return None
 
 
-def _run_s2d_1a_suite(*, database_url: str, artifacts_path: Path) -> SuiteResult:
+def _run_s2d_1a_suite(
+    *,
+    database_url: str,
+    artifacts_path: Path,
+    required: bool,
+    waive_failure: bool,
+) -> SuiteResult:
     run_id = _default_run_id()
 
     cmd = [
@@ -141,6 +171,11 @@ def _run_s2d_1a_suite(*, database_url: str, artifacts_path: Path) -> SuiteResult
         ok = bool(record.get("ok")) and rc == 0
         reason = "ok" if ok else "suite reported failure (ok=false or non-zero exit code)"
 
+    waived = False
+    if not ok and waive_failure:
+        waived = True
+        reason = f"suite failed but waived via {HARD_GATE_WAIVE_ENV}"
+
     print(
         f"[S2D-3A] suite {S2D_1A_SUITE_ID} finished: rc={rc} ok={ok} "
         f"record_found={record is not None} run_id={run_id}"
@@ -154,6 +189,8 @@ def _run_s2d_1a_suite(*, database_url: str, artifacts_path: Path) -> SuiteResult
         exit_code=rc,
         reason=reason,
         record=record,
+        required=required,
+        waived=waived,
     )
 
 
@@ -173,17 +210,51 @@ def main(argv: list[str] | None = None) -> int:
     else:
         suites = [S2D_1A_SUITE_ID]
 
+    skip_suites = _parse_suite_list_env(os.environ.get(HARD_GATE_SKIP_ENV))
+    waive_suites = _parse_suite_list_env(os.environ.get(HARD_GATE_WAIVE_ENV))
+
     results: list[SuiteResult] = []
 
     for suite_id in suites:
-        if suite_id != S2D_1A_SUITE_ID:
+        if suite_id not in SUITE_CATALOG:
             print(f"[S2D-3A] error: unknown suite id: {suite_id}", file=sys.stderr)
             return 2
 
-        result = _run_s2d_1a_suite(database_url=database_url, artifacts_path=artifacts_path)
+        suite_cfg = SUITE_CATALOG[suite_id]
+        required = bool(suite_cfg.get("required", True))
+
+        if suite_id in skip_suites:
+            print(
+                f"[S2D-3A] skipping suite {suite_id} via {HARD_GATE_SKIP_ENV} (adoption/legacy waiver)",
+                file=sys.stderr,
+            )
+            result = SuiteResult(
+                suite_id=suite_id,
+                log_id=str(suite_cfg.get("log_id", "")),
+                run_id="skipped",
+                ok=True,
+                exit_code=0,
+                reason=f"skipped via {HARD_GATE_SKIP_ENV}",
+                record=None,
+                required=required,
+                waived=True,
+            )
+        else:
+            waive_failure = suite_id in waive_suites
+            result = _run_s2d_1a_suite(
+                database_url=database_url,
+                artifacts_path=artifacts_path,
+                required=required,
+                waive_failure=waive_failure,
+            )
+
         results.append(result)
 
-    overall_ok = all(r.ok for r in results)
+    overall_ok = True
+    for r in results:
+        if r.required and not r.waived and not r.ok:
+            overall_ok = False
+            break
 
     summary = HardGateSummary(
         log_id="S2D-3A",


### PR DESCRIPTION
- For more details, see: #195 
- About the log itself, read: `log-S2D-3A-projection-onboarding-hard-gate-entrypoint+CI`