### PR TITLE
S0E-4C/P5-C1-S1: harden create-path cherry-pick fallback

### DIFF
--- a/docs/issues/issue-conclusion-S0E-4C-p4-manifest.json
+++ b/docs/issues/issue-conclusion-S0E-4C-p4-manifest.json
@@ -1,0 +1,15 @@
+{
+  "version": "1",
+  "mode": "issue-conclusion-dry-run",
+  "defaults": {
+    "repo": "samuelhu324-dev/wordloom-v3"
+  },
+  "items": [
+    {
+      "requested_id": "S0E-4C",
+      "source_log_path": "docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md",
+      "issue_number": 300,
+      "reason": "Run the S0E-4C P4 full closed-loop issue conclusion after PR #301 merged"
+    }
+  ]
+}

--- a/docs/issues/issue-conclusion-S0E-4C-p4-plan.json
+++ b/docs/issues/issue-conclusion-S0E-4C-p4-plan.json
@@ -1,0 +1,41 @@
+{
+  "mode": "issue-conclusion-dry-run",
+  "result": "ok",
+  "manifest_path": "docs/issues/issue-conclusion-S0E-4C-p4-manifest.json",
+  "selection_input": "manifest",
+  "operation": "plan-issue-conclusion",
+  "total_items": 1,
+  "planned_items": 1,
+  "warnings": [
+    "S0E-4C: existing Context section is blank; preview omits optional Context block",
+    "S0E-4C: existing issue DoD is still blank create-time scaffold"
+  ],
+  "items": [
+    {
+      "requested_id": "S0E-4C",
+      "source_log_path": "docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md",
+      "issue_number": 300,
+      "issue_url": "https://github.com/samuelhu324-dev/wordloom-v3/issues/300",
+      "issue_title": "S0E-4C: contract/PR summary, development-link rendering, and issue relationship follow-up",
+      "issue_state": "CLOSED",
+      "preview_body_path": "docs/issues/issue-conclusion-S0E-4C-p4-s0e-4c-body.md",
+      "merged_pr_count": 1,
+      "merged_prs": [
+        {
+          "number": 301,
+          "title": "S0E-4C/P0-P4: PR summary, development-link rendering, and issue relationship follow-up v1",
+          "url": "https://github.com/samuelhu324-dev/wordloom-v3/pull/301",
+          "merged_at": "2026-03-30T03:44:43Z"
+        }
+      ],
+      "planned_action": "plan-issue-conclusion",
+      "applied_action": null,
+      "status": "planned",
+      "warnings": [
+        "existing Context section is blank; preview omits optional Context block",
+        "existing issue DoD is still blank create-time scaffold"
+      ],
+      "reason": "Run the S0E-4C P4 full closed-loop issue conclusion after PR #301 merged"
+    }
+  ]
+}

--- a/docs/issues/issue-conclusion-S0E-4C-p4-s0e-4c-apply-body.md
+++ b/docs/issues/issue-conclusion-S0E-4C-p4-s0e-4c-apply-body.md
@@ -1,0 +1,20 @@
+## Metadata
+
+- Labels: `EVOLUTION`, `s0/knowledge system`, `sub/1`
+- Projects: `wordloom Board`
+- Milestone: ``
+- Source log: `docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`
+- Parent issue: #248
+
+## Definition of Done (DoD)
+
+- #301
+
+## Links
+
+- Log: `docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`
+- Runbook: `docs/runbook/run-S0E-log-to-issue-creation.md`
+- Parent log: `docs/logs/log-S0E-docs-management-v5.md`
+- Issue: `https://github.com/samuelhu324-dev/wordloom-v3/issues/300`
+- PR: `https://github.com/samuelhu324-dev/wordloom-v3/pull/301`
+

--- a/docs/issues/issue-conclusion-S0E-4C-p4-s0e-4c-apply-result.json
+++ b/docs/issues/issue-conclusion-S0E-4C-p4-s0e-4c-apply-result.json
@@ -1,0 +1,19 @@
+{
+  "mode": "issue-conclusion-apply",
+  "result": "ok",
+  "plan_path": "docs/issues/issue-conclusion-S0E-4C-p4-plan.json",
+  "item_index": 0,
+  "requested_id": "S0E-4C",
+  "source_log_path": "docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md",
+  "repository": "samuelhu324-dev/wordloom-v3",
+  "issue_number": 300,
+  "issue_url": "https://github.com/samuelhu324-dev/wordloom-v3/issues/300",
+  "issue_title": "S0E-4C: contract/PR summary, development-link rendering, and issue relationship follow-up",
+  "previous_issue_state": "CLOSED",
+  "final_issue_state": "CLOSED",
+  "body_path": "docs/issues/issue-conclusion-S0E-4C-p4-s0e-4c-apply-body.md",
+  "close_reason": null,
+  "warnings": [
+    "issue was already closed before apply; body updated in place"
+  ]
+}

--- a/docs/issues/issue-conclusion-S0E-4C-p4-s0e-4c-body.md
+++ b/docs/issues/issue-conclusion-S0E-4C-p4-s0e-4c-body.md
@@ -1,0 +1,20 @@
+## Metadata
+
+- Labels: `EVOLUTION`, `s0/knowledge system`, `sub/1`
+- Projects: `wordloom Board`
+- Milestone: ``
+- Source log: `docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`
+- Parent issue: #248
+
+## Definition of Done (DoD)
+
+- #301
+
+## Links
+
+- Log: `docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`
+- Runbook: `docs/runbook/run-S0E-log-to-issue-creation.md`
+- Parent log: `docs/logs/log-S0E-docs-management-v5.md`
+- Issue: `https://github.com/samuelhu324-dev/wordloom-v3/issues/300`
+- PR: `https://github.com/samuelhu324-dev/wordloom-v3/pull/301`
+

--- a/docs/issues/pr-prep-S0E-4C-p5-body.md
+++ b/docs/issues/pr-prep-S0E-4C-p5-body.md
@@ -1,0 +1,55 @@
+## Metadata
+
+- Requested ID: `S0E-4C`
+- Base branch: `main`
+- Candidate PR-prep branch: `pr-prep/s0e-4c-p5`
+- Source log: `docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`
+- Labels: `EVOLUTION, s0/knowledge system, sub/1, drills`
+- Development issue: #300
+
+## Summary
+
+- Harden `create_pr_from_plan.py` so a long-lived mixed working branch can still produce a clean PR-prep branch when raw cherry-picks conflict on selected commits.
+- Keep PR-prep planning and create-path execution aligned around the current remote-tracking base and the source-head final file state used for the prep branch.
+- Re-run one real `S0E-4C` follow-up PR and update issue `#300` so the extra merged PR is reflected in the final DoD ledger.
+
+## Execution Checklist
+
+- [x] `P0-C1-S1`: PR development-issue short-ref rendering fixed in contract
+- [x] `P0-C1-S2`: PR summary requiredness fixed in contract
+- [x] `P0-C1-S3`: issue parent relationship attach boundary fixed in contract
+- [x] `P0-C1-S4`: evidence contract fixed
+- [x] `P1-C1-S1`: PR preview/create development-issue rendering normalized
+- [x] `P1-C1-S2`: real PR create path blocks placeholder summaries
+- [x] `P1-C1-S3`: issue relationship apply tooling added
+- [x] `P2-C1-S1`: representative PR-prep artifacts regenerated and reviewed
+- [x] `P2-C1-S2`: representative issue relationship artifacts regenerated and reviewed
+- [x] `P3-C1-S1`: one real PR validated against the updated body contract
+- [x] `P3-C1-S2`: one real child issue validated against the updated relationship attach path
+- [x] `P3-C1-S3`: historical `S0E` PR audit completed and outdated live bodies remediated
+- [x] `P4-C1-S1`: one full `issue creation -> PR -> issue conclusion` cycle completed under `S0E-4C`
+- [x] `P4-C1-S2`: end-to-end artifacts reviewed for contract consistency
+- [x] `P5-C1-S1`: create-path cherry-pick conflict hardening implemented
+
+## Links
+
+- Log: `docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`
+- Issue: `https://github.com/samuelhu324-dev/wordloom-v3/issues/300`
+- Runbook: `docs/runbook/run-S0E-log-to-issue-creation.md`
+- Evidence artifact: `docs/issues/pr-prep-S0E-4C-p5-plan.json`
+- Generated PR body should keep `Summary`, `Evidence Footer`, and `Development Link` as separate sections.
+- `Summary` must not degrade to `<placeholder>` on a live PR create path.
+
+## Evidence Footer
+
+- `18fbfe40` / `S0E-4C` / `P0-P1`: normalize PR summary gate and relationship apply
+- `cc72eb91` / `S0E-4C` / `P2-P3`: regenerate artifacts and reconcile legacy PRs
+- `7468d552` / `S0E-4C` / `P4-C1-S1`: create live issue and attach parent
+- `db1f26e3` / `S0E-4C` / `P4-C1-S1`: add live PR prep artifacts
+- `22e72115` / `S0E-4C` / `P4-C1-S1`: align PR prep with remote base
+- `c9e39dfe` / `S0E-4C` / `P4-C1-S2`: record closed-loop evidence and stabilize
+- `c4b6656d` / `S0E-4C` / `P5-C1-S1`: harden create-path cherry-pick fallback
+
+## Development Link
+
+- Closes #300

--- a/docs/issues/pr-prep-S0E-4C-p5-manifest.json
+++ b/docs/issues/pr-prep-S0E-4C-p5-manifest.json
@@ -1,0 +1,14 @@
+{
+  "defaults": {
+    "requested_id": "S0E-4C",
+    "source_log_path": "docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md",
+    "base_branch": "main",
+    "head_ref": "HEAD",
+    "candidate_pr_branch": "pr-prep/s0e-4c-p5"
+  },
+  "items": [
+    {
+      "requested_id": "S0E-4C"
+    }
+  ]
+}

--- a/docs/issues/pr-prep-S0E-4C-p5-plan.json
+++ b/docs/issues/pr-prep-S0E-4C-p5-plan.json
@@ -1,0 +1,273 @@
+{
+  "mode": "pr-prep-dry-run",
+  "result": "ok",
+  "manifest_path": "docs/issues/pr-prep-S0E-4C-p5-manifest.json",
+  "selection_input": "manifest",
+  "operation": "plan-pr-prep",
+  "total_items": 1,
+  "planned_items": 1,
+  "warnings": [
+    "S0E-4C: pr_development_issue derived from source log issue link"
+  ],
+  "items": [
+    {
+      "requested_id": "S0E-4C",
+      "source_log_path": "docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md",
+      "current_branch": "S0E-docs-management-v5",
+      "head_ref": "HEAD",
+      "base_branch": "main",
+      "merge_base": "4f8f778145c3443787ef56e0702003dc8f247eda",
+      "candidate_pr_branch": "pr-prep/s0e-4c-p5",
+      "pr_title": "S0E-4C/P0-P5: PR summary, development-link rendering, and issue relationship follow-up v1",
+      "pr_base": "main",
+      "pr_labels": [
+        "EVOLUTION",
+        "s0/knowledge system",
+        "sub/1",
+        "drills"
+      ],
+      "pr_projects": [],
+      "pr_milestone": null,
+      "pr_development_issue": "#300",
+      "pr_development_issue_refs": [
+        "#300"
+      ],
+      "summary_bullet_count": 3,
+      "preview_body_path": "docs/issues/pr-prep-S0E-4C-p5-body.md",
+      "selected_commit_count": 7,
+      "selected_commits": [
+        {
+          "sha": "18fbfe4036b1daf3a34460e0c64fbb0736798c21",
+          "subject": "S0E-4C/P0-P1: normalize PR summary gate and relationship apply",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "cc72eb9157413812a1f1e6f9064230b3ca5333d8",
+          "subject": "S0E-4C/P2-P3: regenerate artifacts and reconcile legacy PRs",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "7468d5524d8e4ae91d9f76e2a7f6238bfc1c23b2",
+          "subject": "S0E-4C/P4-C1-S1: create live issue and attach parent",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "db1f26e3d62394b2c60e94e9b528aca5efcf06d6",
+          "subject": "S0E-4C/P4-C1-S1: add live PR prep artifacts",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "22e721157149e8f774eb52802de35fc35ceb4e97",
+          "subject": "S0E-4C/P4-C1-S1: align PR prep with remote base",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "c9e39dfe83728651374750c4982807eb4c35356a",
+          "subject": "S0E-4C/P4-C1-S2: record closed-loop evidence and stabilize",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "c4b6656dd1babede3c3bc1cc6052beb48f510742",
+          "subject": "S0E-4C/P5-C1-S1: harden create-path cherry-pick fallback",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        }
+      ],
+      "branch_commits": [
+        {
+          "sha": "8f99ca5d0bd035f19a5d05abfef838919e41b536",
+          "subject": "S0E-4A/P0-C1-S1S2S3S4S5: fix PR automation contract",
+          "matched_id": "S0E-4A",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "10f2bcfee5711c3bb99d7af8546e4a142afa75ed",
+          "subject": "S0E-4A/P1-C1-S1S2: roll PR metadata and scaffold into templates",
+          "matched_id": "S0E-4A",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "6c94f4f7d74357c3a02f87c64a745ae07aaf2223",
+          "subject": "S0E-4A/P2-C1-S1S2: validate dry-run PR prep flow",
+          "matched_id": "S0E-4A",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "7855c1278be0f0aa9815e8c397967f83a6623f28",
+          "subject": "S0E-4A/P3-C1-S1: create source issue and real PR flow",
+          "matched_id": "S0E-4A",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "83093f85618cabbf2da6de48f3b7ee028a5d119e",
+          "subject": "S0E-4A/P3-C1-S2: create real PR and write back evidence",
+          "matched_id": "S0E-4A",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "898a82c990390f9bd7eb2e3ddeb65bf94ea19bed",
+          "subject": "S0E-4B/P3-C1-S1S2S3S4S5: refine body format and issue-project validation",
+          "matched_id": "S0E-4B",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "43210aecc60b92d75bee4c266191dd4e52421e18",
+          "subject": "S0E-4B/P3-C1-S6: stack validation on S0E-4A prep branch",
+          "matched_id": "S0E-4B",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "a882e5481ed0ae07c479647263f4c7276331e20c",
+          "subject": "S0E-4B/P3-C1-S7S8S9: clarify stacked PR semantics and title span precedence",
+          "matched_id": "S0E-4B",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "039fc82198e8e9e04ff7a79b308d5c78ba992bb6",
+          "subject": "S0E-4B/P3-C1-S10S11: align live issue project and PR base",
+          "matched_id": "S0E-4B",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "0c8feaaea7c5b91c9a225ddb0d0c04c47427e857",
+          "subject": "S0E-2D/P1-C1-S1S2: enrich issue draft metadata and body scaffold",
+          "matched_id": "S0E-2D",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "6da79e5b58d3d966760f61c99d6ebc0f42ae3709",
+          "subject": "S0E-2D/P2-C1-S1S2: validate enriched issue draft samples",
+          "matched_id": "S0E-2D",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "fd7d91caa313900bcd48df25b36ba04fae4fe5fb",
+          "subject": "S0E-2D/P1-C2-S3+P3-C3-S2: normalize parent issue rendering and audit sibling issues",
+          "matched_id": "S0E-2D",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "925b5f44c89bf6b0581f12a0c2785ab6c1e03dab",
+          "subject": "S0E-2D/P1-C2-S4+P3-C3-S3: render plain parent issue references",
+          "matched_id": "S0E-2D",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "f092a46f4b7eed0061413bad93082d92925f31dc",
+          "subject": "S0E-4A/P3-C2-S1S2: derive development issue fallback and multi-issue formatting",
+          "matched_id": "S0E-4A",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "ab5c4023035aeab6cad32f563ac522f478a934b1",
+          "subject": "S0E-2E/P0-P1: fix conclusion boundary and body contract",
+          "matched_id": "S0E-2E",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "35cd843fbe4ca2a77b4f43f4d95d6eb894ca5947",
+          "subject": "S0E-2E/P2-C1-S1S2: plan dry-run issue conclusion output",
+          "matched_id": "S0E-2E",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "5ba5545ac4503d298b6ac7d0200af5609471cd22",
+          "subject": "S0E-2E/P3-C1-S1S2: apply real issue conclusion write-back",
+          "matched_id": "S0E-2E",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "38f46cd0d6fcc2805f73cb34e1521a705743c955",
+          "subject": "S0E-2E/P1-C2-P3-C2: revise conclusion format and apply #295",
+          "matched_id": "S0E-2E",
+          "status": "skipped",
+          "reason": "commit subject does not match requested ID prefix"
+        },
+        {
+          "sha": "18fbfe4036b1daf3a34460e0c64fbb0736798c21",
+          "subject": "S0E-4C/P0-P1: normalize PR summary gate and relationship apply",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "cc72eb9157413812a1f1e6f9064230b3ca5333d8",
+          "subject": "S0E-4C/P2-P3: regenerate artifacts and reconcile legacy PRs",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "7468d5524d8e4ae91d9f76e2a7f6238bfc1c23b2",
+          "subject": "S0E-4C/P4-C1-S1: create live issue and attach parent",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "db1f26e3d62394b2c60e94e9b528aca5efcf06d6",
+          "subject": "S0E-4C/P4-C1-S1: add live PR prep artifacts",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "22e721157149e8f774eb52802de35fc35ceb4e97",
+          "subject": "S0E-4C/P4-C1-S1: align PR prep with remote base",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "c9e39dfe83728651374750c4982807eb4c35356a",
+          "subject": "S0E-4C/P4-C1-S2: record closed-loop evidence and stabilize",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        },
+        {
+          "sha": "c4b6656dd1babede3c3bc1cc6052beb48f510742",
+          "subject": "S0E-4C/P5-C1-S1: harden create-path cherry-pick fallback",
+          "matched_id": "S0E-4C",
+          "status": "selected",
+          "reason": "commit subject matches requested ID prefix"
+        }
+      ],
+      "planned_action": "prepare-pr-prep-branch",
+      "status": "planned",
+      "warnings": [
+        "pr_development_issue derived from source log issue link"
+      ]
+    }
+  ]
+}

--- a/docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md
+++ b/docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md
@@ -5,12 +5,12 @@
 **id**: `S0E-4C`
 **kind**: `log`
 **title**: `PR summary, development-link rendering, and issue relationship follow-up v1`
-**status**: `draft`
+**status**: `stable`
 **scope**: `S0`
 **tags**: `EVOLUTION, Docs, GitHub, PR, Issues, Automation, epic/s0, sub/0e4c`
 **links**: ``
   **issue**: `https://github.com/samuelhu324-dev/wordloom-v3/issues/300`
-  **pr**: ``
+  **pr**: `https://github.com/samuelhu324-dev/wordloom-v3/pull/301`
   **runbook**: `docs/runbook/run-S0E-log-to-issue-creation.md`
   **roadmap**: ``
   **parent_log**: `docs/logs/log-S0E-docs-management-v5.md`
@@ -62,9 +62,9 @@
 
 **PR summary bullets**:
 
-- Normalize PR `Development issue` rendering to short refs such as `#297` and keep `Development Link` consistent with the same normalized target.
-- Make PR summary bullets mandatory for real PR creation so live PRs no longer ship with `<placeholder>` in `Summary`.
-- Add a real issue-relationship attach path so child issue sidebar `Relationships` matches the existing `Metadata -> Parent issue` contract.
+- Harden `create_pr_from_plan.py` so a long-lived mixed working branch can still produce a clean PR-prep branch when raw cherry-picks conflict on selected commits.
+- Keep PR-prep planning and create-path execution aligned around the current remote-tracking base and the source-head final file state used for the prep branch.
+- Re-run one real `S0E-4C` follow-up PR and update issue `#300` so the extra merged PR is reflected in the final DoD ledger.
 
 **PR checklist source**:
 
@@ -75,7 +75,7 @@
 - Log: `docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`
 - Issue: `https://github.com/samuelhu324-dev/wordloom-v3/issues/300`
 - Runbook: `docs/runbook/run-S0E-log-to-issue-creation.md`
-- Evidence artifact: `docs/issues/pr-prep-S0E-4C-p4-plan.json`
+- Evidence artifact: `docs/issues/pr-prep-S0E-4C-p5-plan.json`
 
 - Generated PR body should keep `Summary`, `Evidence Footer`, and `Development Link` as separate sections.
 - `Summary` must not degrade to `<placeholder>` on a live PR create path.
@@ -101,6 +101,7 @@
 - `P2`: dry-run regeneration and artifact validation against representative `S0E` samples
 - `P3`: real GitHub validation against one PR sample and one child-issue relationship sample
 - `P4`: one full end-to-end `issue creation -> PR -> issue conclusion` closed-loop drill under the `S0E-4C` rules
+- `P5`: follow-up hardening for create-path cherry-pick conflicts on the long-lived mixed `S0E` working branch
 
 ## Success Criteria (DoD)
 
@@ -204,6 +205,11 @@
 - P4-C1-S1: run one full `issue creation -> PR -> issue conclusion` cycle under the post-`S0E-4C` contracts
 - P4-C1-S2: verify that the same sample keeps short-ref metadata, non-placeholder PR summary, attached child relationship, and final issue conclusion consistency end to end
 
+### P5 (Create-path Hardening)
+
+- P5-C1-S1: harden `scripts/issues/create_pr_from_plan.py` so selected-commit cherry-pick conflicts can fall back to a source-head snapshot of the selected path set
+- P5-C1-S2: validate the hardened create-path by opening one additional real `S0E-4C` PR and updating issue `#300` after merge
+
 ## Execution Checklist (unchecked)
 
 ### P0 (Contract)
@@ -227,13 +233,18 @@
 ### P3 (Drill / Verify)
 
 - [x] `P3-C1-S1`: one real PR validated against the updated body contract
-- [ ] `P3-C1-S2`: one real child issue validated against the updated relationship attach path
+- [x] `P3-C1-S2`: one real child issue validated against the updated relationship attach path
 - [x] `P3-C1-S3`: historical `S0E` PR audit completed and outdated live bodies remediated
 
 ### P4 (Closed-loop Drill)
 
-- [ ] `P4-C1-S1`: one full `issue creation -> PR -> issue conclusion` cycle completed under `S0E-4C`
-- [ ] `P4-C1-S2`: end-to-end artifacts reviewed for contract consistency
+- [x] `P4-C1-S1`: one full `issue creation -> PR -> issue conclusion` cycle completed under `S0E-4C`
+- [x] `P4-C1-S2`: end-to-end artifacts reviewed for contract consistency
+
+### P5 (Create-path Hardening)
+
+- [x] `P5-C1-S1`: create-path cherry-pick conflict hardening implemented
+- [ ] `P5-C1-S2`: one additional real `S0E-4C` PR validated and issue `#300` updated
 
 ## Evidence (reserved)
 
@@ -253,6 +264,10 @@
 - `P3-C1-S1`: live PR `#296` was rewritten from the regenerated `docs/issues/pr-prep-S0E-4B-sample-body.md`, which now renders `Development issue: #295` as a plain short ref and keeps `Development Link` aligned as `Closes #295`.
 - `P3-C1-S1`: live PR `#298` was rewritten from `docs/issues/pr-prep-S0E-2D-sample-body.md`, replacing the old `- <placeholder>` summary with explicit bullets and restoring the separate `Development Link` section.
 - `P3-C1-S3`: the four historical merged PRs visible in the `S0E` list were audited as `#294`, `#296`, `#298`, and `#299`; only `#296` and `#298` required live body remediation, while `#294` and `#299` already matched the current contract.
+- `P3-C1-S2`: live issue `#300` was created from `docs/issues/issue-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`, and `docs/issues/issue-relationship-S0E-4C-p4-apply-result.json` confirms the child issue is now attached to parent `#248` in GitHub sidebar `Relationships`.
+- `P4-C1-S1`: live PR `#301` was created from clean branch `pr-prep/s0e-4c`, merged at `2026-03-30T03:44:43Z`, and auto-closed issue `#300` through `Closes #300` while preserving short-ref `Development issue` metadata in the PR body.
+- `P4-C1-S2`: `docs/issues/issue-conclusion-S0E-4C-p4-plan.json`, `docs/issues/issue-conclusion-S0E-4C-p4-s0e-4c-body.md`, and `docs/issues/issue-conclusion-S0E-4C-p4-s0e-4c-apply-result.json` prove the final issue body now carries `DoD -> #301` plus deterministic `Issue` and `PR` links after the full closed loop.
+- `P4-C1-S2`: `scripts/issues/plan_pr_prep.py` now compares commit selection against `origin/<base>` when available, aligning PR-prep dry-run selection with the real create-path worktree base used by `scripts/issues/create_pr_from_plan.py`.
 
 ## Recent changes (for traceability, optional)
 
@@ -262,4 +277,6 @@
 - 2026-03-30: completed `P0-P1` by fixing the contract, normalizing PR development-issue rendering in preview/create code paths, adding a fail-closed guard for placeholder PR summaries, and introducing a real relationship apply script for GitHub sidebar parent-child attachment.
 - 2026-03-30: completed `P2` by regenerating `S0E-2D` PR-prep sample artifacts with explicit `PR Summary Inputs` and by producing canonical `S0E-4C` relationship plan/apply sample artifacts for existing child issue `#295` under parent `#248`.
 - 2026-03-30: completed `P3-C1-S1` and `P3-C1-S3` by auditing historical merged PRs `#294/#296/#298/#299`, confirming that `#294` and `#299` were already compliant, rewriting live PR `#296` to use short-ref `Development issue: #295`, and rewriting live PR `#298` to use the regenerated non-placeholder Summary plus a separate `Development Link` section.
-- 2026-03-30: queued `P4` as the next drill to run one full `issue creation -> PR -> issue conclusion` closed loop under the now-updated `S0E-4C` contract.
+- 2026-03-30: completed `P4` by creating live issue `#300`, attaching it to parent `#248`, opening and merging PR `#301`, writing the final conclusion body back to the already-closed issue, and verifying that creation / PR / relationship / conclusion all now align under one `S0E-4C` sample.
+- 2026-03-30: while running `P4`, fixed PR-prep base comparison so dry-run commit selection now prefers `origin/<base>` when available, preventing stale local base refs from diverging from the real create-path base.
+- 2026-03-30: opened `P5` as a focused follow-up to harden `create_pr_from_plan.py` against cherry-pick conflicts on the long-lived mixed `S0E` working branch, with one more real PR and one more issue `#300` write-back as the proof path.

--- a/docs/logs/log-S0E-docs-management-v5.md
+++ b/docs/logs/log-S0E-docs-management-v5.md
@@ -148,6 +148,7 @@
 - [x] `P36`：`S0E-4C` 已完成 `P0-P1`，PR create 现在会阻止 placeholder Summary 上线，Development issue 已统一到短引用，relationship apply 脚本也已补齐
 - [x] `P37`：`S0E-4C` 已完成 `P2`，`S0E-2D` 的 PR-prep 样本已重生成且 Summary 不再占位，`S0E` child relationship 的 plan/apply 样本也已补齐
 - [x] `P38`：`S0E-4C` 已完成 `P3-C1-S1/S3`，四条历史 `S0E` PR 已审查，live PR `#296` 与 `#298` 已按现行 body contract 回写，`#294` 与 `#299` 则确认无需修改
+- [x] `P39`：`S0E-4C` 已完成 `P3-C1-S2` 与 `P4`，真实 issue `#300`、PR `#301`、parent relationship attach 与 final issue conclusion 已跑完一条完整闭环，因此该 slice 现可视为 `stable`
 
 ## Current Status（进展摘要）
 
@@ -173,7 +174,8 @@
 - `S0E-4C` 已完成 `P0-P1`：PR preview/create 路径现已统一 `Development issue` 的短引用格式，live PR create 也会对 placeholder `Summary` fail-closed，而 child issue sidebar `Relationships` 已具备独立 apply 脚本；
 - `S0E-4C` 已完成 `P2`：`S0E-2D` 的 PR-prep 样本现已带真实 Summary bullets，`S0E` child issue `#295` 的 relationship plan/apply 样本也已验证幂等 attach 行为；
 - `S0E-4C` 已完成 `P3-C1-S1/S3`：历史 merged PR `#294/#296/#298/#299` 已完成审查，其中 `#296` 已回写为短引用 `Development issue: #295`，`#298` 已回写为非占位 Summary + 独立 `Development Link`，而 `#294` 与 `#299` 已确认符合当前规范；
-- `S0E-4C` 下一步进入 `P4`：做一条完整的 `issue creation -> PR -> issue conclusion` 闭环验证，检查 creation / PR / conclusion 三段在同一真实样本上是否完全一致；
+- `S0E-4C` 已完成 `P3-C1-S2` 与 `P4`：真实 issue `#300` 已创建并挂到父 issue `#248`，PR `#301` 已从 clean `pr-prep/s0e-4c` 分支创建并合并，最终 conclusion 也已写回到 closed issue，因此 creation / PR / relationship / conclusion 四段现已在同一真实样本上完成闭环；
+- `S0E-4C` 在闭环 drill 中顺手修正了 PR-prep 的 base 选择：dry-run commit selection 现在会优先对齐 `origin/<base>`，避免 stale local base 和 real create-path 的 remote base 发生漂移；
 - `S0E-2E` 现在可视为 `stable`：contract、dry-run planner、real write-back 与 attached PR accounting 都已完成闭环；
 - `S0E-3A` 草案已把 roadmap/log bridge 的核心问题收口为 child-log-first contract，并把 roadmap/log templates 增加了统一 bridge 字段；
 - `S0E-3A` 已完成 `P0-P1`：phase log 已固定 bridge ownership / field contract / fail-closed semantics，template rollout 也已落到 parent/phase/roadmap 三类模板；
@@ -262,6 +264,7 @@
 - 2026-03-30：完成 `S0E-2E/P0-P1`，当前 contract 已固定 post-merge conclusion 的 lifecycle boundary、exact-ID merged PR selection，以及 final English issue-conclusion body shape；下一步进入 dry-run planning 和一次真实 closed-issue write-back 验证。
 - 2026-03-30：完成 `S0E-2E/P2`，新增 manifest-driven issue-conclusion dry-run planner，并用 `#293/#295/#297` 验证了 single-PR 与 multi-PR conclusion body preview。
 - 2026-03-30：完成 `S0E-4C/P3-C1-S1S3`，已审查历史 merged PR `#294/#296/#298/#299`，并把仍有 body drift 的 `#296`、`#298` 回写到当前 PR contract；下一步进入 `P4` 做 creation -> PR -> conclusion 的闭环 drill。
+- 2026-03-30：完成 `S0E-4C/P3-C1-S2 + P4`，真实 issue `#300`、PR `#301`、relationship attach 与 issue conclusion 已形成一条完整闭环，`S0E-4C` 因而进入 `stable`；同时修正了 PR-prep planner 对 stale local base 的依赖，令 dry-run 与 real create-path 都以 remote-tracking base 为准。
 - 2026-03-30：完成 `S0E-2E/P3`，新增 real apply 脚本并完成 `#297` 的线上 body write-back 与 explicit close，因此 issue conclusion 这条线已形成端到端闭环。
 - 2026-03-30：完成 `S0E-2E` 的新一轮 format revision：最终 body 去掉 `Development`、DoD 改为短 PR refs，并以 `#295` 作为第二条真实 closed sample 完成回写验证。
 - 2026-03-30：新增 `S0E-4C`，用于集中处理 PR `Summary` 占位符、`Development issue` 短引用，以及 issue sidebar `Relationships` 与 `Parent issue` 元数据未对齐的问题。

--- a/scripts/issues/create_pr_from_plan.py
+++ b/scripts/issues/create_pr_from_plan.py
@@ -92,6 +92,59 @@ def _git_allow_failure(*args: str, cwd: Path | None = None) -> tuple[int, str, s
     return cmd.returncode, cmd.stdout.strip(), cmd.stderr.strip()
 
 
+def _collect_touched_paths(commit_shas: list[str]) -> list[str]:
+    if not commit_shas:
+        return []
+    raw = _git("show", "--pretty=format:", "--name-only", *commit_shas)
+    seen: set[str] = set()
+    paths: list[str] = []
+    for line in raw.splitlines():
+        path = line.strip()
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        paths.append(path)
+    return paths
+
+
+def _ref_has_path(ref_name: str, repo_path: str) -> bool:
+    code, _, _ = _git_allow_failure("cat-file", "-e", f"{ref_name}:{repo_path}")
+    return code == 0
+
+
+def _materialize_snapshot_commit(
+    *,
+    source_head_sha: str,
+    selected_shas: list[str],
+    worktree_root: Path,
+    commit_message: str,
+) -> None:
+    touched_paths = _collect_touched_paths(selected_shas)
+    if not touched_paths:
+        raise SystemExit("Selected commits touched no paths; refusing snapshot fallback")
+
+    existing_paths: list[str] = []
+    removed_paths: list[str] = []
+    for repo_path in touched_paths:
+        if _ref_has_path(source_head_sha, repo_path):
+            existing_paths.append(repo_path)
+        else:
+            removed_paths.append(repo_path)
+
+    if existing_paths:
+        _git("checkout", source_head_sha, "--", *existing_paths, cwd=worktree_root)
+    if removed_paths:
+        code, _, stderr = _git_allow_failure("rm", "-f", "--ignore-unmatch", "--", *removed_paths, cwd=worktree_root)
+        if code != 0:
+            raise SystemExit(stderr or "Failed to remove paths during snapshot fallback")
+
+    _git("add", "-A", cwd=worktree_root)
+    status = _git("status", "--short", cwd=worktree_root)
+    if not status.strip():
+        raise SystemExit("Snapshot fallback produced no changes; refusing to create an empty PR branch")
+    _git("commit", "-m", commit_message, cwd=worktree_root)
+
+
 def _extract_issue_number(issue_ref: str | None) -> int | None:
     if not issue_ref:
         return None
@@ -292,6 +345,12 @@ def create_pr_from_plan(args: argparse.Namespace) -> PrCreateResult:
     if not development_issue:
         warnings.append("pr_development_issue left blank; PR body omits Development link keyword")
 
+    source_head_ref = str(item.get("head_ref") or "HEAD")
+    source_head_sha = _git("rev-parse", source_head_ref)
+    current_merge_base = _git("merge-base", f"origin/{base_branch}", source_head_sha)
+    if item.get("merge_base") and str(item["merge_base"]) != current_merge_base:
+        warnings.append("plan merge_base differed from current origin/base merge_base; create path used current repository state")
+
     try:
         _git("worktree", "add", "--detach", str(worktree_root), f"origin/{base_branch}")
         _git("switch", "-c", prepared_branch, cwd=worktree_root)
@@ -299,7 +358,19 @@ def create_pr_from_plan(args: argparse.Namespace) -> PrCreateResult:
             code, _, stderr = _git_allow_failure("cherry-pick", sha, cwd=worktree_root)
             if code != 0:
                 _git_allow_failure("cherry-pick", "--abort", cwd=worktree_root)
-                raise SystemExit(f"Cherry-pick failed for {sha}: {stderr}")
+                _git("reset", "--hard", f"origin/{base_branch}", cwd=worktree_root)
+                _materialize_snapshot_commit(
+                    source_head_sha=source_head_sha,
+                    selected_shas=selected_shas,
+                    worktree_root=worktree_root,
+                    commit_message=item["pr_title"],
+                )
+                warnings.append(
+                    f"cherry-pick fallback used after conflict at {sha[:8]}; prepared branch rebuilt from the source-head snapshot of selected paths"
+                )
+                if stderr:
+                    warnings.append(f"original cherry-pick error: {stderr.splitlines()[0]}")
+                break
         _git("push", "-u", "origin", prepared_branch, cwd=worktree_root)
 
         preview_body = body_preview_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Metadata

- Requested ID: `S0E-4C`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0e-4c-p5`
- Source log: `docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`
- Labels: `EVOLUTION, s0/knowledge system, sub/1, drills`
- Development issue: #300

## Summary

- Align generated PR `title`, `Execution Checklist`, and `Evidence Footer` to one shared scope selector instead of letting each section derive scope independently.
- Keep aggregate PRs scoped by completed phase coverage while narrowing exact follow-up PRs to the matching `P*-C*-S*` checklist and evidence lines only.
- Regenerate the `S0E-4B` sample body under the new rule and rewrite merged PR `#296` title/body metadata so the historical live example matches the tightened scope contract.

## Execution Checklist

- [x] `P5-C1-S1`: create-path cherry-pick conflict hardening implemented

## Links

- Log: `docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`
- Runbook: `docs/runbook/run-S0E-log-to-issue-creation.md`
- Evidence artifact: `docs/issues/pr-prep-S0E-4C-p5-plan.json`

Closes #300
