### PR TITLE
S0E-7G/P3-C1-S1: retain workflow_dispatch representative evidence

### DIFF
--- a/.github/workflows/s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml
+++ b/.github/workflows/s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml
@@ -92,6 +92,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -113,16 +115,22 @@ jobs:
             "$S0E_WRAPPER_SELECTION_INPUT_PATH"
             --selection-input-kind "$S0E_WRAPPER_SELECTION_INPUT_KIND"
             --repo "$S0E_WRAPPER_REPO"
-            --audit-plan-path "$S0E_WRAPPER_AUDIT_PLAN_JSON"
             --remediation-plan-path "$S0E_WRAPPER_REMEDIATION_PLAN_JSON"
             --decision-path "$S0E_WRAPPER_DECISION_JSON"
-            --family-plan-path "$S0E_WRAPPER_FAMILY_PLAN_JSON"
             --thin-gate-result-path "$S0E_WRAPPER_THIN_GATE_RESULT_JSON"
             --wrapper-result-path "$S0E_WRAPPER_RESULT_JSON"
             --wrapper-summary-path "$S0E_WRAPPER_SUMMARY_MD"
             --artifact-manifest-path "$S0E_WRAPPER_MANIFEST_JSON"
             --trigger-surface workflow_dispatch
           )
+
+          if [ "$S0E_WRAPPER_SELECTION_INPUT_KIND" = "manifest" ]; then
+            WRAPPER_ARGS+=(--audit-plan-path "$S0E_WRAPPER_AUDIT_PLAN_JSON")
+          fi
+
+          if [ "$S0E_WRAPPER_OPERATION_FAMILY" != "pr-create-preflight" ] || [ "$S0E_WRAPPER_FAMILY_INPUT_KIND" != "plan" ]; then
+            WRAPPER_ARGS+=(--family-plan-path "$S0E_WRAPPER_FAMILY_PLAN_JSON")
+          fi
 
           if [ -n "$S0E_WRAPPER_FAMILY_INPUT_PATH" ]; then
             WRAPPER_ARGS+=(--family-input-path "$S0E_WRAPPER_FAMILY_INPUT_PATH")

--- a/docs/issues/publish-verify-remediation-gate-S0E-7G-p3-c1-dispatch-visibility-check.json
+++ b/docs/issues/publish-verify-remediation-gate-S0E-7G-p3-c1-dispatch-visibility-check.json
@@ -1,0 +1,36 @@
+{
+  "mode": "publish-verify-remediation-gate-workflow-dispatch-visibility-check",
+  "result": "blocked-before-dispatch",
+  "requested_id": "S0E-7G",
+  "scope": [
+    "P3"
+  ],
+  "version": "v1",
+  "workflow_path": ".github/workflows/s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml",
+  "dispatch_ref": "S0E-docs-management-v5",
+  "dispatch_inputs": {
+    "operation_family": "issue-conclusion",
+    "selection_input_path": "docs/issues/lifecycle-audit-S0E-5A-p5-pass-plan.json",
+    "selection_input_kind": "audit-plan",
+    "repo": "samuelhu324-dev/wordloom-v3",
+    "trusted_source_log_path": "docs/logs/log-S0E-7G-publish-verify-remediation-gate-workflow-dispatch-wrapper-surface.md",
+    "wrapper_notes": "S0E-7G P3 pass sample"
+  },
+  "dispatch_attempt": {
+    "tool": "gh workflow run",
+    "timestamp_utc": "2026-04-02T00:00:00Z",
+    "http_status": 404,
+    "message": "workflow s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml not found on the default branch"
+  },
+  "failure_semantics": {
+    "classification": "default-branch-visibility-blocked",
+    "stage": "dispatchability-check",
+    "owner": "GitHub workflow visibility requirement",
+    "workflow_role": "secondary enforcement"
+  },
+  "next_steps": [
+    "Publish the workflow file on the repository default branch so GitHub Actions can resolve it for workflow_dispatch.",
+    "After default-branch visibility exists, dispatch one frozen pass sample and one frozen stop sample on the target ref.",
+    "Retain the resulting run URLs and downloaded artifact references in the S0E-7G evidence ledger before marking the slice stable."
+  ]
+}

--- a/docs/issues/publish-verify-remediation-gate-S0E-7G-p3-c1-representative-validation.json
+++ b/docs/issues/publish-verify-remediation-gate-S0E-7G-p3-c1-representative-validation.json
@@ -1,0 +1,117 @@
+{
+  "mode": "publish-verify-remediation-gate-workflow-dispatch-representative-validation",
+  "result": "ok",
+  "requested_id": "S0E-7G",
+  "scope": [
+    "P3"
+  ],
+  "version": "v1",
+  "summary": {
+    "workflow_dispatch_cases": 2,
+    "pass_cases": 1,
+    "stop_cases": 1,
+    "runtime_fix_commits": 4
+  },
+  "cases": [
+    {
+      "case_id": "workflow-dispatch-pass-issue-conclusion",
+      "surface": "github-actions-workflow-dispatch",
+      "trigger_surface": "workflow_dispatch",
+      "operation_family": "issue-conclusion",
+      "validation_kind": "read-only-pass",
+      "head_sha": "f03bb7d77a9100ef4d0c13d8c8f4077e7d6d9144",
+      "run_id": 23901772523,
+      "run_url": "https://github.com/samuelhu324-dev/wordloom-v3/actions/runs/23901772523",
+      "job_url": "https://github.com/samuelhu324-dev/wordloom-v3/actions/runs/23901772523/job/69699993272",
+      "workflow_conclusion": "success",
+      "artifact": {
+        "id": 6241988140,
+        "name": "s0e-publish-verify-remediation-gate-read-only-wrapper-23901772523-1",
+        "digest": "sha256:3942581520c70371c5d1b7f53fe60e4fb62e9adeef749134fb696e521b899197"
+      },
+      "selection_input_kind": "audit-plan",
+      "selection_input_path": "docs/issues/lifecycle-audit-S0E-5A-p5-pass-plan.json",
+      "family_input_kind": null,
+      "family_input_path": null,
+      "wrapper_result": "pass",
+      "normalized_decision": "allow-apply",
+      "apply_allowed": true,
+      "delegated_apply_requested": false,
+      "delegated_apply_executed": false,
+      "stop_reason": "",
+      "stopped_before_stage": null,
+      "published_artifact_root": "artifacts/github-actions/publish-verify-remediation-gate-read-only-wrapper/23901772523-1",
+      "source_artifact_path": "artifacts/github-actions/publish-verify-remediation-gate-read-only-wrapper/23901772523-1/wrapper-result.json",
+      "notes": [
+        "The representative pass dispatch proves the GitHub-side manual wrapper can replay a frozen lifecycle-family allow path without claiming publish ownership.",
+        "The uploaded artifact root retained wrapper-result, thin-gate-result, lifecycle-gate-decision, workflow-summary, and dispatch-run-manifest before the workflow completed."
+      ]
+    },
+    {
+      "case_id": "workflow-dispatch-stop-pr-create-preflight",
+      "surface": "github-actions-workflow-dispatch",
+      "trigger_surface": "workflow_dispatch",
+      "operation_family": "pr-create-preflight",
+      "validation_kind": "planning-only-stop",
+      "head_sha": "18d6eee07e34adfc85ee34628cdafc91b713d7e8",
+      "run_id": 23902262129,
+      "run_url": "https://github.com/samuelhu324-dev/wordloom-v3/actions/runs/23902262129",
+      "job_url": "https://github.com/samuelhu324-dev/wordloom-v3/actions/runs/23902262129/job/69701697536",
+      "workflow_conclusion": "failure",
+      "artifact": {
+        "id": 6242198301,
+        "name": "s0e-publish-verify-remediation-gate-read-only-wrapper-23902262129-1",
+        "digest": "sha256:38b19ef1a8e96d02636da37581aee98391d9ddf149b4183b50b141799c97a023"
+      },
+      "selection_input_kind": "audit-plan",
+      "selection_input_path": "docs/issues/lifecycle-audit-S0E-5C-p2-stop-plan.json",
+      "family_input_kind": "plan",
+      "family_input_path": "docs/issues/pr-prep-S0E-5C-p2-stop-plan.json",
+      "wrapper_result": "stop",
+      "normalized_decision": "hard-fail-input",
+      "apply_allowed": false,
+      "delegated_apply_requested": false,
+      "delegated_apply_executed": false,
+      "stop_reason": "continuation-blocked-by-thin-gate",
+      "stopped_before_stage": "S4-local-branch-materialization",
+      "published_artifact_root": "artifacts/github-actions/publish-verify-remediation-gate-read-only-wrapper/23902262129-1",
+      "source_artifact_path": "artifacts/github-actions/publish-verify-remediation-gate-read-only-wrapper/23902262129-1/wrapper-result.json",
+      "warnings": [
+        "unexpected sections present: ['Development Link']; PR Links section contains invalid rows: ['- Issue: `https://github.com/samuelhu324-dev/wordloom-v3/issues/309`']; rendered Evidence Footer rows do not match source rows: ['- `167291fc` / `S0E-5C` / `P0`: decompose guarded PR create stages', '- `6ca0da28` / `S0E-5C` / `P1`: map guarded PR create boundaries']; Evidence Footer rows do not match the canonical line shape: ['- `167291fc` / `S0E-5C` / `P0`: decompose guarded PR create stages', '- `6ca0da28` / `S0E-5C` / `P1`: map guarded PR create boundaries']; Development Link section is no longer allowed in canonical PR bodies; GitHub closing-link footer does not match the development issue set: []"
+      ],
+      "notes": [
+        "The representative stop dispatch proves the GitHub-side manual wrapper preserves planning-only pr-create-preflight behavior and stops before S4-local-branch-materialization.",
+        "The workflow failed only after publishing summary and uploaded artifacts, matching the read-only secondary-enforcement contract."
+      ]
+    }
+  ],
+  "runtime_reconciliation": [
+    {
+      "head_sha": "f03bb7d77a9100ef4d0c13d8c8f4077e7d6d9144",
+      "change": "Only pass --audit-plan-path when selection_input_kind=manifest so frozen audit-plan replays do not violate the thin-gate contract."
+    },
+    {
+      "head_sha": "07a39d45652cef623c07869e9dde4d610ef2be63",
+      "change": "Checkout now uses fetch-depth: 0 so pr-create-preflight comparisons against origin/main are available on the GitHub runner."
+    },
+    {
+      "head_sha": "18d6eee07e34adfc85ee34628cdafc91b713d7e8",
+      "change": "The workflow no longer passes forbidden family-plan overrides when pr-create-preflight is replayed from a frozen plan input."
+    }
+  ],
+  "adoption_decision": {
+    "broader_ci_adoption_justified": false,
+    "current_recommended_surface": "manual-workflow_dispatch",
+    "reason": "The dedicated manual GitHub-side wrapper surface is now evidenced, but broader automatic CI widening would still need its own ownership and trigger-policy slice.",
+    "required_before_broader_ci": [
+      "Keep workflow_dispatch manual-only unless a later slice explicitly widens trigger policy.",
+      "Preserve delegate_apply=false, read_only=true, and secondary_enforcement=true on any broader wrapper surface.",
+      "Require representative pass and stop evidence again if any new CI trigger surface is introduced."
+    ]
+  },
+  "boundary_conclusions": [
+    "The GitHub-side manual wrapper now reuses the same wrapper result vocabulary as the shared Python wrapper and the local operator-facing surface.",
+    "The workflow uploads retained artifacts before failing on non-pass outcomes, so stop evidence survives secondary-enforcement failure semantics.",
+    "pr-create-preflight remains planning-only on the GitHub-side surface, with the stop boundary still fixed at S4-local-branch-materialization."
+  ]
+}

--- a/docs/logs/log-S0E-7G-publish-verify-remediation-gate-workflow-dispatch-wrapper-surface.md
+++ b/docs/logs/log-S0E-7G-publish-verify-remediation-gate-workflow-dispatch-wrapper-surface.md
@@ -5,7 +5,7 @@
 **id**: `S0E-7G`
 **kind**: `log`
 **title**: `workflow/publish-verify-remediation gate workflow_dispatch wrapper surface v1`
-**status**: `draft`
+**status**: `stable`
 **scope**: `S0`
 **tags**: `EVOLUTION, Docs, GitHub, Actions, Workflow, Automation, Drills, Evidence, epic/s0, sub/1`
 **links**: ``
@@ -84,6 +84,7 @@
 - `P0-C1-S1S2 / P1-C1-S1S2` | artifact: `docs/issues/publish-verify-remediation-gate-S0E-7G-p0-p1-workflow-dispatch-surface-contract.json`
 - `P2-C1-S1` | artifact: `.github/workflows/s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml`
 - `P3-C1-S1` | artifact: `docs/issues/publish-verify-remediation-gate-S0E-7G-p3-c1-representative-validation.json`
+- `P3-C1-S1` | artifact: `docs/issues/publish-verify-remediation-gate-S0E-7G-p3-c1-dispatch-visibility-check.json`
 
 ## Definitions (optional)
 
@@ -121,10 +122,10 @@
 
 ## Current Status
 
-- `S0E-7G` is now opened as the GitHub-side manual wrapper follow-up after `S0E-7F` fixed the shared wrapper, local operator-facing surface, and representative local evidence.
-- `P0-P1` are now completed at the contract layer: the repo now retains one explicit contract artifact for the GitHub-side manual wrapper boundary, request envelope, workflow-owned artifact root, and upload-before-fail policy.
-- `P2` is now completed: the repo now has one manual GitHub Actions workflow at `.github/workflows/s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml`, and that workflow now invokes the shared wrapper with `trigger_surface=workflow_dispatch`, emits workflow summary plus annotations, uploads retained artifacts, and only then fails on non-pass outcomes.
-- `P3` remains the last open unit: retain one representative pass dispatch and one representative stop dispatch before deciding whether this slice can be marked `stable`.
+- `S0E-7G` is now stable: the GitHub-side manual wrapper surface is implemented, dispatchable, and evidenced with one representative pass run plus one representative stop run.
+- `P0-P1` are completed at the contract layer: the repo retains one explicit contract artifact for the GitHub-side manual wrapper boundary, request envelope, workflow-owned artifact root, and upload-before-fail policy.
+- `P2` is completed: the repo has one manual GitHub Actions workflow at `.github/workflows/s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml`, and that workflow invokes the shared wrapper with `trigger_surface=workflow_dispatch`, emits workflow summary plus annotations, uploads retained artifacts, and only then fails on non-pass outcomes.
+- `P3` is completed: after the workflow became visible on `main`, representative `workflow_dispatch` pass/stop runs were retained on `S0E-docs-management-v5`, and the workflow surface was hardened for frozen audit-plan and frozen pr-create-preflight-plan replay on GitHub runners.
 
 ## P0 (Boundary contract | v1)
 
@@ -163,6 +164,7 @@
 
 - Retain one workflow dispatch that returns wrapper result `pass` on a frozen pass sample.
 - Retain one workflow dispatch that returns wrapper result `stop` on a frozen `pr-create-preflight` stop sample while preserving `S4-local-branch-materialization`.
+- If the workflow is not yet visible on the default branch, retain the dispatchability blocker explicitly instead of pretending representative live evidence already exists.
 
 ## Numbering
 
@@ -224,7 +226,7 @@
 
 ### P3 (Representative dispatch evidence)
 
-- [ ] `P3-C1-S1`: representative pass and stop workflow dispatches retained
+- [x] `P3-C1-S1`: representative pass and stop workflow dispatches retained
 
 ## Evidence (reserved)
 
@@ -233,7 +235,7 @@
 
 ### P0-C1-S1S2 / P1-C1-S1S2 (workflow_dispatch wrapper boundary and contract retained | 2026-04-02)
 
-- headSha: `1a923769`
+- headSha: `8492be78`
 - artifacts:
   - `docs/issues/publish-verify-remediation-gate-S0E-7G-p0-p1-workflow-dispatch-surface-contract.json`
   - `docs/logs/log-S0E-7A-github-actions-secondary-enforcement.md`
@@ -247,7 +249,7 @@
 
 ### P2-C1-S1 (Manual workflow_dispatch wrapper surface implemented | 2026-04-02)
 
-- headSha: `1a923769`
+- headSha: `8492be78`
 - artifacts:
   - `.github/workflows/s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml`
   - `scripts/issues/plan_publish_verify_remediation_gate_read_only_wrapper.py`
@@ -257,6 +259,48 @@
 - observed:
   - `.github/workflows/s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml` now accepts explicit family/input parameters, derives one per-run artifact root, invokes the shared wrapper with `trigger_surface=workflow_dispatch`, writes a retained GitHub summary plus dispatch manifest, emits check annotations, uploads the workflow-owned artifact root, and only then fails on non-pass outcomes.
   - The workflow now reuses `scripts/issues/plan_publish_verify_remediation_gate_read_only_wrapper.py` directly, so GitHub-side dispatches preserve the same wrapper result vocabulary and read-only contract already fixed in `S0E-7F`.
+
+### P3-C1-S1 (workflow_dispatch visibility check blocked before live representative runs | 2026-04-02)
+
+- headSha: `5c9c6fe3`
+- artifacts:
+  - `docs/issues/publish-verify-remediation-gate-S0E-7G-p3-c1-dispatch-visibility-check.json`
+- expected:
+  - `S0E-7G` should dispatch the new manual workflow on the active ref and then retain one pass run plus one stop run as representative live evidence.
+  - If GitHub cannot resolve the workflow yet, the repo should retain that blocker explicitly so later continuation does not confuse a visibility problem with a runtime problem inside the wrapper.
+- observed:
+  - The first `gh workflow run` attempt on ref `S0E-docs-management-v5` returned HTTP `404` with the message `workflow ... not found on the default branch`, which means the workflow implementation itself is pushed but GitHub cannot dispatch it until the file becomes visible on `main`.
+  - `docs/issues/publish-verify-remediation-gate-S0E-7G-p3-c1-dispatch-visibility-check.json` now records the attempted pass-sample inputs, the default-branch visibility blocker, and the exact next steps required before live representative pass/stop dispatches can be retained.
+
+### P3-C1-S1 (Representative workflow_dispatch pass retained | 2026-04-02)
+
+- headSha: `f03bb7d7`
+- artifacts:
+  - `docs/issues/publish-verify-remediation-gate-S0E-7G-p3-c1-representative-validation.json`
+  - `artifacts/github-actions/publish-verify-remediation-gate-read-only-wrapper/23901772523-1/wrapper-result.json`
+  - `artifacts/github-actions/publish-verify-remediation-gate-read-only-wrapper/23901772523-1/thin-gate-result.json`
+  - `artifacts/github-actions/publish-verify-remediation-gate-read-only-wrapper/23901772523-1/dispatch-run-manifest.json`
+- expected:
+  - `S0E-7G` should retain one GitHub-side manual dispatch that surfaces wrapper result `pass` on a frozen lifecycle-family allow path while keeping delegated apply disabled.
+  - The same retained run should prove that the workflow uploads a workflow-owned artifact root and completes successfully on pass outcomes.
+- observed:
+  - Run `23901772523` (`https://github.com/samuelhu324-dev/wordloom-v3/actions/runs/23901772523`) replayed `issue-conclusion` over `docs/issues/lifecycle-audit-S0E-5A-p5-pass-plan.json` and retained wrapper result `pass`, normalized decision `allow-apply`, and uploaded artifact `s0e-publish-verify-remediation-gate-read-only-wrapper-23901772523-1`.
+  - The retained pass artifacts now prove that the GitHub-side manual wrapper can surface an allow path without claiming publish ownership or enabling delegated apply inside the workflow surface.
+
+### P3-C1-S1 (Representative workflow_dispatch stop retained | 2026-04-02)
+
+- headSha: `18d6eee0`
+- artifacts:
+  - `docs/issues/publish-verify-remediation-gate-S0E-7G-p3-c1-representative-validation.json`
+  - `artifacts/github-actions/publish-verify-remediation-gate-read-only-wrapper/23902262129-1/wrapper-result.json`
+  - `artifacts/github-actions/publish-verify-remediation-gate-read-only-wrapper/23902262129-1/thin-gate-result.json`
+  - `artifacts/github-actions/publish-verify-remediation-gate-read-only-wrapper/23902262129-1/dispatch-run-manifest.json`
+- expected:
+  - `S0E-7G` should retain one GitHub-side manual dispatch that surfaces wrapper result `stop` on a frozen `pr-create-preflight` stop sample while preserving `S4-local-branch-materialization`.
+  - The same retained run should fail only after summary and artifact upload have already completed.
+- observed:
+  - Run `23902262129` (`https://github.com/samuelhu324-dev/wordloom-v3/actions/runs/23902262129`) replayed `pr-create-preflight` over `docs/issues/lifecycle-audit-S0E-5C-p2-stop-plan.json` plus the frozen precomputed family plan `docs/issues/pr-prep-S0E-5C-p2-stop-plan.json`, and retained wrapper result `stop`, normalized decision `hard-fail-input`, stop reason `continuation-blocked-by-thin-gate`, and stop boundary `S4-local-branch-materialization`.
+  - The workflow failed only in the final non-pass policy step after publishing summary and artifact upload, so the GitHub-side manual wrapper now has one representative stop run whose retained artifacts explain the planning-only create boundary.
 
 ### <Pn-Cx-Sy> (<Drill name> | YYYY-MM-DD)
 
@@ -272,3 +316,5 @@
 - 2026-04-02: opened `S0E-7G` as the manual GitHub-side `workflow_dispatch` wrapper follow-up after `S0E-7F` stabilized the shared read-only wrapper and local operator-facing surface.
 - 2026-04-02: completed `P0-P1` by retaining the first `workflow_dispatch` wrapper contract artifact, fixing GitHub-side ownership boundaries, supported inputs, workflow-owned artifact root, and upload-before-fail policy.
 - 2026-04-02: completed `P2` by adding `.github/workflows/s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml` over the shared read-only wrapper, with summary, annotations, artifact upload, and fail-after-upload behavior.
+- 2026-04-02: attempted `P3` dispatch evidence on `S0E-docs-management-v5`, but GitHub returned a default-branch visibility `404`; the blocker is now retained explicitly so live representative pass/stop dispatches can resume after the workflow becomes visible on `main`.
+- 2026-04-02: completed `P3` by hardening the workflow surface for frozen audit-plan and frozen pr-create-preflight-plan replays, then retaining one representative pass dispatch and one representative stop dispatch with traceable run URLs and uploaded artifact references.

--- a/docs/logs/log-S0E-docs-management-v5.md
+++ b/docs/logs/log-S0E-docs-management-v5.md
@@ -290,6 +290,7 @@
 - [x] `P144`：`S0E-7F` 已完成 `P3`，现在已接上本地 operator-facing PowerShell surface，并保留了一条 pass 样本和一条 stop 样本的本地 artifact-root 证据
 - [x] `P145`：`S0E-7F` 已完成 `P4` 并收口为 `stable`，现在已经保留横跨 shared wrapper 与 local operator-facing surface 的 representative validation ledger，并明确把 `workflow_dispatch` 固定为下一个 eligible widening surface
 - [x] `P146`：已新建 `S0E-7G`，并已完成 `P0-P2`，现在已经保留 GitHub-side manual wrapper contract artifact，并实现了一个 manual `workflow_dispatch` surface 来调用 shared read-only wrapper
+- [x] `P147`：`S0E-7G/P3` 已完成第一轮 dispatchability check，当前 blocker 已明确收口为“workflow 尚未在 default branch 可见”，因此 live pass/stop dispatch evidence 需等该可见性前置条件满足后继续
 
 ## Current Status（进展摘要）
 
@@ -492,6 +493,8 @@
 - 2026-04-02：`S0E-7F/P3` 已完成：本地 operator-facing PowerShell surface 已接到 shared wrapper 上，并已保留一条 pass 样本和一条 stop 样本的本地 artifact-root 证据；下一步只剩 `P4` 的 representative validation 收口或继续接到 manual `workflow_dispatch` surface。
 - 2026-04-02：`S0E-7F/P4` 已完成：现在已保留一份横跨 shared wrapper 与 local operator-facing surface 的 representative validation ledger，并明确结论为“暂不直接扩大到更广 CI adoption；下一步先做 dedicated read-only workflow_dispatch surface”。
 - 2026-04-02：已新建 `S0E-7G` 并完成 `P0-P2`：GitHub-side manual `workflow_dispatch` wrapper contract 已落地，新的 workflow surface 也已实现并接到 shared read-only wrapper；下一步只剩 representative pass/stop dispatch evidence。
+- 2026-04-02：`S0E-7G/P3` 已完成第一轮 dispatchability check：当前不是 wrapper runtime 出错，而是 GitHub 仍要求 workflow 先在 default branch 可见；因此下一步应先让该 workflow 出现在 `main`，再补 live pass/stop dispatch evidence。
+- 2026-04-02：`S0E-7G/P3` 已完成：workflow_dispatch surface 现已通过一条 representative pass run 与一条 representative stop run，且 workflow 为 frozen audit-plan / frozen pr-create-preflight-plan replay 补齐了参数与 checkout 边界；`S0E-7G` 因而进入 `stable`。
 - 2026-04-02：新增 `S0E-7E`，作为 `S0E-7D/P4` 的直接实现 follow-up，后续将把 future `publish-verify-remediation gate` 从命名 surface 落成一个薄编排入口，并复用现有 issue/relationship/PR guarded adapters。
 - 2026-03-29：完成 `S0E-2D/P1`，issue draft 生成器已切换到 enriched metadata precedence，并且不再把 source log 的中英文 bullets 直接灌进 GitHub issue body。
 - 2026-03-29：完成 `S0E-2D/P2`，`S4E-5B` 与 `S4A-1A` 的 enriched draft 样本已验证 roadmap milestone 解析与关系字段缺失时的保守留空。


### PR DESCRIPTION
## Metadata

- Requested ID: `S0E-7G`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0e-7g-p3`
- Source log: `docs/logs/log-S0E-7G-publish-verify-remediation-gate-workflow-dispatch-wrapper-surface.md`
- Labels: `EVOLUTION, s0/knowledge system, sub/1, drills`
- Development issue: #340

## Summary

- Add one manual GitHub Actions `workflow_dispatch` surface over the shared read-only publish-verify-remediation wrapper.
- Preserve `secondary enforcement` wording, wrapper-owned artifacts, and read-only failure semantics.
- Retain one representative pass dispatch and one representative stop dispatch before discussing any broader CI widening.

## Execution Checklist

- [x] `P0-C1-S1`: GitHub-side read-only wrapper ownership fixed
- [x] `P0-C1-S2`: trigger and wording boundary fixed
- [x] `P1-C1-S1`: workflow_dispatch request envelope fixed
- [x] `P1-C1-S2`: artifact upload and fail-after-upload contract fixed
- [x] `P2-C1-S1`: manual GitHub Actions wrapper surface implemented
- [x] `P3-C1-S1`: representative pass and stop workflow dispatches retained

## Links

- Log: `docs/logs/log-S0E-7G-publish-verify-remediation-gate-workflow-dispatch-wrapper-surface.md`
- Runbook: ``
- Evidence artifact: `docs/issues/publish-verify-remediation-gate-S0E-7G-p0-p1-workflow-dispatch-surface-contract.json`

Closes #340
