### PR TITLE
S0F-1F/P0-P4: bucketed audit output materialization v1

### DIFF
--- a/docs/issues/bucketed-audit-output-S0F-1F-p3-summary.json
+++ b/docs/issues/bucketed-audit-output-S0F-1F-p3-summary.json
@@ -1,0 +1,92 @@
+{
+  "mode": "s0f-1f-p3-bucketed-output-summary",
+  "result": "ok",
+  "requested_id": "S0F-1F",
+  "scope": [
+    "P3"
+  ],
+  "packaged_inputs": {
+    "live_audit_sample": "docs/issues/lifecycle-audit-S0F-1A-live-plan.json",
+    "historical_review_sample": "docs/issues/historical-log-review-S0E-7C-sample-plan.json"
+  },
+  "reviewer_rules": [
+    "Read decision-layer fields first: status and planned_action still answer whether the current item is pass, blocked, review-required, or requires reconciliation.",
+    "Read primary_bucket only when it is non-null: it is the highest-signal deterministic diagnosis bucket already justified by retained structured evidence.",
+    "Treat an empty bucket_set as intentional when the retained surface does not yet have enough deterministic evidence to attribute a lifecycle bucket; do not guess from free-text reason strings.",
+    "Use bucket_source_checks as the traceability link back to the exact retained checks that justified the emitted diagnosis bucket.",
+    "Use bucket_stage to group emitted diagnosis buckets by lifecycle owner across live and historical surfaces without reparsing bucket labels by hand."
+  ],
+  "representative_items": [
+    {
+      "sample": "live-audit-blocked-creation-gap",
+      "source": "docs/issues/lifecycle-audit-S0F-1A-live-plan.json",
+      "requested_id": "S0F-1A",
+      "owner_surface": "live-lifecycle-audit",
+      "lifecycle_stage": "issue-created",
+      "decision_layer": {
+        "status": "blocked",
+        "planned_action": "block-mutation"
+      },
+      "diagnosis_layer": {
+        "primary_bucket": "creation-sidebar-relationship-gap",
+        "bucket_set": [
+          "creation-sidebar-relationship-gap"
+        ],
+        "bucket_stage": "creation",
+        "bucket_source_checks": {
+          "creation-sidebar-relationship-gap": [
+            "sidebar-parent-relationship"
+          ]
+        }
+      },
+      "reader_interpretation": "The item is blocked for creation-stage relationship drift, and the reviewer can confirm the diagnosis directly from the emitted bucket fields without rereading the full check list first."
+    },
+    {
+      "sample": "historical-log-only-gap",
+      "source": "docs/issues/historical-log-review-S0E-7C-sample-plan.json",
+      "requested_id": "S0E-7B",
+      "owner_surface": "historical-log-review",
+      "lifecycle_stage": "log-only",
+      "decision_layer": {
+        "status": "review-required",
+        "planned_action": "open-issue-flow"
+      },
+      "diagnosis_layer": {
+        "primary_bucket": "creation-writeback-gap",
+        "bucket_set": [
+          "creation-writeback-gap"
+        ],
+        "bucket_stage": "creation",
+        "bucket_source_checks": {
+          "creation-writeback-gap": [
+            "historical-lifecycle-gap"
+          ]
+        }
+      },
+      "reader_interpretation": "The historical review surface has enough evidence to say the item never reached deterministic issue writeback, so the reviewer gets a creation-stage diagnosis bucket even though this is a supporting pre-screen surface."
+    },
+    {
+      "sample": "historical-open-issue-no-pr-yet",
+      "source": "docs/issues/historical-log-review-S0E-7C-sample-plan.json",
+      "requested_id": "S0E-5C",
+      "owner_surface": "historical-log-review",
+      "lifecycle_stage": "issue-open-no-pr",
+      "decision_layer": {
+        "status": "review-required",
+        "planned_action": "complete-pr-create"
+      },
+      "diagnosis_layer": {
+        "primary_bucket": null,
+        "bucket_set": [],
+        "bucket_stage": null,
+        "bucket_source_checks": {}
+      },
+      "reader_interpretation": "The item still needs follow-up, but the retained historical surface does not yet have enough deterministic evidence to emit a PR-owned diagnosis bucket, so an empty diagnosis layer is the correct fail-closed reading."
+    }
+  ],
+  "summary": {
+    "status": "pass",
+    "detail": "S0F-1F P3 packages one reviewer-facing bucket-output summary that points at both retained sample surfaces and fixes how reviewers should read decision-layer versus diagnosis-layer fields.",
+    "next_boundary": "P4 should package the emitted diagnosis-layer contract for downstream consumers so later tooling can depend on this summary shape rather than raw sample-specific interpretation."
+  }
+}

--- a/docs/issues/bucketed-audit-output-S0F-1F-p4-contract.json
+++ b/docs/issues/bucketed-audit-output-S0F-1F-p4-contract.json
@@ -1,0 +1,104 @@
+{
+  "mode": "s0f-1f-p4-bucketed-output-contract",
+  "result": "ok",
+  "requested_id": "S0F-1F",
+  "scope": [
+    "P4"
+  ],
+  "version": "v1",
+  "contract_owner": "emitted diagnosis-layer bucket output",
+  "upstream_artifacts": {
+    "taxonomy_source": "docs/logs/log-S0F-1E-completeness-classification-buckets-and-audit-output-taxonomy.md",
+    "live_owner_sample": "docs/issues/lifecycle-audit-S0F-1A-live-plan.json",
+    "historical_supporting_sample": "docs/issues/historical-log-review-S0E-7C-sample-plan.json",
+    "reviewer_summary": "docs/issues/bucketed-audit-output-S0F-1F-p3-summary.json"
+  },
+  "consumer_entrypoints": [
+    {
+      "surface": "live-lifecycle-audit",
+      "artifact": "docs/issues/lifecycle-audit-S0F-1A-live-plan.json",
+      "owner_role": "primary diagnosis-layer owner"
+    },
+    {
+      "surface": "historical-log-review",
+      "artifact": "docs/issues/historical-log-review-S0E-7C-sample-plan.json",
+      "owner_role": "supporting diagnosis-layer owner for deterministic historical gaps only"
+    },
+    {
+      "surface": "reviewer-summary",
+      "artifact": "docs/issues/bucketed-audit-output-S0F-1F-p3-summary.json",
+      "owner_role": "reader-facing packaged interpretation layer"
+    }
+  ],
+  "item_contract": {
+    "decision_layer_fields": [
+      "status",
+      "planned_action"
+    ],
+    "diagnosis_layer_fields": [
+      "primary_bucket",
+      "bucket_set",
+      "bucket_source_checks",
+      "bucket_stage"
+    ],
+    "field_rules": [
+      {
+        "field": "primary_bucket",
+        "type": "string|null",
+        "rule": "Must be null when the retained surface does not have enough deterministic structured evidence to justify one highest-signal diagnosis bucket."
+      },
+      {
+        "field": "bucket_set",
+        "type": "array[string]",
+        "rule": "Must contain the deduplicated emitted bucket family labels justified by retained evidence; may be empty when no deterministic attribution is allowed."
+      },
+      {
+        "field": "bucket_source_checks",
+        "type": "object<string, array[string]>",
+        "rule": "Maps each emitted bucket label to the retained check names that justified that bucket on the current owner surface."
+      },
+      {
+        "field": "bucket_stage",
+        "type": "string|null",
+        "rule": "Must equal the lifecycle owner prefix of primary_bucket when a primary bucket exists; otherwise null."
+      }
+    ]
+  },
+  "consumer_rules": [
+    "Always read decision-layer status and planned_action before diagnosis-layer fields; diagnosis output does not replace stop or allow semantics.",
+    "Treat diagnosis-layer fields as additive summaries above the retained checks array rather than as a replacement for raw audit evidence.",
+    "Do not infer a bucket from free-text reason or lifecycle_stage alone when primary_bucket is null and bucket_set is empty.",
+    "Use bucket_source_checks as the required traceability link whenever a consumer needs to explain why a diagnosis bucket was emitted.",
+    "Use bucket_stage for grouping and routing across surfaces; do not reparsed bucket prefixes ad hoc outside this contract."
+  ],
+  "cross_surface_rules": [
+    {
+      "surface": "live-lifecycle-audit",
+      "rule": "May emit the fullest diagnosis-layer attribution because it owns lifecycle-stage plus check-level completeness evidence."
+    },
+    {
+      "surface": "historical-log-review",
+      "rule": "May emit diagnosis-layer buckets only for deterministic historical review gaps that map cleanly into the fixed S0F-1E vocabulary."
+    },
+    {
+      "surface": "reviewer-summary",
+      "rule": "May restate packaged diagnosis-layer readings, but must reference retained sample artifacts instead of inventing new bucket values."
+    }
+  ],
+  "null_and_empty_semantics": {
+    "primary_bucket": "null means no diagnosis bucket may be emitted deterministically on the current surface.",
+    "bucket_set": "[] means the diagnosis layer is intentionally empty rather than missing from the artifact.",
+    "bucket_source_checks": "{} means no emitted bucket has a justified check lineage on the current surface.",
+    "bucket_stage": "null means there is no emitted primary diagnosis bucket to attribute to a lifecycle owner."
+  },
+  "compatibility_rules": [
+    "Existing decision-layer consumers may ignore diagnosis-layer fields without breaking current stop or allow behavior.",
+    "Diagnosis-layer consumers must accept both emitted and intentionally empty diagnosis fields across retained surfaces.",
+    "Future surfaces may adopt the same diagnosis-layer field names only if they preserve the same fail-closed null and empty semantics recorded here."
+  ],
+  "summary": {
+    "status": "pass",
+    "detail": "S0F-1F P4 packages one downstream-facing contract for emitted diagnosis-layer bucket output so later tooling can depend on stable field names, null semantics, and cross-surface interpretation rules.",
+    "next_boundary": "The next step after P4 is to mark S0F-1F stable if no further output-shape gaps remain, or open a follow-up slice only if a new consumer needs additional surface-specific contract rules."
+  }
+}

--- a/docs/issues/historical-log-review-S0E-7C-sample-plan.json
+++ b/docs/issues/historical-log-review-S0E-7C-sample-plan.json
@@ -27,6 +27,10 @@
       "structure_status": "pass",
       "planned_action": "none",
       "status": "pass-review",
+      "primary_bucket": null,
+      "bucket_set": [],
+      "bucket_source_checks": {},
+      "bucket_stage": null,
       "checks": [
         {
           "name": "frontmatter-required-fields",
@@ -87,6 +91,10 @@
       "structure_status": "pass",
       "planned_action": "complete-pr-create",
       "status": "review-required",
+      "primary_bucket": null,
+      "bucket_set": [],
+      "bucket_source_checks": {},
+      "bucket_stage": null,
       "checks": [
         {
           "name": "frontmatter-required-fields",
@@ -142,6 +150,16 @@
       "structure_status": "pass",
       "planned_action": "open-issue-flow",
       "status": "review-required",
+      "primary_bucket": "creation-writeback-gap",
+      "bucket_set": [
+        "creation-writeback-gap"
+      ],
+      "bucket_source_checks": {
+        "creation-writeback-gap": [
+          "historical-lifecycle-gap"
+        ]
+      },
+      "bucket_stage": "creation",
       "checks": [
         {
           "name": "frontmatter-required-fields",
@@ -172,6 +190,11 @@
           "name": "stable-contradiction",
           "status": "pass",
           "details": "stable status does not contradict the execution checklist"
+        },
+        {
+          "name": "historical-lifecycle-gap",
+          "status": "warning",
+          "details": "log has no linked issue or PR evidence yet"
         }
       ],
       "warnings": [],

--- a/docs/issues/lifecycle-audit-S0F-1A-live-plan.json
+++ b/docs/issues/lifecycle-audit-S0F-1A-live-plan.json
@@ -1,0 +1,121 @@
+{
+  "mode": "lifecycle-audit-dry-run",
+  "result": "ok",
+  "manifest_path": "docs/issues/lifecycle-audit-S0F-1A-live-manifest.json",
+  "selection_input": "manifest",
+  "operation": "plan-lifecycle-audit",
+  "total_items": 1,
+  "planned_items": 0,
+  "warnings": [
+    "S0F-1A: blocked"
+  ],
+  "items": [
+    {
+      "requested_id": "S0F-1A",
+      "source_log_path": "docs/logs/log-S0F-1A-fail-closed-entrypoints-and-preflight-unification.md",
+      "issue_number": 364,
+      "issue_url": "https://github.com/samuelhu324-dev/wordloom-v3/issues/364",
+      "issue_title": "S0F-1A: automation/fail-closed entrypoints and preflight unification",
+      "issue_state": "OPEN",
+      "lifecycle_stage": "issue-created",
+      "expected_parent_issue_number": 363,
+      "actual_parent_issue_number": null,
+      "source_log_issue_url": "https://github.com/samuelhu324-dev/wordloom-v3/issues/364",
+      "source_log_pr_url": null,
+      "merged_pr_count": 0,
+      "merged_prs": [],
+      "planned_action": "block-mutation",
+      "applied_action": null,
+      "status": "blocked",
+      "primary_bucket": "creation-sidebar-relationship-gap",
+      "bucket_set": [
+        "creation-sidebar-relationship-gap"
+      ],
+      "bucket_source_checks": {
+        "creation-sidebar-relationship-gap": [
+          "sidebar-parent-relationship"
+        ]
+      },
+      "bucket_stage": "creation",
+      "checks": [
+        {
+          "name": "source-log-issue-writeback",
+          "status": "pass",
+          "details": "source log links.issue matches the live issue URL"
+        },
+        {
+          "name": "required-body-sections",
+          "status": "pass",
+          "details": "Metadata, Context, Definition of Done (DoD), and Links sections are present"
+        },
+        {
+          "name": "issue-section-order",
+          "status": "pass",
+          "details": "issue body section order matches the canonical contract"
+        },
+        {
+          "name": "metadata-row-shape",
+          "status": "pass",
+          "details": "Metadata bullet rows are contiguous"
+        },
+        {
+          "name": "metadata-links-boundary",
+          "status": "pass",
+          "details": "Metadata keeps state rows only while deterministic log navigation stays in Links"
+        },
+        {
+          "name": "expected-labels",
+          "status": "pass",
+          "details": "live issue labels cover the deterministic label set derived from the source log"
+        },
+        {
+          "name": "body-parent-metadata",
+          "status": "pass",
+          "details": "Metadata section records Parent issue: #363"
+        },
+        {
+          "name": "sidebar-parent-relationship",
+          "status": "fail",
+          "details": "live GitHub parent relationship is None; expected #363"
+        },
+        {
+          "name": "exact-id-merged-pr-evidence",
+          "status": "skipped",
+          "details": "no merged PR evidence is required for the current issue-created stage"
+        },
+        {
+          "name": "final-dod-pr-refs",
+          "status": "skipped",
+          "details": "no final DoD PR refs are required before merged PR evidence exists"
+        },
+        {
+          "name": "link-categories",
+          "status": "pass",
+          "details": "Links section uses only allowed issue link categories"
+        },
+        {
+          "name": "links-coverage",
+          "status": "pass",
+          "details": "Links section covers the expected canonical issue-link fragments"
+        },
+        {
+          "name": "context-sentence-shape",
+          "status": "pass",
+          "details": "open issue keeps the required Context section structurally present while substantive Context prose is deferred to conclusion"
+        },
+        {
+          "name": "closed-body-shape",
+          "status": "skipped",
+          "details": "closed-body shape is not required while the issue remains open"
+        },
+        {
+          "name": "source-log-pr-link",
+          "status": "skipped",
+          "details": "source log links.pr is blank"
+        }
+      ],
+      "warnings": [],
+      "reason": "Full-auto lifecycle rerun for S0F-1A after moving substantive Context generation from create time to issue conclusion."
+    }
+  ]
+}

--- a/docs/logs/log-S0F-1F-bucketed-audit-output-materialization.md
+++ b/docs/logs/log-S0F-1F-bucketed-audit-output-materialization.md
@@ -1,0 +1,280 @@
+# log-S0F-1F (Phase 1F: bucketed audit output materialization)
+
+---
+
+**id**: `S0F-1F`
+**kind**: `log`
+**title**: `bucketed audit output materialization v1`
+**status**: `stable`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, GitHub, Workflow, Automation, Audit, Contract, Classification, Runtime, epic/s0, sub/1f`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-1E-completeness-classification-buckets-and-audit-output-taxonomy.md`
+  **reference_log_1**: `docs/logs/log-S0F-1D-creation-pr-conclusion-completeness-audit.md`
+  **reference_log_2**: `docs/logs/log-S0F-1E-completeness-classification-buckets-and-audit-output-taxonomy.md`
+**issue_keyword**: `audit`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/1f`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-04`
+**updated**: `2026-04-04`
+
+---
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-1F` is the next follow-up slice after `S0F-1E`, and it lowers the stable bucket taxonomy into emitted read-only audit output rather than leaving `primary_bucket` and `bucket_set` as conceptual contract fields only.
+- v1 should materialize deterministic bucket summaries on the real planner/audit result surfaces that already own lifecycle completeness review, starting with the live lifecycle audit entrypoint and then extending to supporting retained output packaging.
+- The first target is output materialization, not remediation logic. Review tooling should be able to consume emitted bucket fields directly from retained result bundles without re-deriving them from raw check arrays.
+- The rollout should remain additive and fail-closed: if bucket attribution cannot be determined from the existing lifecycle stage plus check evidence, the item should keep the existing decision-layer status and report no synthetic bucket guess.
+
+**Default choices (phase defaults / v1)**:
+
+- `S0F-1E` remains the canonical taxonomy source; `S0F-1F` consumes that taxonomy and fixes how it is emitted by runtime/planner output surfaces.
+- The live lifecycle audit result remains the primary owner of emitted bucket fields, because it already owns lifecycle-stage attribution and the richest check-level evidence.
+- Historical pre-screen output may adopt the same emitted diagnosis fields only after the primary live surface shape is fixed; v1 should not force both surfaces to land in the same phase if that would blur ownership.
+- Bucket materialization must be deterministic from existing machine-readable evidence such as `lifecycle_stage`, `status`, and named checks; this slice must not reintroduce prose-only classification or free-text-only diagnosis.
+- Backward compatibility remains required: existing decision-layer fields and retained check arrays stay authoritative, while emitted bucket summaries become an additive summary layer above them.
+
+## PR Summary Inputs (optional)
+
+**PR summary bullets**:
+
+- Materialize the `S0F-1E` bucket taxonomy into emitted read-only audit results so downstream consumers can read `primary_bucket` and related diagnosis fields directly.
+- Keep existing decision-layer status semantics intact while fixing a deterministic diagnosis-layer emission path on runtime/planner outputs.
+- Prepare a retained-output baseline that later review or remediation tooling can consume without reparsing raw check bundles.
+
+**PR checklist source**:
+
+- Default source: reuse this log's execution checklist for generated PR checklist blocks.
+
+**PR links**:
+
+- Log: `docs/logs/log-S0F-1F-bucketed-audit-output-materialization.md`
+- Parent log: `docs/logs/log-S0F-docs-management-v6.md`
+
+## Definitions (optional)
+
+- `materialized bucket output`: emitted diagnosis fields that are actually present in retained runtime/planner results rather than only described in docs.
+- `bucket attribution`: the deterministic mapping from lifecycle stage plus named check evidence to one `primary_bucket` and one deduplicated `bucket_set`.
+- `output owner`: the runtime/planner surface responsible for emitting bucket summaries as part of its retained result shape.
+
+## Constraints
+
+- Do not redesign the taxonomy fixed in `S0F-1E`; this slice only materializes it on real output surfaces.
+- Do not replace or weaken current decision-layer fields such as `status` or `planned_action` while adding diagnosis-layer emission.
+- Do not invent bucket guesses from prose-only evidence; if attribution is not deterministic from existing structured checks, the result must remain unbucketed rather than guessed.
+- Do not widen this slice into live mutation or remediation routing; emitted bucket output stays read-only in `S0F-1F`.
+
+## Scope
+
+- `P0`: create `S0F-1F`, wire it into the `S0F` spine, and fix the materialization boundary
+- `P1`: materialize deterministic bucket fields on the live lifecycle audit result surface
+- `P2`: extend additive bucket emission to the supporting historical pre-screen surface where attribution remains deterministic
+- `P3`: retain representative bucketed output samples and fix reviewer-facing packaging
+- `P4`: package the emitted diagnosis-layer contract for downstream consumption
+
+## Success Criteria (DoD)
+
+- At least one real retained audit/planner output emits `primary_bucket` and related diagnosis-layer fields directly.
+- Bucket emission remains backward-compatible with existing decision-layer status and check-array evidence.
+- The emitted diagnosis fields are deterministic enough that downstream tooling can consume them without reparsing check bundles.
+- Retained samples prove the bucketed output contract is no longer documentation-only.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - the primary live lifecycle audit surface emits stable diagnosis-layer bucket fields;
+  - retained samples prove the emitted output shape directly;
+  - downstream-facing packaging records how diagnosis-layer fields coexist with current decision-layer summaries.
+
+## Current Status
+
+- `S0F-1E` is now stable as the taxonomy slice: stage-local bucket families, check-to-bucket mapping, and the additive diagnosis-layer contract are fixed.
+- The next remaining gap is no longer taxonomy definition but output materialization: current retained result bundles still expose the necessary checks, yet the bucket fields themselves are not fixed as emitted runtime/planner output.
+- `S0F-1F` is now opened as the next `S0F` follow-up so that bucket taxonomy becomes a real retained output surface rather than a docs-only contract.
+- `P0` is now complete: `S0F-1F` is wired into the spine, the materialization boundary is fixed around emitted read-only output rather than taxonomy redesign, and the next follow-up is `P1` live lifecycle audit bucket emission.
+- `P1` is now complete: the live lifecycle audit result emits `primary_bucket`, `bucket_set`, `bucket_source_checks`, and `bucket_stage`, one representative retained sample now carries the emitted diagnosis-layer fields directly, and the next follow-up is `P2` supporting historical emission.
+- `P2` is now complete: the supporting historical pre-screen surface emits additive diagnosis-layer fields only for deterministic cases, the retained historical sample now carries the new fields directly, and the next follow-up is `P3` retained output packaging.
+- `P3` is now complete: one reviewer-facing bucket-output summary packages the live and historical retained samples together, output-reading expectations are fixed for diagnosis-layer consumers, and the next follow-up is `P4` downstream contract packaging.
+- `P4` is now complete: one downstream-facing diagnosis-layer contract packages stable field names, null semantics, and cross-surface consumer rules, and no further phase is currently required inside this slice.
+
+## P0 Materialization Boundary (completed)
+
+- `S0F-1F` should first fix where emitted diagnosis-layer output will live and which read-only surface owns the first implementation.
+- The primary owner should remain the live lifecycle audit result, because it already carries lifecycle-stage attribution and the most complete per-check evidence needed for deterministic bucket emission.
+- Supporting retained output surfaces may follow later, but v1 should not blur the implementation boundary by trying to land all consumers in the same first step.
+
+### P0-C1-S1 (Spine wiring fixed | v1)
+
+- `S0F-1F` is now the canonical `S0F` follow-up for turning the stable `S0F-1E` taxonomy into emitted runtime/planner output.
+- The parent `S0F` spine now points to `S0F-1F` explicitly and records it as the next child slice after `S0F-1E` stabilized the bucket vocabulary and output contract.
+
+### P0-C1-S2 (Output materialization boundary fixed | v1)
+
+- `S0F-1F` now fixes the next implementation target as emitted read-only diagnosis-layer fields on the live lifecycle audit surface rather than further taxonomy discussion.
+- `primary_bucket`, `bucket_set`, `bucket_source_checks`, and `bucket_stage` remain the target emitted fields, but this slice now fixes that they must be derived from existing structured evidence and retained directly in planner/audit output.
+- Historical pre-screen output remains a supporting follow-up surface only where attribution is still deterministic under the same taxonomy; it does not own the first materialization step.
+- The next implementation work therefore begins with live audit emission and retained sample regeneration, not with remediation routing or new free-text reasoning layers.
+
+## P1 Live Audit Emission (completed)
+
+- `S0F-1F` now lowers the `S0F-1E` taxonomy into emitted diagnosis-layer fields on the primary live lifecycle audit result surface.
+- v1 materialization stays additive: existing decision-layer status, planned action, and retained check arrays remain intact while emitted diagnosis fields summarize deterministic bucket attribution above them.
+
+### P1-C1-S1 (Deterministic bucket attribution emitted on live lifecycle audit output | v1)
+
+- `scripts/issues/plan_lifecycle_audit.py` now emits `primary_bucket`, `bucket_set`, `bucket_source_checks`, and `bucket_stage` on each retained item instead of leaving those fields as documentation-only contract language.
+- Bucket attribution now derives strictly from existing structured evidence on the live audit surface: only `fail` or `warning` checks that already have fixed stage-local ownership under `S0F-1E` may emit a diagnosis bucket.
+- v1 stays fail-closed for attribution: if the live audit surface does not have enough deterministic structured evidence to attribute a bucket, the item keeps its decision-layer result without a guessed diagnosis bucket.
+- The emitted `bucket_stage` is now the lifecycle owner implied by the retained `primary_bucket`, while `bucket_source_checks` records which named checks justified each emitted diagnosis bucket.
+
+### P1-C1-S2 (Representative live audit output sample retained with emitted diagnosis-layer fields | v1)
+
+- `docs/issues/lifecycle-audit-S0F-1A-live-plan.json` now retains a representative live lifecycle audit result with emitted diagnosis-layer fields present directly on the item.
+- The retained sample proves that the existing `blocked` decision-layer summary can coexist with emitted diagnosis-layer output, with `sidebar-parent-relationship` materializing as `creation-sidebar-relationship-gap` rather than requiring downstream consumers to re-parse the raw check list.
+- This retained output becomes the first concrete baseline for later consumers that need stable diagnosis-layer fields from live audit output rather than contract prose alone.
+
+## P2 Supporting Historical Emission (completed)
+
+- `S0F-1F` now extends additive diagnosis-layer emission to the supporting historical pre-screen surface, but only where the pre-screen result itself carries enough deterministic evidence to justify a lifecycle bucket.
+- v1 keeps live and historical semantics aligned by refusing to over-attribute: historical review may emit the same diagnosis-layer fields, but only for deterministic lifecycle gaps that map cleanly into the bucket families already fixed in `S0F-1E`.
+
+### P2-C1-S1 (Historical pre-screen output adopts additive diagnosis-layer fields where deterministic | v1)
+
+- `scripts/issues/plan_historical_log_review.py` now emits `primary_bucket`, `bucket_set`, `bucket_source_checks`, and `bucket_stage` on retained review items.
+- Historical diagnosis emission is intentionally narrower than live lifecycle audit emission: v1 only materializes buckets for deterministic historical review findings such as missing issue/PR linkage evidence or invalid evidence-footer-source structure, while leaving non-deterministic in-progress states unbucketed.
+- This keeps the supporting pre-screen additive and fail-closed: items such as `issue-open-no-pr` may still be `review-required`, but they do not emit a guessed PR bucket until the supporting surface actually has enough evidence to justify one.
+
+### P2-C1-S2 (Cross-surface diagnosis semantics aligned with the live owner | v1)
+
+- Historical pre-screen bucket labels now reuse the same stage-local vocabulary as the live owner instead of inventing a separate structure-review taxonomy.
+- A `log-only` historical item now materializes as `creation-writeback-gap`, while structurally clean but still in-progress items remain unbucketed rather than being forced into the wrong lifecycle owner.
+- `bucket_source_checks` on the supporting surface now records the deterministic historical review signal that justified the emitted bucket, which preserves traceability across live and historical result shapes.
+
+## P3 Retained Output Packaging (completed)
+
+- `S0F-1F` now packages the emitted diagnosis-layer output into one reviewer-facing retained summary rather than leaving live and historical samples as separate raw JSON entrypoints only.
+- v1 packaging is intentionally thin: it does not replace the underlying retained samples, but it gives reviewers and later consumers one stable summary surface that explains how to read decision-layer versus diagnosis-layer fields across both owners.
+
+### P3-C1-S1 (Representative emitted bucket-output samples retained | v1)
+
+- `docs/issues/bucketed-audit-output-S0F-1F-p3-summary.json` now packages both retained sample owners together: the live lifecycle audit sample and the supporting historical review sample.
+- The packaged summary preserves one emitted live blocked sample, one emitted historical log-only sample, and one intentionally unbucketed historical in-progress sample so the retained baseline covers both positive attribution and fail-closed empty-diagnosis cases.
+- This summary becomes the first single retained entrypoint for emitted bucket-output review under `S0F-1F` instead of requiring reviewers to open multiple raw sample plans and infer the comparison by hand.
+
+### P3-C1-S2 (Reviewer-facing output-reading contract fixed | v1)
+
+- The reviewer-facing summary now fixes the reading order explicitly: read decision-layer status and planned action first, then read diagnosis-layer bucket fields only when they are emitted.
+- The summary also fixes one critical interpretation rule for later consumers: an empty diagnosis layer may still be the correct output when the retained surface does not yet have enough deterministic evidence to justify stage-local attribution.
+- `bucket_source_checks` and `bucket_stage` are now documented as the two traceability handles diagnosis-layer consumers should rely on when they need to explain or group emitted buckets without reparsing raw bucket labels manually.
+
+## P4 Downstream Contract Packaging (completed)
+
+- `S0F-1F` now packages the emitted diagnosis-layer output as one downstream-facing contract instead of leaving later consumers to reconstruct the field semantics from samples and reviewer notes.
+- v1 contract packaging fixes field names, null behavior, cross-surface interpretation rules, and compatibility expectations for later diagnosis-layer consumers.
+
+### P4-C1-S1 (Emitted diagnosis-layer contract packaged for downstream consumers | v1)
+
+- `docs/issues/bucketed-audit-output-S0F-1F-p4-contract.json` now defines the stable downstream contract for `primary_bucket`, `bucket_set`, `bucket_source_checks`, and `bucket_stage` across the current retained owner surfaces.
+- The contract fixes one key fail-closed rule for downstream tooling: null or empty diagnosis-layer fields are valid contract output when a retained surface does not yet have enough deterministic structured evidence to justify attribution.
+- The contract also records the ownership split across current consumers: live lifecycle audit remains the primary diagnosis-layer owner, historical log review remains a supporting deterministic surface only, and the reviewer summary remains a packaged interpretation layer rather than a new owner.
+
+## Plan (draft)
+
+### P0 (Materialization boundary and spine wiring)
+
+- P0-C1-S1: create `S0F-1F` and wire it into the `S0F` parent spine as the next follow-up slice
+- P0-C1-S2: fix the emitted diagnosis-layer ownership boundary around live lifecycle audit output
+
+### P1 (Live audit emission)
+
+- P1-C1-S1: materialize deterministic bucket attribution on the live lifecycle audit result surface
+- P1-C1-S2: retain one representative live audit output sample carrying emitted diagnosis-layer fields
+
+### P2 (Supporting historical emission)
+
+- P2-C1-S1: extend additive bucket emission to the historical pre-screen surface where attribution remains deterministic
+- P2-C1-S2: fix any cross-surface normalization needed to keep diagnosis-layer semantics aligned with the live owner
+
+### P3 (Retained output packaging)
+
+- P3-C1-S1: retain representative emitted bucket-output samples and reviewer-facing packaging
+- P3-C1-S2: document output-reading expectations for diagnosis-layer consumers
+
+### P4 (Downstream contract packaging)
+
+- P4-C1-S1: package the emitted diagnosis-layer contract for later review or remediation consumers
+
+## Execution Checklist (unchecked)
+
+### P0 (Materialization boundary and spine wiring)
+
+- [x] `P0-C1-S1`: `S0F-1F` created and wired into the `S0F` parent spine
+- [x] `P0-C1-S2`: emitted diagnosis-layer ownership boundary fixed
+
+### P1 (Live audit emission)
+
+- [x] `P1-C1-S1`: deterministic bucket attribution materialized on live lifecycle audit output
+- [x] `P1-C1-S2`: representative live audit output sample retained with emitted diagnosis-layer fields
+
+### P2 (Supporting historical emission)
+
+- [x] `P2-C1-S1`: historical pre-screen output adopts additive diagnosis-layer fields where deterministic
+- [x] `P2-C1-S2`: cross-surface diagnosis semantics remain aligned with the live owner
+
+### P3 (Retained output packaging)
+
+- [x] `P3-C1-S1`: representative emitted bucket-output samples retained
+- [x] `P3-C1-S2`: reviewer-facing output-reading contract fixed
+
+### P4 (Downstream contract packaging)
+
+- [x] `P4-C1-S1`: emitted diagnosis-layer contract packaged for downstream consumers
+
+## Notes (optional)
+
+- `S0F-1F` is intentionally narrower than a remediation slice: it stops at emitted read-only output so later consumers can depend on real diagnosis fields first.
+- If live-surface emission exposes attribution ambiguity, this slice should tighten deterministic mapping rules instead of papering over them with guessed bucket output.
+
+## Evidence
+
+- `S0F-1E` now provides the fixed taxonomy consumed by this slice: the bucket families, check mappings, and additive diagnosis-layer contract are stable enough to materialize on real output surfaces.
+- `scripts/issues/plan_lifecycle_audit.py` remains the primary implementation anchor because it already owns lifecycle-stage attribution and the richest retained check arrays needed for deterministic bucket emission.
+- `scripts/issues/plan_historical_log_review.py` remains the supporting implementation anchor for later additive diagnosis-layer emission where structure-first pre-screen output can still map deterministically into the same taxonomy.
+- `P0-C1-S1` / `P0-C1-S2`: `docs/logs/log-S0F-1F-bucketed-audit-output-materialization.md` now fixes the implementation boundary recorded here: the slice is wired into the `S0F` spine, emitted diagnosis-layer ownership is assigned to live lifecycle audit output first, and the next follow-up is `P1` live bucket emission.
+- `P0-C1-S1`: `docs/logs/log-S0F-docs-management-v6.md` now records `S0F-1F` as the next explicit `S0F` child slice after `S0F-1E` stabilized the taxonomy contract.
+- `P1-C1-S1`: `scripts/issues/plan_lifecycle_audit.py` now emits additive diagnosis-layer bucket fields on each live lifecycle audit item, deriving bucket attribution only from existing structured check evidence and stage ownership already fixed in `S0F-1E`.
+- `P1-C1-S2`: `docs/issues/lifecycle-audit-S0F-1A-live-plan.json` now retains the first representative emitted live sample with `primary_bucket`, `bucket_set`, `bucket_source_checks`, and `bucket_stage` carried directly in the result payload.
+- `P2-C1-S1` / `P2-C1-S2`: `scripts/issues/plan_historical_log_review.py` now emits additive diagnosis-layer bucket fields on supporting historical review items, but only for deterministic lifecycle gaps that can be aligned with the `S0F-1E` vocabulary without guessing.
+- `P2-C1-S1` / `P2-C1-S2`: `docs/issues/historical-log-review-S0E-7C-sample-plan.json` now retains the updated supporting sample shape, including one `log-only` item that materializes as `creation-writeback-gap` while in-progress items remain intentionally unbucketed.
+- `P3-C1-S1` / `P3-C1-S2`: `docs/issues/bucketed-audit-output-S0F-1F-p3-summary.json` now packages the representative live and historical emitted samples into one reviewer-facing summary and fixes how diagnosis-layer consumers should interpret emitted versus intentionally empty bucket fields.
+- `P4-C1-S1`: `docs/issues/bucketed-audit-output-S0F-1F-p4-contract.json` now packages the downstream-facing emitted diagnosis-layer contract, including stable field names, null and empty semantics, cross-surface consumer rules, and compatibility expectations for later tooling.
+
+## Numbering
+
+- `S<n>`: Step.
+- `C<n>`: Cycle.
+
+**Commit / PR naming**:
+
+- `S0F-1F/P<phase>-C<cycle>-S<steps>: <summary>`, where `<steps>` can be a single step (`1`, meaning `...-S1`) or multiple consecutive steps grouped within the same phase / cycle (for example `1S2`, meaning `...-S1S2`).

--- a/docs/logs/log-S0F-docs-management-v6.md
+++ b/docs/logs/log-S0F-docs-management-v6.md
@@ -19,6 +19,11 @@
   **reference_log_3**: `docs/logs/log-S0E-7E-publish-verify-remediation-gate-thin-orchestration-entrypoint.md`
   **reference_log_4**: `docs/logs/log-S0E-7G-publish-verify-remediation-gate-workflow-dispatch-wrapper-surface.md`
   **phase_log_1**: `docs/logs/log-S0F-1A-fail-closed-entrypoints-and-preflight-unification.md`
+  **phase_log_2**: `docs/logs/log-S0F-1B-llm-authored-issue-context-generation.md`
+  **phase_log_3**: `docs/logs/log-S0F-1C-guarded-multi-item-live-mutation-remediation.md`
+  **phase_log_4**: `docs/logs/log-S0F-1D-creation-pr-conclusion-completeness-audit.md`
+  **phase_log_5**: `docs/logs/log-S0F-1E-completeness-classification-buckets-and-audit-output-taxonomy.md`
+  **phase_log_6**: `docs/logs/log-S0F-1F-bucketed-audit-output-materialization.md`
 **issue_keyword**: `automation`
 **issue_top_labels**: `EVOLUTION`
 **issue_scope_labels**: `s0/knowledge system, sub/0`
@@ -110,12 +115,16 @@
 
 - `S0F-1A`（Phase 1）：fail-closed entrypoints and preflight unification
   - 详见：`docs/logs/log-S0F-1A-fail-closed-entrypoints-and-preflight-unification.md`
-- `S0F-1B`（Phase 1B）：canonical keyword whitelist and issue-create hard gate
-  - 详见：``
-- `S0F-1C`（Phase 1C）：live mutation wrapper convergence for issue / PR families
-  - 详见：``
-- `S0F-1D`（Phase 1D）：optional GitHub Actions secondary enforcement rollout
-  - 详见：``
+- `S0F-1B`（Phase 1B）：LLM-authored issue Context generation and exact sentence-count contract
+  - 详见：`docs/logs/log-S0F-1B-llm-authored-issue-context-generation.md`
+- `S0F-1C`（Phase 1C）：guarded multi-item live mutation remediation
+  - 详见：`docs/logs/log-S0F-1C-guarded-multi-item-live-mutation-remediation.md`
+- `S0F-1D`（Phase 1D）：creation / PR / conclusion completeness audit
+  - 详见：`docs/logs/log-S0F-1D-creation-pr-conclusion-completeness-audit.md`
+- `S0F-1E`（Phase 1E）：completeness classification buckets and audit output taxonomy
+  - 详见：`docs/logs/log-S0F-1E-completeness-classification-buckets-and-audit-output-taxonomy.md`
+- `S0F-1F`（Phase 1F）：bucketed audit output materialization
+  - 详见：`docs/logs/log-S0F-1F-bucketed-audit-output-materialization.md`
 
 ## Execution Checklist（当前骨架里程碑汇总）
 
@@ -130,7 +139,23 @@
 
 - `S0F` is now opened and pushed as docs-management v6 on branch `S0F-docs-management-v6`.
 - The first active child slice `S0F-1A` is no longer just a placeholder: `P0` contract language is fixed and `P1` has already hardened the real issue creation entrypoint.
+- Child slice `S0F-1B` is now complete and stable: create-time issue bodies keep an empty `Context`, conclusion-time issue bodies use LLM-authored Context under an exact child/main sentence-count contract, and the retired deterministic Context builder surface has been removed from the shared contract module.
+- `S0F-1B` has also now proved the historical rewrite path in practice: three older closed `S6B` child issues were regenerated through the guarded conclusion remediation path, live body snapshots were retained, and the Context gate was hardened so dotted file paths inside a valid single sentence no longer cause false drift findings.
+- `S0F-1C` is now stable as the multi-item remediation slice: it retained the preview, guarded apply, and post-verify bundles, and it now exposes one operator runbook for repeatable historical remediation without reopening raw mutation entrypoints.
+- `S0F-1C/P0` is now complete: the batch-stage vocabulary is fixed, the three-stage contract is explicit, and the next follow-up is `P1` manifest shape plus preview-only sample retention.
+- `S0F-1C/P1` is now complete: one representative multi-item preview manifest and frozen audit-plan sample are retained, pre-gate stops cleanly at preview time, and the next follow-up is `P2` guarded live-apply contract plus representative apply sample retention.
+- `S0F-1C/P2` is now complete: the shared multi-item issue-conclusion manifest is applied per target through repeated family-owned guarded wrapper calls, and the next follow-up is `P3` preserve-existing post-verify plus per-target drift retention.
+- `S0F-1C/P3` is now complete: preserve-existing re-verification is retained per target after the guarded live sample, all three representative S6B items classify as clean-preserve, and the next follow-up is `P4` operator runbook plus repeatability packaging.
+- `S0F-1C/P4` is now complete: the runbook and repeatability summary are retained, and no further phase is currently required inside this slice.
+- `S0F-1D/P4` is now complete: the first stable read-only completeness package is fixed around the live lifecycle-audit entrypoint plus a compact historical pre-screen sample, and no further phase is currently required inside this slice.
+- `S0F-1E` is now stable: the bucket taxonomy is fixed across all three lifecycle stages, the additive audit-output contract is fixed, and no further phase is currently required inside this slice.
+- `S0F-1F/P0` is now complete: the next follow-up is fixed around materializing emitted diagnosis-layer bucket fields on real read-only output surfaces, and the immediate next step is `P1` live lifecycle audit bucket emission.
+- `S0F-1F/P1` is now complete: the primary live lifecycle audit surface emits additive diagnosis-layer bucket fields directly in retained output, one representative live sample is retained with emitted bucket data, and the next follow-up is `P2` supporting historical emission.
+- `S0F-1F/P2` is now complete: the supporting historical pre-screen surface emits additive diagnosis-layer fields for deterministic cases, one representative historical sample is retained with emitted bucket data, and the next follow-up is `P3` retained output packaging.
+- `S0F-1F/P3` is now complete: one reviewer-facing retained summary now packages live and historical emitted bucket-output samples together, diagnosis-layer reading rules are fixed, and the next follow-up is `P4` downstream contract packaging.
+- `S0F-1F/P4` is now complete: one downstream-facing diagnosis-layer contract packages stable field names, null semantics, and cross-surface consumer rules, and no further phase is currently required inside this slice.
 - The retained evidence now shows four hard boundaries in action: draft-generation still works while real `create-issue` stops on inferred keyword, PR preview planning still works while real `create_pr_from_plan.py` refuses to continue from a stop-state front-half preflight result, raw family apply scripts now fail closed unless they are invoked through the canonical guarded surfaces, and GitHub Actions surfaces are explicitly narrowed back to optional secondary enforcement after local contract ownership is already fixed.
+- The corrected live rerun for `S0F-1A` now reaches the entire closed loop under the updated contract: create keeps `Context` structurally present but empty, PR `#365` merged successfully, and issue `#364` concluded through the guarded issue-conclusion surface after a targeted conclusion-owned remediation handoff.
 
 ## Evidence（可选，聚合型记账）
 
@@ -205,6 +230,22 @@
   - `S0F-1A` now retains one explicit boundary artifact that classifies the thin gate and guarded local wrappers as the primary mutation boundary while classifying both audited GitHub workflows as secondary enforcement only
   - the read-only wrapper dispatch workflow now records `secondary_enforcement=true`, `local_primary_boundary=true`, and `publish_owner=local fail-closed family entrypoint` in its retained run manifest
   - the PR body mirror workflow now records `trigger_surface=workflow_dispatch`, `local_primary_boundary=true`, and a post-publish-only role note in its retained manifest while preserving attribution-stop semantics before mirror verification
+
+### S0F-1B (historical Context refresh and post-review hardening sample | 2026-04-04)
+
+- artifacts:
+  - `docs/logs/log-S0F-1B-llm-authored-issue-context-generation.md`
+  - `docs/issues/issue-conclusion-S0F-1B-p5-live-summary.json`
+  - `docs/issues/issue-conclusion-S0F-1B-p5-s6b-1a-live.json`
+  - `docs/issues/issue-conclusion-S0F-1B-p5-s6b-1b-live.json`
+  - `docs/issues/issue-conclusion-S0F-1B-p5-s6b-1c-live.json`
+- expected:
+  - the new LLM-authored Context contract should not remain only a sample-path improvement; it should also be able to replace historical deterministic Context bodies on already-closed issues through the guarded conclusion remediation path
+  - post-refresh verification should preserve the rewritten Context blocks without false failures caused by dotted file paths or compressed one-item LLM output
+- observed:
+  - `S6B-1A/#357`, `S6B-1B/#358`, and `S6B-1C/#359` were rewritten in place through the guarded issue-conclusion remediation path, and the retained live snapshots now show natural Context prose instead of the earlier deterministic template family
+  - `issue_context_llm.py` now normalizes compressed one-item multi-sentence `lines` output into exact sentence rows, and `body_contract.py` now detects real sentence boundaries instead of treating dotted file paths as multiple sentences
+  - the retained `S0F-1B` summary artifact records both the representative preview files and the post-refresh verification artifacts, so this slice now covers not just contract design but also historical live rewrite proof
 
 ## Notes（落地原则，可选）
 

--- a/scripts/issues/plan_historical_log_review.py
+++ b/scripts/issues/plan_historical_log_review.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from gen_issue_draft import (
@@ -57,6 +57,10 @@ class HistoricalLogReviewItem:
     status: str
     checks: list[ReviewCheck]
     warnings: list[str]
+    primary_bucket: str | None = None
+    bucket_set: list[str] = field(default_factory=list)
+    bucket_source_checks: dict[str, list[str]] = field(default_factory=dict)
+    bucket_stage: str | None = None
     reason: str | None = None
 
 
@@ -280,6 +284,44 @@ def _classify_item(
     return "pr-closed-unmerged", "manual-reconcile", "review-required", "linked PR is closed without merge evidence"
 
 
+def _build_historical_lifecycle_gap_check(lifecycle_stage: str, reason: str | None) -> ReviewCheck | None:
+    if lifecycle_stage == "log-only":
+        return ReviewCheck("historical-lifecycle-gap", "warning", reason or "log has no linked issue or PR evidence yet")
+    if lifecycle_stage == "issue-closed-no-pr":
+        return ReviewCheck("historical-lifecycle-gap", "warning", reason or "issue is closed without linked PR evidence")
+    if lifecycle_stage == "pr-merged-no-issue":
+        return ReviewCheck("historical-lifecycle-gap", "warning", reason or "merged PR exists but issue linkage is missing")
+    return None
+
+
+def _derive_historical_bucket_summary(checks: list[ReviewCheck], lifecycle_stage: str) -> tuple[str | None, list[str], dict[str, list[str]], str | None]:
+    bucket_source_checks: dict[str, list[str]] = {}
+
+    for check in checks:
+        bucket: str | None = None
+        if check.name == "evidence-footer-source-shape" and check.status == "fail":
+            bucket = "pr-evidence-footer-gap"
+        elif check.name == "historical-lifecycle-gap":
+            if lifecycle_stage == "log-only":
+                bucket = "creation-writeback-gap"
+            elif lifecycle_stage == "issue-closed-no-pr":
+                bucket = "conclusion-pr-evidence-gap"
+            elif lifecycle_stage == "pr-merged-no-issue":
+                bucket = "pr-development-linkage-gap"
+
+        if not bucket:
+            continue
+
+        bucket_checks = bucket_source_checks.setdefault(bucket, [])
+        if check.name not in bucket_checks:
+            bucket_checks.append(check.name)
+
+    bucket_set = list(bucket_source_checks.keys())
+    primary_bucket = bucket_set[0] if bucket_set else None
+    bucket_stage = primary_bucket.split("-", 1)[0] if primary_bucket else None
+    return primary_bucket, bucket_set, bucket_source_checks, bucket_stage
+
+
 def _error_item(log_path: str, requested_id: str, detail: str) -> HistoricalLogReviewItem:
     return HistoricalLogReviewItem(
         requested_id=requested_id,
@@ -298,6 +340,10 @@ def _error_item(log_path: str, requested_id: str, detail: str) -> HistoricalLogR
         status="error",
         checks=[ReviewCheck("item-load", "fail", detail)],
         warnings=[],
+        primary_bucket=None,
+        bucket_set=[],
+        bucket_source_checks={},
+        bucket_stage=None,
         reason=detail,
     )
 
@@ -367,6 +413,12 @@ def _build_item(item: dict, defaults: dict, repo_root: Path, repo: str | None, s
         pr_merged_at=pr_merged_at,
     )
 
+    lifecycle_gap_check = _build_historical_lifecycle_gap_check(lifecycle_stage, reason)
+    if lifecycle_gap_check is not None:
+        checks.append(lifecycle_gap_check)
+
+    primary_bucket, bucket_set, bucket_source_checks, bucket_stage = _derive_historical_bucket_summary(checks, lifecycle_stage)
+
     return HistoricalLogReviewItem(
         requested_id=requested_id,
         source_log_path=source_log_path,
@@ -384,6 +436,10 @@ def _build_item(item: dict, defaults: dict, repo_root: Path, repo: str | None, s
         status=item_status,
         checks=checks,
         warnings=warnings,
+        primary_bucket=primary_bucket,
+        bucket_set=bucket_set,
+        bucket_source_checks=bucket_source_checks,
+        bucket_stage=bucket_stage,
         reason=reason,
     )
 

--- a/scripts/issues/plan_lifecycle_audit.py
+++ b/scripts/issues/plan_lifecycle_audit.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import re
 import sys
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from body_contract import ISSUE_ALLOWED_LINK_LABELS, build_canonical_issue_link_lines, bullets_are_contiguous, extract_section_order, issue_body_context_line_bounds, issue_uses_parent_body_contract, link_labels_are_allowed, metadata_contains_parent_issue_row, metadata_contains_source_log_row, ordered_parent_child_issue_refs, parse_issue_number, validate_issue_context_lines
@@ -66,6 +66,10 @@ class LifecycleAuditPlanItem:
     status: str
     checks: list[AuditCheck]
     warnings: list[str]
+    primary_bucket: str | None = None
+    bucket_set: list[str] = field(default_factory=list)
+    bucket_source_checks: dict[str, list[str]] = field(default_factory=dict)
+    bucket_stage: str | None = None
     reason: str | None = None
 
 
@@ -404,6 +408,73 @@ def _build_planned_action(status: str) -> str:
     return "error-audit-input"
 
 
+def _is_conclusion_owned_stage(lifecycle_stage: str | None) -> bool:
+    return lifecycle_stage in {"merged-open", "concluded"}
+
+
+def _bucket_for_check(check_name: str, check_status: str, lifecycle_stage: str | None) -> str | None:
+    if check_status not in {"fail", "warning"}:
+        return None
+
+    if check_name == "expected-labels":
+        return None if _is_conclusion_owned_stage(lifecycle_stage) else "creation-metadata-gap"
+
+    if check_name == "body-parent-metadata":
+        return "conclusion-body-shape-gap" if _is_conclusion_owned_stage(lifecycle_stage) else "creation-metadata-gap"
+
+    if check_name == "sidebar-parent-relationship":
+        return "conclusion-sidebar-relationship-gap" if _is_conclusion_owned_stage(lifecycle_stage) else "creation-sidebar-relationship-gap"
+
+    if check_name == "sidebar-child-relationships":
+        return "conclusion-sidebar-relationship-gap" if _is_conclusion_owned_stage(lifecycle_stage) else None
+
+    if check_name == "source-log-issue-writeback":
+        return "conclusion-writeback-gap" if _is_conclusion_owned_stage(lifecycle_stage) else "creation-writeback-gap"
+
+    if check_name in {"required-body-sections", "issue-section-order", "metadata-row-shape"}:
+        return "conclusion-body-shape-gap" if _is_conclusion_owned_stage(lifecycle_stage) else "creation-body-shape-gap"
+
+    if check_name in {"metadata-links-boundary", "link-categories", "links-coverage"}:
+        return "conclusion-links-gap" if _is_conclusion_owned_stage(lifecycle_stage) else "creation-links-gap"
+
+    if check_name == "context-sentence-shape":
+        return "conclusion-context-gap" if _is_conclusion_owned_stage(lifecycle_stage) else "creation-timing-gap"
+
+    if check_name == "closed-body-shape":
+        return "conclusion-body-shape-gap" if _is_conclusion_owned_stage(lifecycle_stage) else None
+
+    if check_name == "parent-child-dod-ordering":
+        return "conclusion-dod-gap" if _is_conclusion_owned_stage(lifecycle_stage) else None
+
+    if check_name == "final-dod-pr-refs":
+        return "conclusion-dod-gap" if _is_conclusion_owned_stage(lifecycle_stage) else None
+
+    if check_name in {"exact-id-merged-pr-evidence", "source-log-pr-link"}:
+        return "conclusion-pr-evidence-gap" if _is_conclusion_owned_stage(lifecycle_stage) else None
+
+    return None
+
+
+def _derive_bucket_summary(checks: list[AuditCheck], lifecycle_stage: str | None) -> tuple[str | None, list[str], dict[str, list[str]], str | None]:
+    bucket_source_checks: dict[str, list[str]] = {}
+    ranked_checks = sorted(
+        enumerate(checks),
+        key=lambda item: (0 if item[1].status == "fail" else 1, item[0]),
+    )
+    for _, check in ranked_checks:
+        bucket = _bucket_for_check(check.name, check.status, lifecycle_stage)
+        if not bucket:
+            continue
+        bucket_checks = bucket_source_checks.setdefault(bucket, [])
+        if check.name not in bucket_checks:
+            bucket_checks.append(check.name)
+
+    bucket_set = list(bucket_source_checks.keys())
+    primary_bucket = bucket_set[0] if bucket_set else None
+    bucket_stage = primary_bucket.split("-", 1)[0] if primary_bucket else None
+    return primary_bucket, bucket_set, bucket_source_checks, bucket_stage
+
+
 def _classify_stage(issue_state: str, merged_prs: list[MergedPrEvidence], source_log_pr_url: str | None, link_lines: list[str]) -> str:
     if issue_state == "CLOSED":
         return "concluded"
@@ -485,6 +556,10 @@ def _build_item(item: dict, defaults: dict, repo_root: Path, repo: str) -> Lifec
             planned_action="error-missing-issue-reference",
             applied_action=None,
             status="error",
+            primary_bucket=None,
+            bucket_set=[],
+            bucket_source_checks={},
+            bucket_stage=None,
             checks=[],
             warnings=warnings + ["explicit issue reference is required or source log links.issue must be populated"],
             reason=item.get("reason"),
@@ -508,6 +583,10 @@ def _build_item(item: dict, defaults: dict, repo_root: Path, repo: str) -> Lifec
             planned_action="reconcile-audit-input",
             applied_action=None,
             status="reconciliation",
+            primary_bucket=None,
+            bucket_set=[],
+            bucket_source_checks={},
+            bucket_stage=None,
             checks=[],
             warnings=warnings,
             reason=item.get("reason"),
@@ -727,6 +806,8 @@ def _build_item(item: dict, defaults: dict, repo_root: Path, repo: str) -> Lifec
     else:
         status = "pass"
 
+    primary_bucket, bucket_set, bucket_source_checks, bucket_stage = _derive_bucket_summary(checks, lifecycle_stage)
+
     return LifecycleAuditPlanItem(
         requested_id=requested_id,
         source_log_path=_repo_rel(source_log_path),
@@ -744,6 +825,10 @@ def _build_item(item: dict, defaults: dict, repo_root: Path, repo: str) -> Lifec
         planned_action=_build_planned_action(status),
         applied_action=None,
         status=status,
+        primary_bucket=primary_bucket,
+        bucket_set=bucket_set,
+        bucket_source_checks=bucket_source_checks,
+        bucket_stage=bucket_stage,
         checks=checks,
         warnings=warnings,
         reason=item.get("reason"),


### PR DESCRIPTION
## Metadata

- Requested ID: `S0F-1F`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0f-1f`
- Source log: `docs/logs/log-S0F-1F-bucketed-audit-output-materialization.md`
- Labels: `EVOLUTION, s0/knowledge system, sub/1f, drills`
- Development issue: #370

## Summary

- Materialize the `S0F-1E` bucket taxonomy into emitted read-only audit results so downstream consumers can read `primary_bucket` and related diagnosis fields directly.
- Keep existing decision-layer status semantics intact while fixing a deterministic diagnosis-layer emission path on runtime/planner outputs.
- Prepare a retained-output baseline that later review or remediation tooling can consume without reparsing raw check bundles.

## Execution Checklist

- [x] `P0-C1-S1`: `S0F-1F` created and wired into the `S0F` parent spine
- [x] `P0-C1-S2`: emitted diagnosis-layer ownership boundary fixed
- [x] `P1-C1-S1`: deterministic bucket attribution materialized on live lifecycle audit output
- [x] `P1-C1-S2`: representative live audit output sample retained with emitted diagnosis-layer fields
- [x] `P2-C1-S1`: historical pre-screen output adopts additive diagnosis-layer fields where deterministic
- [x] `P2-C1-S2`: cross-surface diagnosis semantics remain aligned with the live owner
- [x] `P3-C1-S1`: representative emitted bucket-output samples retained
- [x] `P3-C1-S2`: reviewer-facing output-reading contract fixed
- [x] `P4-C1-S1`: emitted diagnosis-layer contract packaged for downstream consumers
- [x] `P4-C1-S2`: future local scratch-output families default to ignored `docs/issues` patterns or `artifacts/`
- [x] `P4-C1-S3`: screenshot1-era local `docs/issues` experiment outputs attributed back to `S0F-1F` as post-stabilization bookkeeping

## Links

- Log: `docs/logs/log-S0F-1F-bucketed-audit-output-materialization.md`
- Parent log: `docs/logs/log-S0F-docs-management-v6.md`

Closes #370
