### PR TITLE
S0F-3J/P0-P4: old GC cleanup candidate selection after DOC reader stabilization v1

### DIFF
--- a/docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md
+++ b/docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md
@@ -1,0 +1,450 @@
+# log-S0F-3J (Phase 3J: old GC cleanup candidate selection after DOC reader stabilization)
+
+---
+
+**id**: `S0F-3J`
+**kind**: `log`
+**title**: `old GC cleanup candidate selection after DOC reader stabilization v1`
+**status**: `stable`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Governance, Cleanup, GC, epic/s0, sub/3j`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-4F-doc-reader-surface-consolidation-after-first-promotion-quartet.md`
+  **reference_log_1**: `docs/logs/log-S0F-4D-doc-current-contract-surface-and-legacy-gc-triage-model.md`
+  **reference_log_2**: `docs/logs/log-S0F-3G-governance-cleanup-staging-and-phased-file-cleanup.md`
+  **reference_log_3**: `docs/governance/views/view-gc-triage-and-retention-rule-v1.md`
+  **reference_log_4**: `docs/governance/views/view-gc-first-cleanup-boundary-v1.md`
+  **reference_log_5**: `docs/governance/views/view-gc-dual-reading-transition-v1.md`
+  **reference_log_6**: `docs/governance/INDEX.md`
+  **reference_log_7**: `docs/governance/contracts/support-only/INDEX.md`
+  **reference_log_8**: `docs/logs/log-S0F-4F-doc-reader-surface-consolidation-after-first-promotion-quartet.md`
+  **reference_log_9**: `docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md`
+**issue_keyword**: `governance`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/3`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-08`
+**updated**: `2026-04-08`
+
+---
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-3J` opens the next bounded follow-up after `S0F-4F` stabilized the `DOC` reader surfaces, because the repo can now evaluate old `GC-*` cleanup candidates without reopening whether `DOC` current reading is already settled.
+- v1 fixes one cleanup-entry principle:
+  - do not reopen the already-adjudicated keep set from the first old-`GC-*` cleanup boundary
+  - do not move files merely because they are old or deprecated
+  - only consider a file as a new cleanup candidate when it has already lost both `current narrow-registry` standing and root-path redirect duty
+- Under this model, `S0F-3J` is a candidate-selection and bounded-cleanup-admission lane first, not a mass relocation lane.
+
+**Default choices (phase defaults / v1)**:
+
+- Reuse the three-bucket triage rule directly:
+  - `current narrow-registry`
+  - `legacy redirect`
+  - `support-only history or backtrace`
+- Keep the first already-adjudicated boundary unchanged unless one new contradiction is found in source:
+  - `GC-ISS-0001` through `GC-ISS-0005`
+  - `GC-PRB-0001`
+  - `GC-PRB-0001-backfill-historical-drift-fail-on-findings.md`
+- Prefer one explicit candidate subset over a broad inventory of every old `GC-*` file in the repo.
+- Do not execute a support-only relocation merely because a file looks redundant; the candidate must first satisfy the standing-loss and redirect-loss rule explicitly.
+- Keep the stable close-out discipline explicit for this slice: the six outlets must be answered during the final round even when the correct result is mostly justified `no-op`.
+
+## PR Summary Inputs (optional)
+
+- Use this block because `S0F-3J` is expected to define the first post-`DOC`-stabilization old-`GC-*` cleanup candidate package.
+
+**PR summary bullets**:
+
+- Select the next admissible old-`GC-*` cleanup candidate subset after `DOC` reader stabilization.
+- Apply the existing triage and first-boundary rules instead of reopening already-defended keep-versus-root decisions.
+- Keep six-outlet close-out evaluation explicit so cleanup admission, relocation, and retained-log ownership do not blur together.
+
+**PR checklist source**:
+
+- Default source: reuse this log's execution checklist for the first bounded old-`GC-*` cleanup candidate-selection package after `DOC` reader stabilization.
+
+**PR links**:
+
+- Log: `docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md`
+- Previous log: `docs/logs/log-S0F-4F-doc-reader-surface-consolidation-after-first-promotion-quartet.md`
+- GC triage rule: `docs/governance/views/view-gc-triage-and-retention-rule-v1.md`
+- First cleanup boundary: `docs/governance/views/view-gc-first-cleanup-boundary-v1.md`
+
+**Evidence Footer Source**:
+
+- `P0-C1-S1S2S3` | artifact: `docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md`
+
+## Exported Sections / Outlet Ownership
+
+- Use this block to keep cleanup admission, relocation decisions, retained reader notes, and strong-structure log ownership separated explicitly.
+- This slice must answer `contract / runbook / view / index/front-door / disposition/placement / log-retained core` explicitly during the final stable round; justified `no-op` is valid.
+- The presence of six outlets here does not authorize six new files automatically.
+
+**Outlet ownership**:
+
+- `contract`: only if one stable old-namespace cleanup rule changes beyond the already-published triage and first-boundary views
+- `runbook`: only if this slice stabilizes one reusable old-`GC-*` cleanup operator procedure beyond one bounded candidate package
+- `view`: one bounded candidate-inventory or standing-summary surface only if later readers would materially benefit from it
+- `index/front-door`: only the current navigation surfaces or support-only index mutations needed if a real cleanup candidate is executed
+- `disposition/placement`: the actual keep / redirect / support-only standing decision for the selected candidate subset
+- `log-retained core`: candidate-selection reasoning, evidence, no-op justification, stop rules, and close-out answers that must remain here
+
+## Definitions (optional)
+
+- **cleanup candidate**: an old `GC-*` file or bounded subset that appears eligible for support-only relocation or similar cleanup because current-registry and redirect duties may both be gone
+- **root-path redirect duty**: the continuing reader value of leaving an old file at the contracts root so old IDs still land on the intended redirect surface
+- **candidate-selection lane**: a bounded slice that first proves one subset is admissible for cleanup before any broader move round is considered
+
+## Constraints
+
+- Do not reopen the `DOC` reader-surface wording settled in `S0F-4F`.
+- Do not reopen the already-defended keep set in `view-gc-first-cleanup-boundary-v1.md` unless source ownership now contradicts that boundary.
+- Do not move files based on age, deprecation alone, or directory tidiness.
+- Do not let the six-outlet block degenerate into a matrix-completion exercise; explicit `no-op` is valid when the slice does not justify a new outlet file.
+
+## Scope
+
+- `P0`: open `S0F-3J`, fix the cleanup-candidate admission boundary, and wire the new slice into the parent spine
+- `P1`: inventory the next plausible old-`GC-*` candidate subset against the standing-loss and redirect-loss rule
+- `P2`: adjudicate whether that subset is truly admissible for cleanup and what minimal standing change would be warranted
+- `P3`: package the bounded outcome, including any support-only move, retain-in-root decision, or explicit stop result
+- `P4`: run the explicit six-outlet evaluation and close-out decision for the bounded cleanup candidate package
+
+## Success Criteria (DoD)
+
+- One reader can explain why the selected old-`GC-*` candidate subset is admissible or not admissible for cleanup without reopening the whole old-namespace inventory.
+- One reader can explain why the first already-adjudicated keep set is not being reopened mechanically.
+- One reader can explain the six-outlet answer for this cleanup candidate lane without assuming every outlet must produce a new file.
+- The repo has one bounded next-step lane for old-`GC-*` cleanup after `DOC` stabilization.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - one bounded old-`GC-*` candidate subset has been evaluated against the standing-loss and redirect-loss rule
+  - any resulting keep / move / stop decision is explicit enough to defend
+  - the six-outlet close-out answers are explicit enough that later cleanup work does not need to reopen outlet ownership first
+
+## P0 (Contract | v1)
+
+### P0-C1-S1 (Cleanup-candidate admission rule fixed | v1)
+
+- `S0F-3J` is now opened as the first bounded old-`GC-*` cleanup candidate lane after `DOC` reader stabilization.
+- A file is not a cleanup candidate here merely because it is old or deprecated.
+- The admission question is narrower: has the file already lost both current-registry standing and root-path redirect duty?
+
+### P0-C1-S2 (Already-defended keep set excluded from re-entry | v1)
+
+- This slice does not reopen the first already-adjudicated old-`GC-*` boundary.
+- The following files remain outside this lane's default candidate pool unless one source contradiction is proven later:
+  - `GC-ISS-0001`
+  - `GC-ISS-0002`
+  - `GC-ISS-0003`
+  - `GC-ISS-0004`
+  - `GC-ISS-0005`
+  - `GC-PRB-0001`
+  - `GC-PRB-0001-backfill-historical-drift-fail-on-findings.md`
+
+### P0-C1-S3 (Six-outlet close-out requirement fixed for this lane | v1)
+
+- This lane should carry the explicit six-outlet evaluation block through its final stable round.
+- The required final-round question is not `which six files get created?`
+- The required question is `what is the explicit answer for contract / runbook / view / index/front-door / disposition/placement / log-retained core for this cleanup candidate package?`
+
+## P1 (Candidate subset inventory | v1)
+
+### P1-C1-S1 (Standing-loss inventory completed for the next plausible old-GC subset | v1)
+
+- `docs/governance/INDEX.md` still admits only the current narrow-registry rows under the newer area set (`ATTR`, `COMPL`, `ICL`, `ICR`, `ICT`, `IID`, `PRA`, `PRG`, `PRR`, `REMED`, `WF`), so the old root-level `GC-*` files outside that front door are easy to enumerate directly.
+- A root scan of `docs/governance/contracts/` shows only one non-current old-namespace residue set beyond the active registry rows:
+  - `GC-ISS-0001` through `GC-ISS-0005`
+  - `GC-PRB-0001`
+- That residue set is exactly the already-adjudicated first cleanup boundary, not a newly discovered post-`DOC`-stabilization candidate pool.
+- The already-relocated `GC-PRB-0001-backfill-historical-drift-fail-on-findings.md` remains in `docs/governance/contracts/support-only/` and therefore does not reopen as a new root-level candidate subset here.
+- Result for `P1-C1-S1`:
+  - no new plausible old-`GC-*` candidate subset currently exists outside the already-defended keep set
+  - `S0F-3J` therefore carries forward one explicit null-inventory result instead of manufacturing a cleanup candidate from file age or deprecated status alone
+
+### P1-C1-S2 (Root-path redirect-duty inventory completed for the same subset | v1)
+
+- The old `GC-ISS-*` split-package view still says to keep all old `GC-ISS-*` file paths in place and to keep those old record IDs valid as preserved historical redirect records.
+- The old `GC-PRB-0001` split-package view still says the deprecated umbrella file remains preserved on disk while current meaning is read through `GC-PRR-0001` and `GC-PRG-0001`.
+- The old-`GC-*` retention rule and first cleanup boundary still say the same thing operationally:
+  - `GC-ISS-*` and `GC-PRB-0001` remain `legacy redirect` files at the contracts root
+  - they should not be proposed again merely because they are deprecated
+- Because the only non-current residue set still carries explicit redirect and lineage duty across the published views, this slice cannot yet prove redirect-loss for any new subset.
+- Result for `P1-C1-S2`:
+  - no selected subset currently satisfies `standing-loss + redirect-loss`
+  - the clean input to `P2` is therefore an adjudication of explicit `no new admissible candidate yet`, not a relocation package
+
+## P2 (Cleanup adjudication | v1)
+
+### P2-C1-S1 (Admissibility adjudicated from the null-inventory result | v1)
+
+- The adjudication target for this round is no longer `which residue file should move next?`
+- The actual adjudication target is `does the repo currently prove one post-boundary old-GC subset that has already lost both current-registry standing and root-path redirect duty?`
+- Based on `P1`, the answer remains `no`:
+  - no root-level old-`GC-*` subset exists outside the already-defended keep boundary
+  - the only non-current residue set still carries published redirect or lineage duty
+  - no source contradiction has been found that would reopen the first cleanup boundary
+- Result for `P2-C1-S1`:
+  - no currently selected subset is admissible for cleanup under the standing-loss plus redirect-loss rule
+  - `S0F-3J` therefore advances on an explicit null adjudication rather than on a deferred or ambiguous maybe-candidate
+
+### P2-C1-S2 (Minimum defended result fixed as stop-with-explicit-no-op | v1)
+
+- The minimum defended result for this round is not `move-to-support-only`, because no admissible subset has been proven.
+- The minimum defended result is also not a fresh `keep-in-root` package, because the only relevant root-level residue set was already defended by the first cleanup boundary and is not being reopened here.
+- The correct bounded result for this slice is therefore:
+  - `stop-with-explicit-no-op` for post-`DOC`-stabilization old-`GC-*` cleanup admission at the current repo state
+  - keep the first already-defended boundary unchanged
+  - permit a future cleanup re-entry only if one later source change proves that some old root path has actually lost redirect duty in addition to current-registry standing
+- Result for `P2-C1-S2`:
+  - `S0F-3J` now has one defended minimum outcome for the current repo state
+  - the next round can package this stop result cleanly instead of pretending there is an unfinished relocation package waiting to run
+
+## P3 (Bounded cleanup package | v1)
+
+### P3-C1-S1 (Bounded stop package written for the current repo state | v1)
+
+- `S0F-3J` does not end in a support-only relocation packet, because this slice never proved one admissible cleanup subset.
+- `S0F-3J` also does not reopen the first keep-legacy boundary, because that question is already defended elsewhere and no contradiction has been found here.
+- The bounded package written by this phase is therefore a stop package with one narrow meaning:
+  - post-`DOC`-stabilization old-`GC-*` cleanup admission was rechecked
+  - the current repo state still yields no new admissible subset
+  - the correct immediate package outcome is explicit `no-op`, not deferred ambiguity
+- This preserves the lane as a useful governance checkpoint rather than leaving it as a half-open discovery round.
+
+### P3-C1-S2 (Retained reader notes and stop rules fixed for later re-entry | v1)
+
+- The retained reader note for this slice is now explicit:
+  - later readers should treat `S0F-3J` as the post-`DOC`-stabilization confirmation that the first old-`GC-*` cleanup boundary still holds unchanged
+  - they should not infer from this lane that old root-level residue automatically becomes support-only once family-first reading stabilizes
+- The stop rule for later re-entry is also explicit:
+  - do not reopen this lane merely because the same deprecated files still exist at root
+  - reopen only if one later source change proves that an old root-level `GC-*` path no longer provides redirect or lineage value
+  - if that happens, open a new bounded follow-up from the changed source state rather than mutating `S0F-3J` into a retroactive relocation lane
+- Result for `P3-C1-S2`:
+  - retained reader guidance and future stop rules now live inside this lane
+  - `P4` can now answer the six outlets from a fully packaged stop result rather than from a still-fluid adjudication state
+
+## P4 (Six-outlet evaluation | v1)
+
+### P4-C1-S1 (Six-outlet answer fixed for the bounded stop package | v1)
+
+- `contract`:
+  - answer: `no-op`
+  - reason: `no stable current rule changed`
+  - explanation: `S0F-3J` does not create or modify a new cleanup rule beyond the already-published triage and first-boundary views; it only confirms that those stable rules still yield no new admissible candidate
+- `runbook`:
+  - answer: `no-op`
+  - reason: `procedure not repeatable beyond this package`
+  - explanation: this slice does not stabilize a new reusable operator sequence; it records one bounded adjudication that the current repo state still stops before relocation
+- `view`:
+  - answer: `no-op`
+  - reason: `full log is already the most efficient reader surface`
+  - explanation: one extra candidate-summary view would mostly restate the same stop result already expressed compactly in this lane and in the existing boundary views
+- `index/front-door`:
+  - answer: `no-op`
+  - reason: `no current navigation changed`
+  - explanation: no root file moved, no support-only index row changed, and no governance front door needs updated landing guidance because the defended outcome is explicit stop
+- `disposition/placement`:
+  - answer: `no-op`
+  - reason: `role export not settled yet`
+  - explanation: no new subset reached relocation eligibility, so there is no new keep / move / placement mutation to export from this lane
+- `log-retained core`:
+  - answer: `retain`
+  - reason: `log still owns slice-local bridge and evidence`
+  - explanation: candidate inventory, null adjudication, stop-package reasoning, future re-entry rules, and close-out answers belong here as the strong-structure ledger for this bounded stop result
+
+### P4-C1-S2 (No bounded export tail warranted; slice marked stable | v1)
+
+- `S0F-3J` does not need one additional bounded export tail.
+- Reason:
+  - the six-outlet review is effectively one retained-log result plus justified `no-op` across the other outlets
+  - no further export package is needed to update a contract, runbook, view, index, or placement surface
+  - the lane's current reader job is already complete once the stop result and re-entry rules are explicit
+- Stable result:
+  - `S0F-3J` is now `stable`
+  - the post-`DOC`-stabilization old-`GC-*` cleanup re-entry question is now answered for the current repo state: no new admissible cleanup subset exists, no relocation package is warranted, and future re-entry requires new source evidence of redirect-loss
+
+## Numbering
+
+- `S<n>`: Step.
+- `C<n>`: Cycle.
+
+**Commit / PR naming**:
+
+- `<ID>/P<phase>-C<cycle>-S<steps>: <summary>`, where `<steps>` can be a single step (`1`, meaning `...-S1`) or multiple consecutive steps grouped within the same phase / cycle (for example `1S2`, meaning `...-S1S2`).
+- When one PR aggregates multiple whole phases, the PR title should compress the phase set instead of repeating every commit unit:
+  - consecutive phases: `<ID>/P0-P3: <log title>`
+  - discontinuous phases: `<ID>/P0+P3: <log title>`
+  - mixed discontinuous + consecutive phases: `<ID>/P0+P3-P4: <log title>`
+- When the PR is a non-one-shot follow-up that carries a specific incremental unit, prefer the exact commit-style unit in the title: `<ID>/P*-C*-S*: <one-sentence summary>`.
+
+## Plan (draft)
+
+### P1 (Candidate subset inventory)
+
+- P1-C1-S1: inventory the next plausible old-`GC-*` candidate subset that may have lost current-registry standing
+- P1-C1-S2: inventory whether the same subset has also lost root-path redirect duty
+
+### P2 (Cleanup adjudication)
+
+- P2-C1-S1: decide whether the selected subset is admissible for cleanup under the standing-loss plus redirect-loss rule
+- P2-C1-S2: decide the minimum defended result: keep-in-root, move-to-support-only, or stop-with-explicit-no-op
+
+### P3 (Bounded cleanup package)
+
+- P3-C1-S1: package the bounded outcome and required write-backs for the selected subset
+- P3-C1-S2: fix retained reader notes and stop rules for anything explicitly left outside the package
+
+### P4 (Six-outlet evaluation)
+
+- P4-C1-S1: answer `contract / runbook / view / index/front-door / disposition/placement / log-retained core` explicitly for the cleanup candidate package
+- P4-C1-S2: decide whether any extra bounded export tail is warranted after the cleanup candidate package closes
+
+## Execution Checklist (unchecked)
+
+### P0 (Contract)
+
+- [x] `P0-C1-S1`: cleanup-candidate admission rule fixed
+- [x] `P0-C1-S2`: already-defended keep set excluded from re-entry
+- [x] `P0-C1-S3`: six-outlet close-out requirement fixed for this lane
+
+### P1 (Candidate subset inventory)
+
+- [x] `P1-C1-S1`: next plausible old-`GC-*` candidate subset inventoried for standing-loss
+- [x] `P1-C1-S2`: root-path redirect duty inventoried for the same subset
+
+### P2 (Cleanup adjudication)
+
+- [x] `P2-C1-S1`: admissibility decided for the selected subset
+- [x] `P2-C1-S2`: minimum defended result fixed
+
+### P3 (Bounded cleanup package)
+
+- [x] `P3-C1-S1`: bounded cleanup package or explicit stop package written
+- [x] `P3-C1-S2`: retained reader notes and stop rules fixed
+
+### P4 (Six-outlet evaluation)
+
+- [x] `P4-C1-S1`: six-outlet answer fixed for the cleanup candidate package
+- [x] `P4-C1-S2`: bounded follow-up or no-tail result fixed
+
+## Current Status
+
+- `S0F-3J` is now opened as the next bounded follow-up after `S0F-4F`: `DOC` current reading is stable enough that old `GC-*` cleanup can now be evaluated without reopening `DOC` reader-surface wording.
+- `P0` is now complete: the cleanup-candidate admission rule, the excluded already-defended keep set, and the explicit six-outlet close-out requirement are now fixed.
+- `P1` is now complete: the inventory shows that the only old root-level `GC-*` residue outside the current narrow registry is still the already-defended `GC-ISS-*` plus `GC-PRB-0001` redirect set, so no new admissible cleanup candidate subset has been found yet.
+- `P2` is now complete: the null-inventory result is now adjudicated explicitly, and the minimum defended result for the current repo state is `stop-with-explicit-no-op` rather than a fresh relocation or keep-in-root package.
+- `P3` is now complete: this lane is now packaged as one bounded stop result with retained reader notes and explicit re-entry rules, rather than as a latent relocation package.
+- `P4` is now complete: the six outlets are now answered explicitly, no bounded export tail is warranted, and `S0F-3J` is now stable as the defended post-`DOC`-stabilization stop result for old-`GC-*` cleanup admission.
+- There is no immediate follow-up required inside `S0F-3J`; any later cleanup re-entry should open a new bounded slice only if future source changes prove redirect-loss for one old root-level `GC-*` path.
+
+## Evidence (reserved)
+
+- Artifacts are the source of truth for evidence; this log records the head SHA, key parameters, and artifact paths (or CI run URLs).
+- This section is the human-facing ledger and should remain separate from `Evidence Footer Source`.
+
+### P0-C1-S1 through P0-C1-S3 (old-GC cleanup candidate lane opened after DOC reader stabilization | 2026-04-08)
+
+- headSha: `85d7ed2f2cdd0fdf08b72bbfb24fcf036373c9be`
+- artifacts:
+  - `docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to explain why old-`GC-*` cleanup now reopens as one bounded candidate-selection lane instead of as a broad move round or a second `DOC` wording slice
+- observed:
+  - `S0F-3J` now fixes the cleanup-candidate admission rule, excludes the already-defended keep set from default re-entry, and carries the explicit six-outlet close-out requirement into the new cleanup lane from the start
+
+### P1-C1-S1 through P1-C1-S2 (candidate inventory yields no new admissible old-GC subset | 2026-04-08)
+
+- headSha: `a2096440519912e22c84442457b0f8945ecd64a1`
+- artifacts:
+  - `docs/governance/INDEX.md`
+  - `docs/governance/contracts/support-only/INDEX.md`
+  - `docs/governance/views/view-gc-first-cleanup-boundary-v1.md`
+  - `docs/governance/views/view-gc-dual-reading-transition-v1.md`
+  - `docs/governance/views/view-iss-split-package-v1.md`
+  - `docs/governance/views/view-prb-split-package-v1.md`
+  - `docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to explain whether any post-`DOC`-stabilization old-`GC-*` subset now satisfies the admission question without reopening the already-defended keep set mechanically
+- observed:
+  - the only old root-level `GC-*` residue outside the current narrow registry is still the previously defended `GC-ISS-*` plus `GC-PRB-0001` redirect set
+  - published split-package, triage, and boundary views still assign redirect or lineage value to that whole residue set
+  - no newly admissible cleanup subset is currently proven by source
+
+### P2-C1-S1 through P2-C1-S2 (null inventory adjudicated as explicit stop-with-no-op | 2026-04-08)
+
+- headSha: `9a4b44b0224a9ffe8aaaaa23189d02c2b349566b`
+- artifacts:
+  - `docs/governance/views/view-gc-first-cleanup-boundary-v1.md`
+  - `docs/governance/views/view-gc-triage-and-retention-rule-v1.md`
+  - `docs/governance/views/view-iss-split-package-v1.md`
+  - `docs/governance/views/view-prb-split-package-v1.md`
+  - `docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to explain whether `S0F-3J` currently owns a real cleanup move package or instead owns an explicit stop decision grounded in the published standing and redirect rules
+- observed:
+  - no currently selected old-`GC-*` subset is admissible for cleanup under the standing-loss plus redirect-loss test
+  - the first already-defended keep boundary remains intact without contradiction
+  - the minimum defended result for the current repo state is `stop-with-explicit-no-op`
+
+### P3-C1-S1 through P3-C1-S2 (bounded stop package and re-entry rules fixed | 2026-04-08)
+
+- headSha: `1d1fabf1b76cea2106cb82e9ed260a1f9ec6b2f2`
+- artifacts:
+  - `docs/governance/views/view-gc-first-cleanup-boundary-v1.md`
+  - `docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to explain the bounded package owned by `S0F-3J` without mistaking it for either a hidden relocation round or a reopened first cleanup boundary
+- observed:
+  - `S0F-3J` now packages the current repo-state result as an explicit stop-with-no-op package
+  - retained reader guidance now states that family-first stabilization alone does not dissolve old root-level redirect value
+  - later re-entry is now gated on one future source change that proves redirect-loss, not on repeated re-scanning of the same deprecated files
+
+### P4-C1-S1 through P4-C1-S2 (six-outlet close-out completed; no export tail required | 2026-04-08)
+
+- headSha: `8aa3f10b7848515e60d785727768b40481b72037`
+- artifacts:
+  - `docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to explain the six-outlet result for `S0F-3J` without assuming that a stable cleanup lane must emit new contract, view, index, or placement files
+- observed:
+  - the correct close-out result is one retained-log package plus justified `no-op` across `contract`, `runbook`, `view`, `index/front-door`, and `disposition/placement`
+  - no bounded export tail is warranted after the close-out review
+  - `S0F-3J` now satisfies its stable criteria as a defended stop package
+
+## Recent changes (for traceability, optional)
+
+- 2026-04-08: opened `S0F-3J` as the next bounded old-`GC-*` cleanup candidate-selection lane after `DOC` reader stabilization, fixed the admission boundary, excluded the already-defended keep set from default re-entry, and fixed the six-outlet close-out requirement for the lane.
+- 2026-04-08: completed `P1` inventory and recorded the current null result: no new old-`GC-*` subset outside the already-defended keep set can yet prove both standing-loss and redirect-loss, so the next round should adjudicate an explicit no-op or stop package rather than force a relocation candidate.
+- 2026-04-08: completed `P2` adjudication and fixed the minimum defended result as `stop-with-explicit-no-op`, because no post-boundary old-`GC-*` subset is currently proven admissible for cleanup.
+- 2026-04-08: completed `P3` packaging and fixed the retained reader notes plus future re-entry stop rules, so this lane now owns one bounded stop package rather than one incomplete relocation placeholder.
+- 2026-04-08: completed `P4` six-outlet close-out, concluded that no bounded export tail is warranted, and marked `S0F-3J` stable as the defended no-op stop package for the current old-`GC-*` cleanup state.


### PR DESCRIPTION
## Metadata

- Requested ID: `S0F-3J`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0f-3j`
- Source log: `docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md`
- Labels: `EVOLUTION, s0/knowledge system, drills`
- Development issue: #421

## Summary

- Select the next admissible old-`GC-*` cleanup candidate subset after `DOC` reader stabilization.
- Apply the existing triage and first-boundary rules instead of reopening already-defended keep-versus-root decisions.
- Keep six-outlet close-out evaluation explicit so cleanup admission, relocation, and retained-log ownership do not blur together.

## Execution Checklist

- [x] `P0-C1-S1`: cleanup-candidate admission rule fixed
- [x] `P0-C1-S2`: already-defended keep set excluded from re-entry
- [x] `P0-C1-S3`: six-outlet close-out requirement fixed for this lane
- [x] `P1-C1-S1`: next plausible old-`GC-*` candidate subset inventoried for standing-loss
- [x] `P1-C1-S2`: root-path redirect duty inventoried for the same subset
- [x] `P2-C1-S1`: admissibility decided for the selected subset
- [x] `P2-C1-S2`: minimum defended result fixed
- [x] `P3-C1-S1`: bounded cleanup package or explicit stop package written
- [x] `P3-C1-S2`: retained reader notes and stop rules fixed
- [x] `P4-C1-S1`: six-outlet answer fixed for the cleanup candidate package
- [x] `P4-C1-S2`: bounded follow-up or no-tail result fixed

## Links

- Log: `docs/logs/log-S0F-3J-old-gc-cleanup-candidate-selection-after-doc-reader-stabilization.md`

Closes #421
