### PR TITLE
S0F-5A/P0-P5: stable-first close-out protocol and post-stable outlet export v1

### DIFF
--- a/docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md
+++ b/docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md
@@ -1,0 +1,446 @@
+# log-S0F-5A (Phase 5A: stable-first close-out protocol and post-stable outlet export)
+
+---
+
+**id**: `S0F-5A`
+**kind**: `log`
+**title**: `stable-first close-out protocol and post-stable outlet export v1`
+**status**: `stable`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Governance, Workflow, Closeout, Runbook, Contract, Views, epic/s0, sub/5a`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-4D-doc-current-contract-surface-and-legacy-gc-triage-model.md`
+  **reference_log_1**: `docs/logs/log-S0F-4A-document-role-boundaries-writeback-protocol-and-disposition-model.md`
+  **reference_log_2**: `docs/logs/log-S0F-3H-recurring-governance-run-model-and-ledger-split.md`
+  **reference_log_3**: `docs/logs/log-S0F-4B-source-log-compatibility-and-weak-structure-export-discipline.md`
+  **reference_log_4**: `docs/logs/log-S0F-4D-doc-current-contract-surface-and-legacy-gc-triage-model.md`
+**issue_keyword**: `governance`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/5`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-08`
+**updated**: `2026-04-08`
+
+---
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-5A` opens the next bounded follow-up after `S0F-4D` to fix one missing operating rule above the six-outlet model: when a slice should stay concentrated in its source log during draft iteration, and when it should export stable material into `contract`, `runbook`, `view`, `index/front-door`, and disposition write-backs.
+- This slice exists because the repo already has:
+  - one six-outlet role model in `S0F-4A`
+  - one recurring-run packaging model in `S0F-3H`
+  - one weak-structure compatibility boundary in `S0F-4B`
+- But the repo still lacks one explicit `stable-first` close-out rule that answers three practical questions together:
+  - why draft logs should usually not trigger broad outlet export too early
+  - when a stable log should open a post-stable export step instead of carrying long-term mixed responsibility
+  - when exporting nothing is the correct answer because no stable target outlet is justified yet
+
+**Default choices (phase defaults / v1)**:
+
+- Do not require every draft log to export six outlets while its boundary is still moving.
+- Do not require every stable log to produce all six outlets mechanically.
+- Treat `stable` as the normal decision gate for close-out review unless a narrower stable surface was already separated earlier by explicit bounded choice.
+- Prefer one explicit post-stable export step or follow-up phase over many incremental draft-stage write-backs that churn multiple files repeatedly.
+- Do not update the parent or phase-log templates from `P1` alone; template hardening should wait until the close-out questionnaire and export-packaging rules are explicit enough to avoid baking half-settled guidance into authoring scaffolds.
+- A stable log should answer the full close-out questionnaire, but the result may legitimately be:
+  - export one or two outlets only
+  - rewrite only the log and one front door
+  - or export nothing yet because the supposed target outlet still lacks stable identity
+
+## Problem Statement
+
+- `S0F-4A` already explains the six outlet roles and the export order.
+- `S0F-3H` already explains why stable recurring procedure should move toward runbook or packet surfaces instead of staying in one ever-growing log.
+- `S0F-4B` already protects the source-log family from being replaced by a premature outlet-first authoring format.
+- The missing piece is a timing and trigger rule:
+  - when should one slice stop iterating inside the draft source log and start exporting stable material?
+  - should every stable slice open one fixed `Pn+1` style export pass?
+  - how should the repo avoid both extremes:
+    - premature runbook or view proliferation during draft churn
+    - never-exported mixed-role logs that remain overloaded after the slice is already stable
+
+## Scope
+
+- `P0`: open `S0F-5A`, wire the new slice into the parent spine, and fix the problem as `stable-first close-out protocol` work rather than immediate contract promotion work
+- `P1`: define the `stable-first` gate for outlet export, including when draft slices should stay concentrated in the source log
+- `P2`: define the mandatory post-stable close-out questionnaire and the allowed answers when some outlets are intentionally no-op
+- `P3`: define the default export packaging rule, including when a stable slice should use one bounded follow-up phase such as `Pn+1` rather than scattered draft-stage writes
+- `P4`: define the no-proliferation rule for `runbook`, `view`, and other outlets so stable close-out does not become a mechanical file explosion
+- `P5`: pilot the protocol on a recent stable governance lane and determine whether later `DOC` promotion slices such as a future `S0F-4E` should use this close-out pattern directly
+
+## Success Criteria (DoD)
+
+- One reader can explain why draft logs normally remain concentrated during active iteration.
+- One reader can explain why `stable` is the normal gate for export review, not a signal that every possible outlet must now be created.
+- One reader can explain when a stable slice should open one bounded post-stable export step instead of spreading write-backs across the draft period.
+- One reader can explain why `runbook` extraction depends on stable repeated procedure rather than on the mere presence of operational prose inside a log.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - the stable-first gate, the mandatory close-out questionnaire, the post-stable export packaging rule, and the anti-proliferation gates are all explicit enough to reuse without reopening their semantics first
+  - the parent and phase-log templates already carry the converged close-out guidance
+  - at least one recent stable governance lane has been piloted successfully against the protocol and yields a clear answer for whether a later `DOC` promotion slice should use this pattern directly
+
+## P0 (Scaffold | v1)
+
+### P0-C1-S1 (Problem boundary fixed | v1)
+
+- `S0F-5A` is now opened to fix `stable-first close-out protocol` as a repo operating rule.
+- This slice does not yet promote `DOC-AREA-0001` bodies.
+- That later promotion lane should follow after the close-out trigger and export discipline are explicit enough to avoid reopening timing and file-churn debates during the first real `DOC` promotion.
+
+### P0-C1-S2 (Default sequencing fixed | v1)
+
+- The current recommended sequence is now:
+  - first finish `S0F-5A`
+  - then open `S0F-4E` for the first real `DOC` promoted contract body
+- This keeps the close-out trigger, export timing, and anti-proliferation rule ahead of the first real `DOC-...` contract extraction.
+
+## P1 (Stable-first gate | v1)
+
+### P1-C1-S1 (Draft-stage concentration rule fixed | v1)
+
+- During active draft iteration, the source log remains the default concentration surface when any of the following is still moving materially:
+  - the problem boundary or owned question
+  - the current rule or successor rule text
+  - the stable operator sequence
+  - the reader-facing summary shape
+  - the front-door mutation or placement consequence
+- Under this rule, draft slices should usually avoid broad outlet export because repeated multi-file write-backs during active boundary churn create unstable `runbook`, `view`, or `contract` surfaces too early.
+- Early export is allowed only when a narrower stable surface is already explicit and bounded enough that later draft changes will not repeatedly reopen that outlet.
+
+### P1-C1-S2 (Stable-entry close-out gate fixed | v1)
+
+- A slice enters formal close-out review when both of these become true:
+  - its primary semantic or operational question is already converged enough that later work is mostly packaging, export, or bounded consequence handling rather than redefinition
+  - one reader can explain the slice-local answer and the remaining next step without needing draft-only reconstruction across many scattered edits
+- `stable` is therefore the normal export-review gate, not a command to emit every possible outlet.
+- The required next action at that gate is: answer the close-out questionnaire explicitly and then decide whether the correct result is `export`, `partial export`, `log-only retention`, or `defer because target outlet identity is still not stable`.
+- Template hardening is not part of this `P1` gate; it should follow later once the mandatory questionnaire and post-stable export packaging rules are fixed.
+
+## P2 (Mandatory close-out questionnaire | v1)
+
+### P2-C1-S1 (Mandatory outlet questions fixed | v1)
+
+- Every stable slice entering close-out review must answer the following questions explicitly:
+  - `contract`: did this slice define or materially change one stable current rule that should now read outside the log?
+  - `runbook`: did this slice stabilize one repeatable operator procedure with durable steps, stop rules, and verification expectations?
+  - `view`: did this slice produce one bounded reader-facing summary that would save later readers from replaying the full ledger?
+  - `index/front-door`: did this slice change current navigation, directory entrypoints, or current-reader landing guidance?
+  - `disposition/placement`: did this slice change standing or physical placement only after the relevant stable role exports were already settled?
+  - `log-retained core`: what must remain in the source log as slice-local decision record, evidence ledger, bridge notes, and automation-facing strong structure even after any exports?
+- These questions must be answered outlet by outlet.
+- A stable slice is not allowed to skip the questionnaire by asserting only that it is `done` or `stable`.
+
+### P2-C1-S2 (Allowed no-op answers fixed | v1)
+
+- The close-out questionnaire may legitimately return `no-op` for any outlet, but the reason must be explicit and low-cardinality.
+- The first allowed no-op result set is:
+  - `no stable current rule changed`:
+    - do not export a new or changed `contract`
+  - `procedure not repeatable beyond this package`:
+    - do not export a `runbook`
+  - `full log is already the most efficient reader surface`:
+    - do not export a `view`
+  - `no current navigation changed`:
+    - do not touch `index/front-door`
+  - `role export not settled yet`:
+    - do not write `disposition/placement` changes yet
+  - `log still owns slice-local bridge and evidence`:
+    - retain the source log as the primary ledger
+- The stable reviewer question is therefore not `did every outlet get a file?`
+- The correct question is `did every outlet receive an explicit answer, including justified no-op where export is not warranted?`
+
+## P3 (Post-stable export packaging | v1)
+
+### P3-C1-S1 (`Pn+1` style export packaging rule fixed | v1)
+
+- After a slice reaches the stable-entry close-out gate and completes the mandatory questionnaire, the default export packaging decision is:
+  - use one bounded post-stable follow-up phase such as `Pn+1` when the remaining work is primarily outlet export, write-back, thinning, or placement consequence handling rather than new semantic exploration
+- Prefer one bounded `Pn+1` style export phase when all of the following are true:
+  - the slice-local question is already converged
+  - the remaining work touches more than one outlet or more than one retained file
+  - the repo needs one auditable package for export ordering, no-op justification, and consequence write-backs
+  - repeated draft-stage multi-file updates would otherwise obscure the close-out boundary
+- Do not force a `Pn+1` export phase when either of these is true:
+  - the correct questionnaire result is effectively all no-op except retained log status
+  - one already-bounded follow-up slice exists and is the more reader-meaningful owner for the remaining work
+- The purpose of `Pn+1` is therefore not to create one mandatory extra phase for every stable slice.
+- Its purpose is to package post-stable export work into one defended bounded unit when export is real work rather than a tiny tail edit.
+
+### P3-C1-S2 (Minimum write-back set and stop rule fixed | v1)
+
+- When a stable slice does open one bounded post-stable export phase, the minimum write-back set is:
+  - update or create each outlet explicitly approved by the close-out questionnaire
+  - rewrite the source log so it keeps only retained strong structure, evidence, and bridge notes for the exported material
+  - update the relevant `index/front-door` only when current navigation changed
+  - update `disposition/placement` only after role export is already settled
+  - write one concise parent-spine status line describing the export package outcome
+- The export package may also write one consequence update into an origin control slice, but only when the package changes that slice's still-open standing, blocker, or cleanup state.
+- Stop the export package immediately when any of the following becomes true:
+  - the supposed target outlet still lacks stable identity
+  - one export would force the repo to invent a new reader surface only to satisfy the matrix mechanically
+  - role ownership becomes ambiguous again during the package
+  - the package starts introducing new semantic design rather than exporting already-stable meaning
+- If the stop rule triggers, the correct result is to keep the retained log as the temporary home and open a later bounded slice for the missing stable target rather than faking completion through premature outlet creation.
+
+## P4 (Anti-proliferation rule | v1)
+
+### P4-C1-S1 (Runbook extraction gate fixed | v1)
+
+- Export a `runbook` only when all of the following are true:
+  - the slice stabilizes one repeatable operator procedure beyond this single package
+  - ordered steps, stop rules, and verification expectations are stable enough to survive later reuse
+  - the procedure can be described without replaying one specific candidate inventory, one-off blocker set, or one historical execution narrative
+- Do not export a `runbook` when any of the following is true:
+  - the procedure is still bound to one narrow package and is not expected to repeat
+  - the steps are still changing materially with the semantics of the slice itself
+  - the source log remains the clearest place to explain the bounded execution without inventing a second operator surface
+- Operational prose inside a log is therefore not sufficient by itself to justify a `runbook`.
+- The extraction gate is repeatability plus stable operator identity, not mere presence of steps.
+
+### P4-C1-S2 (View and summary extraction gate fixed | v1)
+
+- Export a `view` only when all of the following are true:
+  - later readers would materially benefit from one bounded reader-facing summary instead of replaying the full source log
+  - the summary has a stable reading job such as family interpretation, current-versus-legacy status, lineage map, or compact outcome table
+  - the summary does not simply duplicate stable meaning already owned by `contract` or stable procedure already owned by `runbook`
+- Do not export a `view` when any of the following is true:
+  - the retained source log is already the most efficient reader surface
+  - the proposed summary would mostly restate the same content in shorter prose without adding a distinct reading role
+  - the summary exists only to satisfy the six-outlet matrix mechanically
+- The correct no-op answer for `view` is therefore common and legitimate.
+- `view` extraction requires a durable reader job, not just a desire to shorten one finished log.
+
+### P4-C1-S3 (Template hardening rule applied | v1)
+
+- The parent and phase-log templates should now carry the converged close-out rule directly:
+  - draft logs stay concentrated by default while boundaries are still moving
+  - stable logs must answer the outlet-by-outlet close-out questionnaire explicitly
+  - justified `no-op` answers are valid
+  - `runbook` and `view` extraction require a stable role, not matrix completion
+- Template hardening is now allowed because `P1` through `P3` already fixed timing, questionnaire, and export-packaging rules, and `P4` now fixes the anti-proliferation gates needed to freeze authoring guidance safely.
+
+## Numbering
+
+- `S<n>`: Step.
+- `C<n>`: Cycle.
+
+**Commit / PR naming**:
+
+- `<ID>/P<phase>-C<cycle>-S<steps>: <summary>`, where `<steps>` can be a single step (`1`, meaning `...-S1`) or multiple consecutive steps grouped within the same phase / cycle (for example `1S2`, meaning `...-S1S2`).
+- When one PR aggregates multiple whole phases, the PR title should compress the phase set instead of repeating every commit unit:
+  - consecutive phases: `<ID>/P0-P3: <log title>`
+  - discontinuous phases: `<ID>/P0+P3: <log title>`
+  - mixed discontinuous + consecutive phases: `<ID>/P0+P3-P4: <log title>`
+- When the PR is a non-one-shot follow-up that carries a specific incremental unit, prefer the exact commit-style unit in the title: `<ID>/P*-C*-S*: <one-sentence summary>`.
+
+## Plan (draft)
+
+### P1 (Stable-first gate)
+
+- P1-C1-S1: define when draft slices should remain concentrated in the source log
+- P1-C1-S2: define when a stable slice enters formal close-out review
+
+### P2 (Mandatory close-out questionnaire)
+
+- P2-C1-S1: define the mandatory outlet questions a stable slice must answer
+- P2-C1-S2: define allowed no-op answers when some outlets are intentionally not exported
+
+### P3 (Post-stable export packaging)
+
+- P3-C1-S1: define when one bounded `Pn+1` style export phase is preferred over repeated draft-stage multi-file write-backs
+- P3-C1-S2: define the minimum write-back set and stop rule for that export phase
+
+### P4 (Anti-proliferation rule)
+
+- P4-C1-S1: define when `runbook` extraction is justified and when it is not
+- P4-C1-S2: define when `view` or other summary surfaces are justified and when the retained log should remain the only reader surface
+- P4-C1-S3: apply the converged close-out rule to the parent and phase-log templates only after `P1` through `P3` are explicit enough to freeze authoring guidance safely
+
+### P5 (Pilot)
+
+- P5-C1-S1: pilot the protocol on one recent stable governance lane
+- P5-C1-S2: decide whether the first `DOC` promotion lane should use this close-out pattern directly
+
+## Execution Checklist (unchecked)
+
+### P0 (Scaffold)
+
+- [x] `P0-C1-S1`: problem boundary fixed
+- [x] `P0-C1-S2`: default sequencing fixed
+
+### P1 (Stable-first gate)
+
+- [x] `P1-C1-S1`: draft-stage concentration rule fixed
+- [x] `P1-C1-S2`: stable-entry close-out gate fixed
+
+### P2 (Mandatory close-out questionnaire)
+
+- [x] `P2-C1-S1`: mandatory outlet questions fixed
+- [x] `P2-C1-S2`: allowed no-op answers fixed
+
+### P3 (Post-stable export packaging)
+
+- [x] `P3-C1-S1`: `Pn+1` style export packaging rule fixed
+- [x] `P3-C1-S2`: minimum write-back and stop rule fixed
+
+### P4 (Anti-proliferation rule)
+
+- [x] `P4-C1-S1`: runbook extraction gate fixed
+- [x] `P4-C1-S2`: view and summary extraction gate fixed
+- [x] `P4-C1-S3`: template hardening gate fixed for parent and phase-log scaffolds
+
+### P5 (Pilot)
+
+- [x] `P5-C1-S1`: one recent stable lane piloted
+- [x] `P5-C1-S2`: follow-up `DOC` promotion lane sequencing fixed
+
+## Current Status
+
+- `S0F-5A` is now opened as the next bounded follow-up after `S0F-4D`.
+- `P0` is now complete: the problem is fixed as `stable-first close-out protocol` work rather than immediate `DOC` promotion work.
+- `P1` is now complete: the repo now has one explicit draft-stage concentration rule and one explicit stable-entry close-out gate, so later outlet export can begin from a defended review boundary instead of from ongoing draft churn.
+- Template hardening is intentionally deferred: the parent and phase-log templates should not be rewritten from `P1` alone, because they still need the later `P2` questionnaire and `P3` export-packaging rules before that guidance is safe to freeze into scaffolds.
+- `P2` is now complete: the repo now has one mandatory outlet-by-outlet close-out questionnaire and one explicit allowed no-op answer set, so `stable` review can ask for explicit ownership decisions without forcing a mechanical six-file export.
+- `P3` is now complete: the repo now has one explicit rule for when a stable slice should package export as one bounded `Pn+1` style follow-up phase, plus one minimum write-back set and stop rule for that package.
+- `P4` is now complete: the repo now has one explicit anti-proliferation gate for `runbook` and `view` extraction, and the converged close-out rule is now safe to freeze into the parent and phase-log templates.
+- `P5` is now complete: the protocol has now been piloted against recent stable lane `S0F-4D`, and that pilot yields one clear follow-up answer for future `DOC` promotion work.
+- `S0F-5A` is now stable: the repo now has one complete stable-first close-out protocol, one hardened template baseline, and one recent stable pilot confirming how to apply the protocol to future `DOC` promotion slices.
+- The next immediate step is now to open `S0F-4E` for the first real `DOC` promoted contract body, using `S0F-5A` as the close-out protocol rather than reopening timing or outlet-export debates.
+
+## P5 (Pilot | v1)
+
+### P5-C1-S1 (Recent stable governance lane piloted on `S0F-4D` | v1)
+
+- Chosen pilot lane:
+  - `S0F-4D`
+- Reason for choosing it:
+  - it is a recent stable governance lane
+  - it already spans `contract`, `view`, `index/front-door`, and `disposition/placement` concerns
+  - it directly precedes the future `S0F-4E` `DOC` promotion lane, so it is the most decision-relevant pilot for this protocol
+- Pilot result under the `S0F-5A` questionnaire:
+  - `contract`:
+    - yes, `S0F-4D` established the `DOC` current-contract home, naming model, and template under `docs/governance/contract/`
+  - `runbook`:
+    - justified `no-op`
+    - reason: `S0F-4D` stabilizes storage, naming, and transition rules, but it does not define one repeatable operator procedure that should become a stable runbook
+  - `view`:
+    - yes, multiple stable reader surfaces were justified and exported, including the `DOC` front-door and `GC` triage / cleanup-boundary views
+  - `index/front-door`:
+    - yes, `docs/governance/contract/INDEX.md` and related front-door guidance were changed materially
+  - `disposition/placement`:
+    - yes, the old-`GC-*` triage and first cleanup boundary were explicit enough to record standing consequences
+  - `log-retained core`:
+    - yes, `S0F-4D` still retains the bounded ledger, checklist, evidence, and sequencing for the placement lane
+- Pilot reading:
+  - the protocol correctly classifies `S0F-4D` as a slice that legitimately exports several outlets while also keeping `runbook` as an explicit no-op
+  - this confirms that the protocol does not force six-outlet completion mechanically and can still support a multi-outlet positive-control case cleanly
+
+### P5-C1-S2 (Decision for future `S0F-4E` promotion lane fixed | v1)
+
+- The first real `DOC` promotion lane should use the `S0F-5A` close-out pattern directly.
+- Practical reading for `S0F-4E`:
+  - open `S0F-4E` as the first real promoted-contract slice
+  - let `S0F-4E` do the substantive promotion work for one chosen `DOC-<AREA>-<NNNN>` body
+  - when `S0F-4E` reaches stable review, apply the `S0F-5A` questionnaire and anti-proliferation gates explicitly
+  - only open one bounded `Pn+1` export phase if the remaining work is truly export/thinning/consequence packaging rather than substantive contract authorship
+- This means `S0F-4E` should not reopen the old question of whether close-out happens during draft churn.
+- It should inherit that answer from `S0F-5A` and use the protocol as already-fixed operating guidance.
+
+## Evidence (reserved)
+
+- Artifacts are the source of truth for evidence; this log records the head SHA, key parameters, and artifact paths (or CI run URLs).
+- This section is the human-facing ledger and should remain separate from `Evidence Footer Source`.
+
+### P0-C1-S1 through P0-C1-S2 (stable-first close-out protocol slice opened | 2026-04-08)
+
+- headSha: `e4fc27f13bb7a91aa0bdfe697bd757bb8da22953`
+- artifacts: `docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md`
+- artifacts: `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to explain why the next governance step is a close-out protocol slice rather than the first real `DOC` promotion body
+- observed:
+  - the repo now has one explicit next slice dedicated to `stable-first` close-out timing, anti-proliferation rules, and post-stable export sequencing before the first real `DOC` contract promotion lane opens
+
+### P1-C1-S1 through P1-C1-S2 (stable-first gate fixed | 2026-04-08)
+
+- headSha: `e4fc27f13bb7a91aa0bdfe697bd757bb8da22953`
+- artifacts: `docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md`
+- artifacts: `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to explain why draft slices usually stay concentrated in the source log and why `stable` is the normal gate for close-out review rather than a mechanical six-outlet export command
+- observed:
+  - the repo now has one explicit draft-stage concentration rule, one explicit stable-entry close-out gate, and one explicit deferral of template hardening until the later questionnaire and packaging rules are fixed
+
+### P2-C1-S1 through P2-C1-S2 (mandatory close-out questionnaire fixed | 2026-04-08)
+
+- headSha: `bb41cdeedbc97d041fd95bb2fe59edd79ebaad9c`
+- artifacts: `docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md`
+- artifacts: `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to explain which questions every stable slice must answer at close-out and why explicit no-op answers are valid when an outlet is not warranted
+- observed:
+  - the repo now has one outlet-by-outlet close-out questionnaire plus one explicit allowed no-op answer set, so stable review no longer depends on either memory or a mechanical all-outlets export expectation
+
+### P3-C1-S1 through P3-C1-S2 (post-stable export packaging rule fixed | 2026-04-08)
+
+- headSha: `5b4f0b356d586c6d1b8a303ca7a2ac60dddc46f2`
+- artifacts: `docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md`
+- artifacts: `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to explain when a stable slice deserves one bounded `Pn+1` style export package and what minimum write-backs plus stop rules govern that package
+- observed:
+  - the repo now has one explicit `Pn+1` packaging rule, one minimum write-back set for post-stable export work, and one stop rule that blocks premature outlet creation when stable target identity is still missing
+
+### P4-C1-S1 through P4-C1-S3 (anti-proliferation and template hardening rule fixed | 2026-04-08)
+
+- headSha: `caefbefa8587b914d890f9e2cffeb3c4686a61cc`
+- artifacts: `docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md`
+- artifacts: `docs/logs/_template-log-parent-epic-spine.md`
+- artifacts: `docs/logs/_template-log-phase-drills-evidence.md`
+- artifacts: `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to explain when `runbook` and `view` extraction are justified, and future authors should no longer need memory alone to apply the close-out protocol correctly when opening new logs
+- observed:
+  - the repo now has explicit anti-proliferation gates for `runbook` and `view`, and both log templates now carry stable-first close-out guidance instead of requiring ad hoc recall
+
+### P5-C1-S1 through P5-C1-S2 (pilot on `S0F-4D` and `S0F-4E` sequencing fixed | 2026-04-08)
+
+- headSha: `842f418a234de0e23ea33ac621ee6d2443a9bf04`
+- artifacts: `docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md`
+- artifacts: `docs/logs/log-S0F-4D-doc-current-contract-surface-and-legacy-gc-triage-model.md`
+- artifacts: `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - one reader should be able to see that the protocol works on one recent stable governance lane and that the first real `DOC` promotion lane can now inherit this close-out model directly
+- observed:
+  - `S0F-4D` works as a clean positive-control pilot: it justifies `contract`, `view`, `index/front-door`, and `disposition/placement` exports while keeping `runbook` as explicit no-op, and that result is strong enough to let future `S0F-4E` promotion work use `S0F-5A` as inherited close-out guidance
+
+## Recent changes (for traceability, optional)
+
+- 2026-04-08: opened `S0F-5A` to formalize stable-first close-out timing and post-stable outlet export before the first real `DOC` promoted contract body.
+- 2026-04-08: completed `P1` by fixing the draft-stage concentration rule, the stable-entry close-out gate, and the decision to defer template hardening until later `P2/P3/P4` rules converge.
+- 2026-04-08: completed `P2` by fixing the mandatory outlet-by-outlet close-out questionnaire and the allowed no-op answer set for stable slices.
+- 2026-04-08: completed `P3` by fixing when post-stable export should be packaged as one bounded `Pn+1` style follow-up phase and by defining the minimum write-back set plus stop rule for that export package.
+- 2026-04-08: completed `P4` by fixing the anti-proliferation gates for `runbook` and `view` extraction and by hardening the converged close-out rule into the parent and phase-log templates.
+- 2026-04-08: completed `P5` by piloting the protocol on stable lane `S0F-4D`, confirming that explicit `runbook` no-op plus multi-outlet export is a valid positive-control outcome, and fixing that future `S0F-4E` promotion work should use `S0F-5A` directly as its close-out protocol.


### PR DESCRIPTION
## Metadata

- Requested ID: `S0F-5A`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0f-5a`
- Source log: `docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md`
- Labels: `EVOLUTION, s0/knowledge system, drills`
- Development issue: #437

## Summary

- Define the stable-first gate for outlet export and keep draft slices concentrated until their boundary is stable.
- Fix the mandatory close-out questionnaire and bounded post-stable export packaging rule.
- Apply anti-proliferation gates so stable logs do not mechanically explode into contracts, runbooks, and views.

## Execution Checklist

- [x] `P0-C1-S1`: problem boundary fixed
- [x] `P0-C1-S2`: default sequencing fixed
- [x] `P1-C1-S1`: draft-stage concentration rule fixed
- [x] `P1-C1-S2`: stable-entry close-out gate fixed
- [x] `P2-C1-S1`: mandatory outlet questions fixed
- [x] `P2-C1-S2`: allowed no-op answers fixed
- [x] `P3-C1-S1`: `Pn+1` style export packaging rule fixed
- [x] `P3-C1-S2`: minimum write-back and stop rule fixed
- [x] `P4-C1-S1`: runbook extraction gate fixed
- [x] `P4-C1-S2`: view and summary extraction gate fixed
- [x] `P4-C1-S3`: template hardening gate fixed for parent and phase-log scaffolds
- [x] `P5-C1-S1`: one recent stable lane piloted
- [x] `P5-C1-S2`: follow-up `DOC` promotion lane sequencing fixed

## Links

- Log: `docs/logs/log-S0F-5A-stable-first-close-out-protocol-and-post-stable-outlet-export.md`

Closes #437
