### PR TITLE
S0F-5G/P0-P4: remaining old-S0 history-line expansion and manual screening v1

### DIFF
--- a/docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md
+++ b/docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md
@@ -1,0 +1,71 @@
+# Old S0 Issue-Only Reconstructed Ancestry Detail v1
+
+## Purpose
+
+- This view is the first reader-facing detail surface for early old-`S0` ancestry that currently sits outside the counted root-log review scope.
+- It exists so readers can inspect each known `S0A` / `S0B` supplemental anchor, see what evidence actually exists locally, and see which parts still remain unresolved.
+- It is a supplemental history/view surface, not a current `DOC` contract landing, not part of the counted `84`-row old-`S0` overview, and not part of the counted `63`-row non-surfaced remainder.
+
+## Detail Boundary
+
+- This surface expands the anchor set first declared in `view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md`.
+- It covers only the currently known early anchors outside counted scope:
+  - one preserved legacy `S0A` carry-forward log
+  - one preserved legacy `S0B` parent ADR anchor
+  - one known `S0B-1A` missing-log placeholder that still lacks local issue materialization
+- It does not claim that the full early ancestry is already reconstructed.
+- It does make the current evidence state explicit enough that later reconstruction work can be bounded rather than guessed.
+
+## Detail Model
+
+| field | job |
+| --- | --- |
+| `ancestry item` | the supplemental early-history anchor under review |
+| `current evidence class` | whether the anchor currently survives as a legacy log, legacy ADR, or unresolved issue-only placeholder |
+| `current local anchor` | the local path or local evidence state available now |
+| `counted-scope status` | whether the anchor is already counted in the old-`S0` overview |
+| `provisional reconstructed standing` | the best current reader-facing standing without fabricating missing evidence |
+| `why this standing now` | short explanation for the provisional standing |
+| `next safe reconstruction step` | the next bounded step if later reconstruction work proceeds |
+
+## Supplemental Anchor Detail
+
+| ancestry item | current evidence class | current local anchor | counted-scope status | provisional reconstructed standing | why this standing now | next safe reconstruction step |
+| --- | --- | --- | --- | --- | --- | --- |
+| `S0A` legacy carry-forward anchor | `legacy log carry-forward` | `legacy/from_structured_docs/from-logs/v2-logs/log-S0A-dlq-replay-platform.md` | `outside counted scope` | `retain as supplemental direct history` | `the repo holds one concrete early `S0A` text body, so readers can already inspect a real historical anchor without inventing missing logs or silently changing the counted overview` | `if needed, publish one later bounded reconstruction note that states how this legacy `S0A` anchor relates to later counted old-S0 governance lines without admitting it into counted scope by default` |
+| `S0B` parent legacy decision anchor | `legacy ADR carry-forward` | `legacy/from_structured_docs/from-adrs/adr-S0B-docs-management-v2.md` | `outside counted scope` | `lineage-support anchor` | `the ADR is a stable parent-level decision surface with explicit docs-management v2 decision content and context issues `#43, #44`, but it is not one counted root `docs/logs/log-S0*.md` row` | `use it as the bounded parent decision anchor if one later reconstruction packet needs to explain how the counted `S0B-2A` / `S0B-3A` rows inherited earlier taxonomy and cutover decisions` |
+| `S0B-1A` missing-log ancestry | `issue-only placeholder` | `no local source log or local issue artifact is materialized yet` | `outside counted scope` | `standing-first unresolved supplemental ancestry` | `the repo currently knows the anchor matters historically, but there is not yet one locally materialized issue body, issue summary, or source-log surrogate that can defend a stronger standing without fabrication` | `materialize one bounded issue-only evidence packet first, then decide whether the result should read as retained direct history, lineage-only support, or still remain outside counted scope` |
+
+## Current Reader Conclusions
+
+- `S0A` is now readable as real supplemental direct history because one concrete legacy text body exists locally.
+- `S0B` parent ancestry is now readable as parent-level lineage support because one stable ADR anchor exists locally and exposes the decision boundary plus context-issue references.
+- `S0B-1A` still cannot honestly be shown as more than unresolved supplemental ancestry until one issue-only evidence packet exists locally.
+- This means the current supplemental branch is already useful for reader clarity even though it is not yet a complete reconstruction set.
+
+## Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `which exact early S0A / S0B anchors exist outside counted scope, and what evidence do they currently have?` | `view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md` | this surface expands the supplemental anchor set row by row |
+| `which earlier anchors exist outside the counted 84-row old-S0 review scope at all?` | `view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md` | the routing view remains the first-open boundary surface |
+| `why did the early S0A + S0B packet exist, and what did that early packet change?` | `view-old-s0-narrative-history-pilot-s0a-s0b-v1.md` | the narrative-history pilot translates the same anchor set into emergence, problem, result, and inheritance reading |
+| `which counted S0B rows are already part of the current old-S0 review scope?` | `view-old-s0-series-s0b-standing-v1.md` | the counted `S0B` series standing remains separate from this supplemental ancestry layer |
+| `what is the counted old-S0 overview for the current root-log review scope?` | `view-old-s0-absorption-coverage-overview-v1.md` | the aggregate overview remains the counted-scope summary |
+
+## Reader Notes
+
+- This detail surface is intentionally evidence-first.
+- It prefers `known local anchor plus explicit gap` over speculative reconstruction.
+- The provisional standings here are reader-facing support standings, not automatic promotion decisions.
+- If later reconstruction work lands, it should update this detail surface before asking the counted overview to absorb any new rows.
+
+## Source Refs
+
+- `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+- `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md`
+- `docs/governance/views/view-old-s0-narrative-history-pilot-s0a-s0b-v1.md`
+- `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+- `docs/governance/views/view-old-s0-series-s0b-standing-v1.md`
+- `legacy/from_structured_docs/from-logs/v2-logs/log-S0A-dlq-replay-platform.md`
+- `legacy/from_structured_docs/from-adrs/adr-S0B-docs-management-v2.md`

--- a/docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md
+++ b/docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md
@@ -1,0 +1,63 @@
+# Old S0 Issue-Only Reconstructed Ancestry Routing v1
+
+## Purpose
+
+- This view is the first reader-facing routing surface for early old-`S0` ancestry that currently survives only through legacy carry-forward files or issue-only evidence.
+- It exists so readers can see that the counted old-`S0` root-log review scope is intentionally bounded and does not yet equal the full earliest ancestry picture.
+- It is a supplemental history/view surface, not a current `DOC` contract landing, not part of the counted `84`-row old-`S0` overview, and not part of the counted `63`-row non-surfaced remainder.
+
+## Boundary
+
+- This surface covers only ancestry that is currently outside the counted root-log review scope because it is missing from the present root-log population used by the old-`S0` overview views.
+- It currently includes three reader-facing anchor classes:
+  - legacy carry-forward `S0A` anchor that still exists on disk
+  - legacy carry-forward `S0B` parent decision anchor that still exists on disk
+  - known `S0B-1A` missing-log ancestry that currently needs issue-only reconstruction rather than root-log replay
+- This surface does not change aggregate counts yet.
+- Any future admission of these anchors into counted scope should happen only through one later explicit reconstruction packet.
+
+## Current Supplemental Anchors
+
+| ancestry anchor | evidence now | counted in old-S0 overview now | open first | why |
+| --- | --- | --- | --- | --- |
+| `S0A` legacy carry-forward anchor | `legacy/from_structured_docs/from-logs/v2-logs/log-S0A-dlq-replay-platform.md` | `no` | `view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md` | the repo still has one preserved pre-current-format `S0A` log, but the current overview intentionally counts only root `docs/logs/log-S0*.md` review-scope rows |
+| `S0B` parent legacy decision anchor | `legacy/from_structured_docs/from-adrs/adr-S0B-docs-management-v2.md` | `no` | `view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md` | the repo still has one preserved `S0B` parent decision anchor, but it is an ADR carry-forward artifact rather than one counted current root log |
+| `S0B-1A` issue-only missing-log ancestry | `issue-only evidence not yet materialized locally` | `no` | `view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md` | the ancestry is known to matter historically, but the repo does not currently hold one matching source log, so the next safe step is bounded issue-only reconstruction rather than fabricated source-log backfill |
+
+## Reconstruction Rules
+
+- Treat these anchors as supplemental reader support first, not as automatic counted-scope rows.
+- Do not fabricate a fake historical root log just to make the overview totals look complete.
+- If a later reconstruction packet lands, it should record:
+  - what evidence exists locally versus only on GitHub
+  - whether the result is retained direct history, lineage-only support, or some later counted-scope adjustment
+  - why the reconstructed result still should or should not affect the counted old-`S0` overview totals
+
+## Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `does the current old-S0 overview already include the earliest S0A and issue-only S0B ancestry?` | `view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md` | this surface makes the exclusion boundary explicit |
+| `which known early anchors exist outside the counted 84-row old-S0 review scope?` | `view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md` | the supplemental anchor list lives here |
+| `which exact early anchors exist, what evidence do they have now, and which ones remain unresolved?` | `view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md` | the detail surface expands the current supplemental anchor set row by row |
+| `why did the early S0A + S0B packet exist, and what results did it leave behind?` | `view-old-s0-narrative-history-pilot-s0a-s0b-v1.md` | the narrative-history pilot explains emergence, problem, result, and inheritance across the mixed early packet |
+| `what is the counted old-S0 overview for the current root-log review scope?` | `view-old-s0-absorption-coverage-overview-v1.md` | the aggregate view remains the canonical counted-scope summary |
+| `what is the counted non-surfaced remainder inside the current root-log review scope?` | `view-old-s0-remaining-history-line-routing-v1.md` | the remainder-routing view remains the canonical counted-scope remainder surface |
+
+## Reader Notes
+
+- This surface exists to prevent a false completeness impression.
+- The current old-`S0` overview is still correct for its bounded counted scope.
+- What it does not yet do is represent every earlier issue-only or legacy-only ancestry anchor.
+- Use this view when the question is about that missing ancestry layer rather than about the already-counted root-log population.
+- Use `view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md` when the question moves from `is there an excluded ancestry branch?` to `what exactly is currently known inside that branch?`
+
+## Source Refs
+
+- `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+- `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+- `docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md`
+- `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md`
+- `docs/governance/views/view-old-s0-narrative-history-pilot-s0a-s0b-v1.md`
+- `legacy/from_structured_docs/from-logs/v2-logs/log-S0A-dlq-replay-platform.md`
+- `legacy/from_structured_docs/from-adrs/adr-S0B-docs-management-v2.md`

--- a/docs/governance/views/view-old-s0-remaining-history-line-detail-v1.md
+++ b/docs/governance/views/view-old-s0-remaining-history-line-detail-v1.md
@@ -1,0 +1,138 @@
+# Old S0 Remaining History-Line Detail v1
+
+## Purpose
+
+- This view is the widened reader-facing detail surface for the remaining non-surfaced old-`S0` line.
+- It exists so readers can inspect the already-adjudicated retained-history population and the still-unresolved `S0F` subset together without replaying the support-only working ledger row by row.
+- It is not yet the manual screening packet for contract admission or six-outlet adjustment.
+
+## Population Boundary
+
+- This detail surface covers the full current non-surfaced old-`S0` remainder fixed by `view-old-s0-remaining-history-line-routing-v1.md`:
+  - `63` rows total
+  - `45` already-adjudicated rows
+  - `18` still-unresolved `S0F` rows
+- It intentionally excludes the `21` rows already surfaced into current `DOC` contracts or current `DOC` views.
+
+## Detail Model
+
+| field | job |
+| --- | --- |
+| `source log` | exact old-`S0` source log in the remaining line |
+| `series` | fixed series bucket |
+| `current standing now` | the best current standing already visible from the landed series views, or `unreviewed` for the unresolved `S0F` subset |
+| `history-line route` | bounded remainder-line reading route such as `retain-direct-history`, `lineage-only`, `external-current-home`, or `standing-first unresolved` |
+| `strongest current reading home now` | strongest current home already known for the row |
+| `why it still stays in the remaining line` | short reader-facing explanation for why the row is still outside the surfaced `DOC` set |
+
+## Already-Adjudicated Direct-History Line
+
+| source log | series | current standing now | history-line route | strongest current reading home now | why it still stays in the remaining line |
+| --- | --- | --- | --- | --- | --- |
+| `S0B-2A` | `S0B` | `retained-evidence` | `retain-direct-history` | `backend/scripts/cli.py` plus `docs/labs/_snapshot/` and `docs/runbook/_snapshot/` | `the row remains bounded tooling-governance history while current tooling and evidence-root behavior already read through live repo surfaces rather than through one surfaced DOC target` |
+| `S0C-3A` | `S0C` | `retained-evidence` | `retain-direct-history` | `backend/scripts/cli.py` and `backend/scripts/cli_app/` | `the row remains readable CLI-thinning and scenario-decomposition history while current behavior already reads through the landed thin entry and execution modules` |
+| `S0C-3A-1A` | `S0C` | `retained-evidence` | `retain-direct-history` | `backend/scripts/cli.py` and `backend/scripts/cli_app/` | `the migration bridge remains bounded retained history rather than one current surfaced target` |
+| `S0C-3A-2A` | `S0C` | `retained-evidence` | `retain-direct-history` | `backend/scripts/cli_app/common.py` plus workflow-side artifact helpers | `the row remains direct artifact-contract convergence history while current helper behavior already reads elsewhere` |
+| `S0C-3A-3A` | `S0C` | `retained-evidence` | `retain-direct-history` | `backend/scripts/cli.py` and `backend/scripts/cli_app/parser.py` | `the dispatch-thinning cutover remains bounded retained history rather than one current DOC-facing route` |
+| `S0C-4A` | `S0C` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0C-scenarios-taxonomy.md` and `docs/labs/scenarios/catalog.yml` | `the row remains direct scenario-taxonomy history while operator discovery already reads through the stable runbook and catalog surfaces` |
+| `S0C-4A-1A` | `S0C` | `retained-evidence` | `retain-direct-history` | `docs/labs/scenarios/catalog.yml`, `backend/scripts/ci/validate_scenario_catalog.py`, and `.github/workflows/ci-scenario-guardrails.yml` | `the row remains direct catalog-guardrail history while live validation and workflow references already read through current guardrail surfaces` |
+| `S0D-2A` | `S0D` | `retained-evidence` | `retain-direct-history` | `backend/scripts/ci/workflow_artifacts.py` plus `docs/labs/_snapshot/auto/` and `artifacts/*runs*.json` | `the row remains direct drills/evidence automation history while current artifact discovery and bookkeeping already read through live helper and ledger surfaces` |
+| `S0D-3A` | `S0D` | `retained-evidence` | `retain-direct-history` | `docs/runbook/_template-runbook.md` plus current operator-entry runbooks | `the row remains direct runbook-governance history while current runbook entry behavior already reads through the live template and adopted operator surfaces` |
+| `S0D-4A` | `S0D` | `retained-evidence` | `retain-direct-history` | `docs/UI&UX/README.md`, `docs/UI&UX/UI-FIX-NOTE-TEMPLATE.md`, and `docs/UI&UX/assets/README.md` | `the row remains direct UI evidence-lite governance history while current usage already reads through the UI note and asset surfaces` |
+| `S0D-5A` | `S0D` | `retained-evidence` | `retain-direct-history` | `.github/workflows/reusable-labs-scenario-runner.yml` plus `backend/scripts/ci/workflow_artifacts.py` and `.github/workflows/drill-failures.yml` | `the row remains direct evidence-packing history while current workflow packing behavior already reads through live workflow and helper surfaces` |
+| `S0D-6A` | `S0D` | `retained-evidence` | `retain-direct-history` | `docs/roadmap/road-template-main-roadmap.md` plus `docs/roadmap/road-template-branch-roadmap.md` and `docs/demo/demo-001/` | `the row remains direct roadmap/demo container history while current roadmap and demo reading already reads through templates and structured demo roots` |
+| `S0E-2A` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus `scripts/issues/gen_issue_draft.py` | `the row remains direct issue-creation history while current operator reading already starts from the runbook and draft-generation surfaces` |
+| `S0E-2B` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus `scripts/issues/gen_issue_draft.py --create` | `the row remains direct create-mode automation history while current behavior already reads through the live runbook and create entrypoint` |
+| `S0E-2C` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus issue batch and relationship planners | `the row remains direct batch/backfill orchestration history while current planning behavior already reads through the runbook and planning scripts` |
+| `S0E-3B` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus live label-preflight paths | `the row remains direct live-label preflight history while current enforcement already reads through the runbook and script-level preflight paths` |
+| `S0E-4A` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus live PR planning/create surfaces | `the row remains direct PR-automation history while current PR planning and create behavior already reads through the runbook and live helpers` |
+| `S0E-4B` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus PR body/title helper surfaces | `the row remains direct PR-formatting history while current body and label behavior already reads through the runbook and helper surfaces` |
+| `S0E-4C` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus relationship planners/apply helpers | `the row remains direct PR-linkage history while current relationship apply behavior already reads through the runbook and planning surfaces` |
+| `S0E-4D` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus lifecycle planners | `the row remains direct lifecycle-orchestration history while current operator reading already reads through runbook procedure and live planners` |
+| `S0E-4F` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus current PR body helpers | `the row remains direct PR-body cleanup history while current body generation already reads through runbook and current helpers` |
+| `S0E-5B` | `S0E` | `retained-evidence` | `retain-direct-history` | `scripts/issues/plan_lifecycle_remediation.py` plus `docs/runbook/run-S0E-log-to-issue-creation.md` | `the row remains direct guarded-lifecycle expansion history while current planning already reads through live lifecycle planners and runbook procedure` |
+| `S0E-5C` | `S0E` | `retained-evidence` | `retain-direct-history` | `scripts/issues/plan_pr_create_preflight_with_gate.py` plus `docs/runbook/run-S0E-log-to-issue-creation.md` | `the row remains direct guarded PR-create history while current gate behavior already reads through live preflight and runbook surfaces` |
+| `S0E-5D` | `S0E` | `retained-evidence` | `retain-direct-history` | `scripts/issues/plan_body_completeness_check_wrapper.py`, `scripts/issues/verify_live_pr_body_contract.py`, and `docs/runbook/run-S0E-log-to-issue-creation.md` | `the row remains direct body-contract normalization history while current check and verification behavior already reads through live helper surfaces` |
+| `S0E-6D` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus issue-context authoring and refresh helpers | `the row remains direct issue-context rendering history while current authoring behavior already reads through the runbook and live helpers` |
+| `S0E-6E` | `S0E` | `retained-evidence` | `retain-direct-history` | issue-context refresh artifacts plus the runbook's single-item authoring procedure | `the row remains direct context-authoring boundary history while current preserve-versus-author behavior already reads through live refresh workflow and authoring procedure` |
+| `S0E-6F` | `S0E` | `retained-evidence` | `retain-direct-history` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus current issue-body helpers | `the row remains direct issue-body boundary history while current rendering already reads through the runbook and current helper surfaces` |
+| `S0E-7B` | `S0E` | `retained-evidence` | `retain-direct-history` | `scripts/issues/resolve_pr_source_log_attribution.py` plus workflow-side attribution hooks | `the row remains direct attribution-handoff implementation history while current operational reading already starts from the resolver and workflow hooks` |
+| `S0E-7C` | `S0E` | `retained-evidence` | `retain-direct-history` | `scripts/issues/plan_lifecycle_audit.py` plus current audit planning artifacts | `the row remains direct historical-review audit history while current audit behavior already reads through live planning surfaces` |
+
+## Already-Adjudicated Lineage-Only Line
+
+| source log | series | current standing now | history-line route | strongest current reading home now | why it still stays in the remaining line |
+| --- | --- | --- | --- | --- | --- |
+| `S0C-2A` | `S0C` | `retired-lineage` | `lineage-only` | current-library integration and invariant-focused tests | `the row remains historical retirement lineage rather than one retained current-reading surface` |
+| `S0C-5A` | `S0C` | `history-lineage` | `lineage-only` | `docs/logs/log-S0D-1A-log-entries-orchestration.md` plus the parent and phase templates | `the row remains lineage into the current log-orchestration grammar rather than one surfaced target on its own` |
+| `S0E-1B` | `S0E` | `retired-lineage` | `lineage-only` | `docs/logs/log-S0E-1B-md-to-docx-minimal-sample.md` plus preserved export scripts | `the row remains archive lineage only and does not act as one current reader surface` |
+| `S0E-4E` | `S0E` | `history-lineage` | `lineage-only` | `scripts/issues/resolve_pr_source_log_attribution.py` plus `docs/logs/log-S0E-7B-attribution-handoff-implementation-and-auto-mirroring-integration.md` | `the row remains attribution-boundary lineage rather than one direct current-reading target` |
+| `S0E-5E` | `S0E` | `history-lineage` | `lineage-only` | `docs/logs/log-S0E-6F-issue-body-metadata-links-boundary-follow-up.md` plus current issue-body procedures | `the row remains parent-issue ordering lineage into later issue-body surfaces rather than one direct retained history surface` |
+| `S0E-6B` | `S0E` | `history-lineage` | `lineage-only` | `docs/logs/log-S0E-6A-log-structure-normalization-and-dual-track-evidence-contract.md` plus later gate procedures | `the row remains log-stability and gate-strategy lineage rather than one direct retained current-reading surface` |
+| `S0E-7A` | `S0E` | `history-lineage` | `lineage-only` | `docs/logs/log-S0E-7B-attribution-handoff-implementation-and-auto-mirroring-integration.md` plus later workflow packet surfaces | `the row remains workflow-enforcement lineage rather than one first-open current-reading surface` |
+
+## Already-Adjudicated External-Current-Home Line
+
+| source log | series | current standing now | history-line route | strongest current reading home now | why it still stays in the remaining line |
+| --- | --- | --- | --- | --- | --- |
+| `S0E-1A` | `S0E` | `non-doc` | `external-current-home` | `docs/demo/demo-001/_cv/` plus `scripts/cv/` | `the row belongs to the demo/tooling line rather than to the current DOC surfaced set` |
+| `S0E-5A` | `S0E` | `retained-evidence` | `external-current-home` | `GC-COMPL-0001` plus `scripts/issues/plan_lifecycle_pre_gate.py` | `the row remains a planner-shell history row while the strongest current meaning already lives in the narrow GC completeness record` |
+| `S0E-7D` | `S0E` | `non-doc` | `external-current-home` | `GC-WF-0001` | `the row's current workflow-failure rule meaning already lives outside DOC in the narrow GC registry surface` |
+| `S0E-7E` | `S0E` | `retained-evidence` | `external-current-home` | `GC-WF-0001` plus retained support-only thin-gate body | `the row remains workflow-support history while the strongest current rule home already lives in the narrow GC record` |
+| `S0E-7F` | `S0E` | `retained-evidence` | `external-current-home` | `GC-WF-0001` plus retained support-only wrapper body | `the row remains wrapper history while the strongest current rule home already lives in the narrow GC record` |
+| `S0E-7G` | `S0E` | `retained-evidence` | `external-current-home` | `GC-WF-0001` plus retained support-only workflow-dispatch body | `the row remains transport history while the strongest current rule home already lives in the narrow GC record` |
+| `S0F-1H` | `S0F` | `non-doc` | `external-current-home` | `GC-PRR-0001` | `the row's current reviewer-classification meaning already lives outside DOC in the narrow GC reviewer record` |
+| `S0F-1I` | `S0F` | `retained-evidence` | `external-current-home` | `GC-PRG-0001` plus `run-S0F-1H-pr-body-completeness-review.md` | `the row remains convergence history while current gate semantics and operator procedure already read through external current homes` |
+| `S0F-1J` | `S0F` | `non-doc` | `external-current-home` | `GC-PRG-0001` | `the row's current gate meaning already lives outside DOC in the narrow GC gate record` |
+
+## Standing-First Unresolved S0F Line
+
+| source log | series | current standing now | history-line route | strongest current reading home now | why it still stays in the remaining line |
+| --- | --- | --- | --- | --- | --- |
+| `S0F-1C` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-1K` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-2A` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-2B` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3A` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3B` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3C` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3D` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3E` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3F` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3G` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3H` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3J` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3K` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3L` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-3M` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-4H` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+| `S0F-5A` | `S0F` | `unreviewed` | `standing-first unresolved` | `not yet fixed` | `the row still lacks defended standing in the old-S0 remainder view and therefore must stay outside manual contract screening for now` |
+
+## Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `which exact remaining rows are already adjudicated and how do they read now?` | `view-old-s0-remaining-history-line-detail-v1.md` | this is the widened detail answer for the already-adjudicated retained-history population and the unresolved `S0F` subset together |
+| `which remaining rows still lack standing and must stay outside manual screening?` | `view-old-s0-remaining-history-line-detail-v1.md` | the unresolved `18`-row `S0F` subset is explicit here rather than implied through counts only |
+| `which remaining rows should now enter manual screening for possible contract or view concentration?` | `view-old-s0-remaining-history-line-manual-screening-v1.md` | the manual-screening surface now sits on top of this widened detail layer and keeps first-pass candidate buckets explicit |
+| `what is the aggregate shape of the remaining line?` | `view-old-s0-remaining-history-line-routing-v1.md` | the routing view remains the count-first and series-first entrypoint |
+| `inside one series, what is the standing of each row now?` | `view-old-s0-series-s0b-standing-v1.md` or the later matching series drill-down view | the per-series standing surfaces remain the row-level standing source |
+
+## Reader Notes
+
+- Read this detail surface after `view-old-s0-remaining-history-line-routing-v1.md` when the question moves from counts to exact remaining rows.
+- This view intentionally stops short of manual screening for contract admission:
+  - it widens the readable history line
+  - it separates direct retained history, lineage-only, external current-home rows, and unresolved rows
+  - it does not yet decide candidate current-contract or candidate current-view writes
+- Use `view-old-s0-remaining-history-line-manual-screening-v1.md` when the question changes from `how do these rows currently read?` to `which of these rows should I challenge manually for later concentration or outlet adjustment?`
+
+## Source Refs
+
+- `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+- `docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0b-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0c-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0d-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0e-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0f-standing-v1.md`

--- a/docs/governance/views/view-old-s0-remaining-history-line-manual-screening-v1.md
+++ b/docs/governance/views/view-old-s0-remaining-history-line-manual-screening-v1.md
@@ -1,0 +1,168 @@
+# Old S0 Remaining History-Line Manual Screening v1
+
+## Purpose
+
+- This view is the first reader-facing manual screening surface for the remaining non-surfaced old-`S0` line.
+- It exists so one human reviewer can inspect the current remainder without accepting one automatic contract-admission filter from the model.
+- It is not itself a current `DOC` contract landing, not a replacement for the standing views, and not a support-only working ledger.
+
+## First-Pass Screening Rule
+
+- This first pass is intentionally conservative.
+- The first pass does not auto-admit any row into `candidate current-contract` or `candidate current-view`.
+- Instead, it separates the remaining line into:
+  - `standing-first unresolved`
+  - `candidate current-contract`
+  - `candidate current-view`
+  - `retain as history`
+  - `lineage only`
+  - `non-DOC / external current-home`
+- Human review may later move a row from one of the non-candidate buckets into `candidate current-contract` or `candidate current-view` if the widened history line proves that the current outlet should change.
+
+## Screening Model
+
+| field | job |
+| --- | --- |
+| `source log` | exact old-`S0` source log under review |
+| `series` | fixed series bucket |
+| `current standing now` | the current standing already visible from the landed standing views |
+| `first-pass screening class` | the current manual-screening bucket for this first pass |
+| `why this class now` | short explanation for why the row currently lands there |
+
+## First-Pass Summary
+
+- Remaining-line population screened here: `63` rows.
+- The screened `63`-row population here still excludes the supplemental early `S0A` / `S0B` issue-only reconstructed ancestry branch, because that branch is outside the counted root-log remainder rather than inside it.
+- `candidate current-contract`: `0`
+- `candidate current-view`: `0`
+- `retain as history`: `29`
+- `lineage only`: `7`
+- `non-DOC / external current-home`: `9`
+- `standing-first unresolved`: `18`
+
+## Candidate Current-Contract
+
+- No rows are auto-screened into `candidate current-contract` in this first pass.
+- This is intentional: the lane now gives the human reviewer one full widened history line first, instead of allowing the model to front-run contract admission from partial structural signals.
+
+## Candidate Current-View
+
+- No rows are auto-screened into `candidate current-view` in this first pass.
+- This is intentional: if one new current reader-facing concentration point is warranted, that judgment should now happen after human review of the widened detail line rather than through model-first over-filtering.
+
+## Retain As History
+
+| source log | series | current standing now | first-pass screening class | why this class now |
+| --- | --- | --- | --- | --- |
+| `S0B-2A` | `S0B` | `retained-evidence` | `retain as history` | `the row remains readable retained tooling-governance history, but its strongest current meaning already reads through live repo tooling and evidence-root surfaces` |
+| `S0C-3A` | `S0C` | `retained-evidence` | `retain as history` | `the row remains readable retained CLI-structure history, but current command behavior already reads through the landed thin entry and execution modules` |
+| `S0C-3A-1A` | `S0C` | `retained-evidence` | `retain as history` | `the row remains readable retained migration-bridge history, not one current surfaced rule body` |
+| `S0C-3A-2A` | `S0C` | `retained-evidence` | `retain as history` | `the row remains readable retained artifact-contract convergence history, while current helper behavior already reads elsewhere` |
+| `S0C-3A-3A` | `S0C` | `retained-evidence` | `retain as history` | `the row remains readable retained dispatch-thinning history, not one current surfaced target` |
+| `S0C-4A` | `S0C` | `retained-evidence` | `retain as history` | `the row remains readable retained scenario-taxonomy history, while current operator discovery already reads through the stable runbook and catalog` |
+| `S0C-4A-1A` | `S0C` | `retained-evidence` | `retain as history` | `the row remains readable retained catalog-guardrail history, while current validation already reads through the stable guardrail surfaces` |
+| `S0D-2A` | `S0D` | `retained-evidence` | `retain as history` | `the row remains readable retained drills/evidence automation history, while current artifact behavior already reads through live helpers and ledgers` |
+| `S0D-3A` | `S0D` | `retained-evidence` | `retain as history` | `the row remains readable retained runbook-governance history, while current runbook entry behavior already reads through live templates and operator-entry surfaces` |
+| `S0D-4A` | `S0D` | `retained-evidence` | `retain as history` | `the row remains readable retained UI evidence-lite governance history, while current usage already reads through the UI note and asset surfaces` |
+| `S0D-5A` | `S0D` | `retained-evidence` | `retain as history` | `the row remains readable retained evidence-packing history, while current workflow packing already reads through live workflow and helper surfaces` |
+| `S0D-6A` | `S0D` | `retained-evidence` | `retain as history` | `the row remains readable retained roadmap/demo container history, while current roadmap/demo reading already reads through templates and structured demo roots` |
+| `S0E-2A` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained issue-creation history, while current operator reading already starts from the runbook and draft-generation surfaces` |
+| `S0E-2B` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained create-mode automation history, while current behavior already reads through the live runbook and create entrypoint` |
+| `S0E-2C` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained batch/backfill orchestration history, while current planning behavior already reads through the runbook and live planners` |
+| `S0E-3B` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained live-label preflight history, while current enforcement already reads through runbook and script-level preflight paths` |
+| `S0E-4A` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained PR-automation history, while current PR planning/create behavior already reads through runbook and live helpers` |
+| `S0E-4B` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained PR-formatting history, while current body/title behavior already reads through runbook and helper surfaces` |
+| `S0E-4C` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained PR-linkage history, while current relationship apply behavior already reads through runbook and planning surfaces` |
+| `S0E-4D` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained lifecycle-orchestration history, while current operator reading already reads through runbook procedure and live planners` |
+| `S0E-4F` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained PR-body cleanup history, while current body generation already reads through runbook and helper surfaces` |
+| `S0E-5B` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained guarded-lifecycle history, while current planning already reads through live lifecycle planners and runbook procedure` |
+| `S0E-5C` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained guarded PR-create history, while current gate behavior already reads through live preflight and runbook surfaces` |
+| `S0E-5D` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained body-contract normalization history, while current check and verification behavior already reads through live helper surfaces` |
+| `S0E-6D` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained issue-context rendering history, while current authoring behavior already reads through the runbook and live helpers` |
+| `S0E-6E` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained context-authoring boundary history, while current preserve-versus-author behavior already reads through live refresh workflow and authoring procedure` |
+| `S0E-6F` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained issue-body boundary history, while current rendering already reads through runbook and live helper surfaces` |
+| `S0E-7B` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained attribution-handoff implementation history, while current operational reading already starts from resolver and workflow hooks` |
+| `S0E-7C` | `S0E` | `retained-evidence` | `retain as history` | `the row remains readable retained audit-planning history, while current audit behavior already reads through live planning surfaces` |
+
+## Lineage Only
+
+| source log | series | current standing now | first-pass screening class | why this class now |
+| --- | --- | --- | --- | --- |
+| `S0C-2A` | `S0C` | `retired-lineage` | `lineage only` | `the row is mainly retirement lineage and does not need one direct retained-current reading route` |
+| `S0C-5A` | `S0C` | `history-lineage` | `lineage only` | `the row mainly survives as lineage into the current log-orchestration grammar rather than as one direct retained history target` |
+| `S0E-1B` | `S0E` | `retired-lineage` | `lineage only` | `the row is archived export lineage rather than one current retained reading surface` |
+| `S0E-4E` | `S0E` | `history-lineage` | `lineage only` | `the row mainly survives as attribution-boundary lineage into later resolver and implementation surfaces` |
+| `S0E-5E` | `S0E` | `history-lineage` | `lineage only` | `the row mainly survives as parent-issue ordering lineage into later issue-body surfaces` |
+| `S0E-6B` | `S0E` | `history-lineage` | `lineage only` | `the row mainly survives as log-stability and gate-strategy lineage into later concrete gate surfaces` |
+| `S0E-7A` | `S0E` | `history-lineage` | `lineage only` | `the row mainly survives as workflow-enforcement lineage into later attribution and workflow packet surfaces` |
+
+## Non-DOC / External Current-Home
+
+| source log | series | current standing now | first-pass screening class | why this class now |
+| --- | --- | --- | --- | --- |
+| `S0E-1A` | `S0E` | `non-doc` | `non-DOC / external current-home` | `the row belongs to the demo/tooling line rather than to the current DOC surfaced set` |
+| `S0E-5A` | `S0E` | `retained-evidence` | `non-DOC / external current-home` | `the row remains planner-shell history while its strongest current rule meaning already lives in GC-COMPL-0001` |
+| `S0E-7D` | `S0E` | `non-doc` | `non-DOC / external current-home` | `the row's current workflow-failure rule meaning already lives outside DOC in GC-WF-0001` |
+| `S0E-7E` | `S0E` | `retained-evidence` | `non-DOC / external current-home` | `the row remains workflow-support history while its strongest current rule home already lives in GC-WF-0001` |
+| `S0E-7F` | `S0E` | `retained-evidence` | `non-DOC / external current-home` | `the row remains wrapper history while its strongest current rule home already lives in GC-WF-0001` |
+| `S0E-7G` | `S0E` | `retained-evidence` | `non-DOC / external current-home` | `the row remains transport history while its strongest current rule home already lives in GC-WF-0001` |
+| `S0F-1H` | `S0F` | `non-doc` | `non-DOC / external current-home` | `the row's current reviewer-classification meaning already lives outside DOC in GC-PRR-0001` |
+| `S0F-1I` | `S0F` | `retained-evidence` | `non-DOC / external current-home` | `the row remains convergence history while current gate semantics and operator procedure already read through external current homes` |
+| `S0F-1J` | `S0F` | `non-doc` | `non-DOC / external current-home` | `the row's current gate meaning already lives outside DOC in GC-PRG-0001` |
+
+## Standing-First Unresolved
+
+| source log | series | current standing now | first-pass screening class | why this class now |
+| --- | --- | --- | --- | --- |
+| `S0F-1C` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-1K` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-2A` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-2B` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3A` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3B` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3C` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3D` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3E` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3F` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3G` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3H` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3J` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3K` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3L` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-3M` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-4H` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+| `S0F-5A` | `S0F` | `unreviewed` | `standing-first unresolved` | `the row still lacks defended standing in the old-S0 remainder line and should not be screened for contract admission yet` |
+
+## Human Review Order
+
+1. Read `view-old-s0-remaining-history-line-routing-v1.md` for the aggregate remainder split.
+2. Read `view-old-s0-remaining-history-line-detail-v1.md` for the full widened detail line.
+3. Use this screening view to challenge the conservative first-pass buckets.
+4. Only after that decide whether one row should move into `candidate current-contract`, `candidate current-view`, or one later `needs six-outlet adjustment` follow-up.
+
+## Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `which remaining rows should I screen manually for possible contract or view concentration?` | `view-old-s0-remaining-history-line-manual-screening-v1.md` | this surface is the bounded first manual-screening packet for the non-surfaced remainder |
+| `which remaining rows currently look like no automatic contract/view candidates?` | `view-old-s0-remaining-history-line-manual-screening-v1.md` | this first pass intentionally exposes the conservative screening result rather than hiding it in prose |
+| `what is the widened detail line before screening?` | `view-old-s0-remaining-history-line-detail-v1.md` | the detail surface remains the pre-screening history-line view |
+
+## Reader Notes
+
+- This first-pass screening view is intentionally conservative and human-first.
+- Empty `candidate current-contract` and `candidate current-view` buckets do not mean the remainder line has no later candidates.
+- They mean the current lane has now widened the reading surface enough that the next promotion or outlet-adjustment judgment should be made manually rather than through one automatic filter.
+- They also do not mean the repo has no earlier ancestry outside the counted remainder; that separate question now routes through `view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md`.
+
+## Source Refs
+
+- `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+- `docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md`
+- `docs/governance/views/view-old-s0-remaining-history-line-detail-v1.md`
+- `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0b-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0c-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0d-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0e-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0f-standing-v1.md`

--- a/docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md
+++ b/docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md
@@ -1,0 +1,88 @@
+# Old S0 Remaining History-Line Routing v1
+
+## Purpose
+
+- This view is the first reader-facing routing surface for the remaining non-surfaced old-`S0` line.
+- It exists so readers can inspect the full old-`S0` remainder after the current surfaced `DOC` set without dropping immediately into the support-only working ledger.
+- It is not a current-rule surface, not a replacement for the per-series standing views, and not the final manual-screening packet.
+
+## Remaining-Line Boundary
+
+- The remaining history line uses the same root review-scope population already fixed by `view-old-s0-absorption-coverage-overview-v1.md`.
+- It covers the current non-surfaced old-`S0` remainder only:
+  - total non-surfaced remainder: `63` rows
+  - already-adjudicated but still non-surfaced rows: `45`
+  - still-unresolved rows: `18`
+- This view intentionally excludes the `21` rows already surfaced into current `DOC` contracts or current `DOC` views.
+- This view also intentionally excludes the supplemental early `S0A` / `S0B` issue-only reconstructed ancestry branch, because that branch is outside the counted root-log review scope rather than inside this counted `63`-row remainder.
+
+## Routing Model
+
+| field | job |
+| --- | --- |
+| `series` | one old-`S0` series bucket such as `S0B`, `S0C`, `S0D`, `S0E`, or `S0F` |
+| `remaining rows` | current non-surfaced rows from that series |
+| `already-adjudicated remainder` | rows from that series whose standing is already defended but not yet widened into one clearer history line |
+| `still-unresolved remainder` | rows from that series whose standing and widened history routing are both still missing |
+| `open first` | the first reader-facing surface to open for that bucket now |
+| `why` | short routing rationale |
+
+## Remaining-Line Snapshot
+
+- Current remaining old-`S0` history line: `63` rows.
+- Already-adjudicated remainder: `45` rows.
+- Still-unresolved remainder: `18` rows.
+- All current unresolved remainder now sits in `S0F`; `S0B`, `S0C`, `S0D`, and `S0E` have no generic unresolved remainder left.
+- The remaining-line reading job therefore splits cleanly into two questions:
+  - `which rows are already judged but still need one widened history/view route?`
+  - `which rows still lack defended standing and must stay outside manual contract screening for now?`
+
+## Series Routing Summary
+
+| series | remaining rows | already-adjudicated remainder | still-unresolved remainder | open first | why |
+| --- | --- | --- | --- | --- | --- |
+| `S0B` | `1` | `1` | `0` | `view-old-s0-series-s0b-standing-v1.md` | the only remaining row in `S0B` is already adjudicated, so the series drill-down is currently enough until a later widened detail surface lands |
+| `S0C` | `8` | `8` | `0` | `view-old-s0-series-s0c-standing-v1.md` | the full `S0C` remainder is already adjudicated and currently reads through the existing per-series standing surface |
+| `S0D` | `5` | `5` | `0` | `view-old-s0-series-s0d-standing-v1.md` | the full `S0D` remainder is already adjudicated and currently reads through the existing per-series standing surface |
+| `S0E` | `28` | `28` | `0` | `view-old-s0-series-s0e-standing-v1.md` | the full `S0E` remainder is already adjudicated after `S0F-5F`, but it still lacks one widened non-surfaced history line above the per-series standing surface |
+| `S0F` | `21` | `3` | `18` | `view-old-s0-series-s0f-standing-v1.md` | `S0F` is the only remaining series that still mixes already-adjudicated non-surfaced rows with genuine unresolved remainder |
+
+## Current Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `what is the full old-S0 remainder after the current surfaced DOC set?` | `view-old-s0-remaining-history-line-routing-v1.md` | this surface is the bounded first-open answer for the full non-surfaced remainder |
+| `if I want to judge whether one old-S0 row can later enter contract or should remain history, where should I start?` | `view-old-s0-contract-judgment-front-door-v1.md` | the contract-judgment front door now decides whether you should read surfaced migration, narrative packet history, remaining manual screening, or unresolved standing first |
+| `which remaining rows are already adjudicated versus still unresolved?` | `view-old-s0-remaining-history-line-routing-v1.md` | this surface fixes that split explicitly before later detail and manual screening views |
+| `what earlier ancestry sits outside this counted 63-row remainder because it survives only as legacy or issue-only evidence?` | `view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md` | the supplemental reconstruction-routing view handles ancestry outside the counted remainder scope |
+| `which exact early anchors are in that supplemental ancestry branch right now?` | `view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md` | the supplemental detail view expands the excluded ancestry branch without altering the counted remainder |
+| `which exact remaining rows are already adjudicated and how do they read now?` | `view-old-s0-remaining-history-line-detail-v1.md` | the widened detail surface now expands the retained-history population and the unresolved `S0F` subset without collapsing them back into the working ledger |
+| `which remaining rows should I now screen manually for possible contract or view concentration?` | `view-old-s0-remaining-history-line-manual-screening-v1.md` | the manual-screening surface now separates unresolved rows, retained-history rows, lineage rows, and external-current-home rows without auto-admitting a new contract set |
+| `inside one series, what is the standing of the remaining rows?` | `view-old-s0-series-s0b-standing-v1.md` or the later matching series drill-down view | the series drill-down layer remains the bounded per-log standing answer |
+| `which rows are already in the surfaced DOC set instead of this remainder line?` | `view-old-s0-migration-ledger-v1.md` | the migration ledger remains the canonical surfaced-row projection |
+| `how much of old S0 is surfaced versus still outside the surfaced set?` | `view-old-s0-absorption-coverage-overview-v1.md` | the aggregate overview remains the count-first entrypoint |
+
+## Reader Notes
+
+- Read this view first when the question is `what still remains outside the current surfaced DOC set?`
+- This surface intentionally stops at routing and population shape:
+  - it shows the current remainder split
+  - it points readers at the existing series surfaces
+  - it does not replace the later manual screening packet
+- Use `view-old-s0-remaining-history-line-detail-v1.md` when the question moves from `how big is the remainder?` to `which exact rows are in that remaining line, and how do they currently read?`
+- Use `view-old-s0-remaining-history-line-manual-screening-v1.md` when the question becomes `which rows should a human now challenge as possible contract/view candidates or outlet-adjustment follow-ups?`
+- Use `view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md` when the question is about early ancestry that is not part of this counted remainder in the first place.
+- The support-only working ledger remains useful for mutable row notes, but not as the first-open reader surface for understanding the current remaining line.
+
+## Source Refs
+
+- `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+- `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+- `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md`
+- `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md`
+- `docs/governance/views/view-old-s0-migration-ledger-v1.md`
+- `docs/governance/views/view-old-s0-series-s0b-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0c-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0d-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0e-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0f-standing-v1.md`

--- a/docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md
+++ b/docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md
@@ -1,0 +1,493 @@
+# log-S0F-5G (Phase 5G: remaining old-S0 history-line expansion and manual screening)
+
+---
+
+**id**: `S0F-5G`
+**kind**: `log`
+**title**: `remaining old-S0 history-line expansion and manual screening v1`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Governance, Records, Views, History, Migration, Review, epic/s0, sub/5g`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-5F-remaining-s0e-standing-adjudication-and-packeted-review.md`
+  **reference_log_1**: `docs/logs/log-S0F-5B-old-s0-migration-ledger-view-and-support-only-inventory-model.md`
+  **reference_log_2**: `docs/logs/log-S0F-6B-old-s0-absorption-coverage-and-history-chain-views.md`
+  **reference_log_3**: `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+  **reference_log_4**: `docs/governance/views/view-old-s0-series-s0f-standing-v1.md`
+  **reference_log_5**: `docs/governance/views/view-doc-history-and-lineage-v1.md`
+**issue_keyword**: `migration`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/5`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-10`
+**updated**: `2026-04-10`
+
+---
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-5G` opens as the bounded follow-up after `S0F-5F` to expand the remaining old-`S0` history/view line before any further manual contract screening or six-outlet adjustment is attempted.
+- This lane exists because the repo now has:
+  - one stable current `DOC` front door
+  - one bounded `DOC` history view
+  - one bounded promotion map
+  - one aggregate old-`S0` coverage view
+  - bounded series standing pilots for `S0B`, `S0E`, and `S0F`
+  - but it still does not have one sufficiently expanded history/view layer across the remaining old-`S0` population for human contract screening without replaying source logs row by row.
+- The lane is intentionally history/view-first rather than contract-first:
+  - do not auto-admit new `DOC` contracts just because a row looks structurally important
+  - first widen the reader-facing history/view layer so one human reviewer can inspect the full remaining old-`S0` line more safely
+  - then use that widened surface to decide which rows should stay as retained history, which should become explicit current reader surfaces, and which six-outlet assignments need manual adjustment
+  - keep any earlier `S0A` / `S0B` ancestry that currently survives only through legacy carry-forward files or issue-only evidence on a separate supplemental branch until one later explicit reconstruction packet decides whether it should affect counted scope or outlet placement
+
+**Default choices (phase defaults / v1)**:
+
+- Treat remaining old-`S0` history expansion and later contract admission as two different jobs.
+- Do not use `S0F-5G` to auto-promote source-log or template contracts into `DOC` current contracts without an explicit later human screening result.
+- Prefer widening one explicit view layer over hiding judgments inside the support-only working ledger.
+- Preserve the already-landed standing vocabulary from `S0F-6B` and the already-executed standing results from `S0F-5C`, `S0F-5E`, and `S0F-5F`; this lane widens routing and manual screening surfaces rather than reopening those settled row outcomes by default.
+
+## Problem Statement
+
+- After `S0F-5F`, `S0E` no longer carries generic unresolved remainder, and the earlier small-series work has already removed the generic unresolved remainder from `S0B`, `S0C`, and `S0D`.
+- The repo can now explain per-series standing for several bounded pilots, but it still cannot show one expanded history/view line for the full remaining old-`S0` population in a way that supports low-risk manual contract screening.
+- Without one widened history/view layer, later contract admission review risks:
+  - filtering candidate contracts too early from partial source-log archaeology
+  - undercounting source-log and template contracts that are still real governance surfaces but not yet published as family-owned `DOC` bodies
+  - conflating `current contract`, `retained history`, `lineage`, `manual review candidate`, and `non-DOC` rows inside one support-only working ledger that is not meant to be a reader-facing review surface
+- The current counted root-log overview also leaves one separate early-ancestry gap: some `S0A` and `S0B` history is known to matter, but it is not represented as the same root-log population used by the current `84` / `63` old-`S0` views.
+- If that gap stays implicit, readers may mistake the counted root-log overview for the whole ancestry picture instead of the current bounded review scope.
+
+## PR Summary Inputs (optional)
+
+- Use this block because `S0F-5G` is expected to publish a widened history/view line first and to hand back one clearer manual screening surface rather than to auto-land one new contract by default.
+
+**PR summary bullets**:
+
+- Open the bounded lane for remaining old-`S0` history-line expansion.
+- Fix one explicit rule that history/view widening happens before manual contract screening.
+- Keep later six-outlet adjustment and contract admission human-guided instead of auto-filtered from partial row review.
+
+**PR checklist source**:
+
+- Default source: reuse this log's execution checklist for the history-line expansion lane.
+
+**PR links**:
+
+- Log: `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+- Previous log: `docs/logs/log-S0F-5F-remaining-s0e-standing-adjudication-and-packeted-review.md`
+
+## Exported Sections / Outlet Ownership
+
+- This slice starts as a reader-surface widening lane, not as a new `DOC` contract landing lane.
+- The default expected landing is in `view` and possibly in the existing standing surfaces, not in new current-rule records.
+
+**Outlet ownership**:
+
+- `contract`: no-op by default; any new contract landing should happen only after explicit manual screening on top of the widened history/view layer
+- `runbook`: no-op by default; this lane explains reading and review routing, not stable operator procedure
+- `view`: expected landing surface for remaining old-`S0` history-line expansion, widened reader routing, and manual screening support
+- `index/front-door`: possible later update only if the widened history/view layer changes first-open routing materially enough to justify it
+- `disposition/placement`: possible later write-back only when a row's widened history line proves a placement consequence directly
+- `log-retained core`: keep this source log for boundary, phase order, evidence ledger, and the explicit human-screening handoff rule
+
+## Definitions (optional)
+
+- **remaining old-`S0` history-line expansion**: widening reader-facing history/view coverage for old-`S0` rows that are still not concentrated into one clear current history line, even when their standing has already been adjudicated elsewhere
+- **manual screening surface**: one widened `view` layer that lets a human reviewer decide whether a row should stay history-only, become one current contract candidate, or require a six-outlet reassignment
+- **history/view-first lane**: one lane that improves reader routing and historical concentration before any later contract landing or outlet adjustment is attempted
+
+## Constraints
+
+- Do not reopen already-defended standing results just to force them into current contracts.
+- Do not treat the support-only working ledger as the final human review surface.
+- Do not assume every structurally important source-log or template rule should become one family-owned `DOC` current contract.
+- Do not widen this lane into support-only relocation execution or whole-repo cleanup movement.
+- Do not fabricate fake backdated source logs for issue-only ancestry that never existed in that shape locally.
+- Do not silently merge reconstructed issue-only ancestry into the counted old-`S0` totals until one later explicit reconstruction packet defends that scope change.
+
+## Scope
+
+- `P0`: open `S0F-5G`, wire it into the parent spine, and fix the history/view-first manual-screening boundary
+- `P1`: fix the exact remaining old-`S0` population that still needs widened history/view routing after the existing coverage, standing, and history-chain pilots
+- `P2`: land one widened history/view routing surface for the remaining old-`S0` population so readers can see the still-unconcentrated line without replaying the working ledger alone
+- `P3`: expand the series and/or chain surfaces needed so the remaining `S0F` backlog and the already-adjudicated non-surfaced rows become human-reviewable as one explicit history line
+- `P4`: publish one manual screening view or equivalent reader-facing packet that separates `candidate current contract`, `retain as history`, `lineage only`, `non-DOC`, and `needs six-outlet adjustment`
+- `P4` supplemental branch: publish one reader-facing routing surface for early `S0A` / `S0B` legacy-or-issue-only ancestry that currently sits outside the counted root-log review scope
+- `P5`: determine whether any bounded first write-back subset should follow immediately, or whether the lane should stop at human-screening publication and wait for manual review feedback
+- `P6`: fix the next owner after manual screening, including whether later follow-up should be contract-admission-first, six-outlet-adjustment-first, or no-op on most rows
+
+## Success Criteria (DoD)
+
+- One reader can inspect the remaining old-`S0` history line without relying on the support-only working ledger as the only global review surface.
+- The repo has one explicit manual screening surface for later human review of contract candidacy and six-outlet adjustments.
+- The lane leaves later contract-admission decisions more visible and less auto-filtered than the current partial history/view layer allows.
+- The repo also has one explicit supplemental routing surface for historically relevant early ancestry that is currently outside the counted root-log review scope because it survives only as legacy or issue-only evidence.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - the remaining old-`S0` history/view expansion boundary is explicit enough to reuse
+  - the widened history/view layer exists and is sufficient for manual review of the remaining line
+  - the next post-screening owner is explicit enough that later contract admission or outlet-adjustment work does not need to reopen the same history-line boundary first
+
+## P0 (Contract | v1)
+
+### P0-C1-S1 (History/view-first screening boundary fixed | v1)
+
+- `S0F-5G` is now opened as the remaining old-`S0` history-line expansion and manual-screening lane.
+- This slice does not decide that one new `DOC` contract packet already exists.
+- It first fixes that the next job is to widen reader-facing history/view coverage before one human reviewer filters contract candidates or outlet changes manually.
+
+### P0-C1-S2 (Immediate sequencing fixed | v1)
+
+- The immediate next work after scaffold is now fixed as:
+  - first inventory the remaining old-`S0` line that still lacks widened history/view routing
+  - then publish one widened history/view surface for that line
+  - then publish one manual screening packet on top of that widened surface
+- This keeps reader routing and human review ahead of any later contract landing pressure.
+
+## Plan (draft)
+
+### P1 (Remaining old-`S0` history-line inventory)
+
+- `P1-C1-S1`: fix the exact remaining old-`S0` row population that still lacks widened history/view routing after the current pilots
+- `P1-C1-S2`: fix the minimum routing classes that the later manual screening surface must expose
+
+### P1-C1-S1 (Remaining old-`S0` history-line population fixed | v1)
+
+- The remaining old-`S0` line that still lacks widened history/view routing is now fixed as the full non-surfaced remainder after the current `DOC` surfaced set, not just as the still-`unreviewed` subset.
+- The exact current remaining history-line population is now `63` rows, matching the current non-surfaced remainder in `view-old-s0-absorption-coverage-overview-v1.md`.
+- That `63`-row remainder is now split into two review classes:
+  - `45` already-adjudicated but still non-surfaced rows whose standing is already known, but whose wider history/view routing is still not concentrated enough for low-risk manual contract screening
+  - `18` still-unresolved `S0F` rows whose standing and wider history/view routing are both still missing
+- The `45` already-adjudicated but still non-surfaced rows are now fixed as:
+  - `S0B`: `S0B-2A`
+  - `S0C`: `S0C-2A`, `S0C-3A`, `S0C-3A-1A`, `S0C-3A-2A`, `S0C-3A-3A`, `S0C-4A`, `S0C-4A-1A`, `S0C-5A`
+  - `S0D`: `S0D-2A`, `S0D-3A`, `S0D-4A`, `S0D-5A`, `S0D-6A`
+  - `S0E`: `S0E-1A`, `S0E-1B`, `S0E-2A`, `S0E-2B`, `S0E-2C`, `S0E-3B`, `S0E-4A`, `S0E-4B`, `S0E-4C`, `S0E-4D`, `S0E-4E`, `S0E-4F`, `S0E-5A`, `S0E-5B`, `S0E-5C`, `S0E-5D`, `S0E-5E`, `S0E-6B`, `S0E-6D`, `S0E-6E`, `S0E-6F`, `S0E-7A`, `S0E-7B`, `S0E-7C`, `S0E-7D`, `S0E-7E`, `S0E-7F`, `S0E-7G`
+  - `S0F`: `S0F-1H`, `S0F-1I`, `S0F-1J`
+- The `18` still-unresolved `S0F` rows are now fixed as:
+  - `S0F-1C`, `S0F-1K`
+  - `S0F-2A`, `S0F-2B`
+  - `S0F-3A`, `S0F-3B`, `S0F-3C`, `S0F-3D`, `S0F-3E`, `S0F-3F`, `S0F-3G`, `S0F-3H`, `S0F-3J`, `S0F-3K`, `S0F-3L`, `S0F-3M`
+  - `S0F-4H`, `S0F-5A`
+- Under this `P1` boundary, later widened history/view routing should cover the whole remaining `63`-row line, but `P3` should enter the still-unresolved `18`-row `S0F` subset separately from the already-adjudicated `45`-row retained-history population.
+
+### P1-C1-S2 (Screening routing classes fixed | v1)
+
+- The minimum routing classes for the later manual screening surface are now fixed as six distinct reader-facing buckets:
+  - `standing-first unresolved`: the row still lacks defended standing and must not be screened for contract admission yet
+  - `candidate current-contract`: the row looks structurally current enough that later human review may consider one current contract concentration write
+  - `candidate current-view`: the row looks more like one possible current reader-surface concentration point than like one rule-body landing
+  - `retain as history`: the row should stay directly readable as retained historical evidence even after screening
+  - `lineage only`: the row is historically relevant, but current reading should open some later or stronger surface first rather than the row itself
+  - `non-DOC / external current-home`: the row's strongest current meaning already lives outside the current `DOC` surface or outside one reader-facing write target for this lane
+- These routing classes intentionally sit above the earlier standing vocabulary rather than replacing it:
+  - `retained-evidence`, `history-lineage`, `retired-lineage`, and `non-doc` remain valid standing answers
+  - the new routing classes decide how the later manual screening surface should present those standing answers for human contract and outlet review
+- The routing classes also intentionally preserve one explicit `needs six-outlet adjustment` consequence, but not as a first-pass population bucket:
+  - first the manual screening surface should show the six routing classes above
+  - then human review may mark a row inside one of those classes as a later `needs six-outlet adjustment` follow-up if its current outlet still looks wrong after the widened history line is visible
+- Under this rule, `P4` should publish one human-reviewable surface that separates unresolved rows from contract/view candidates and from rows that should remain retained, lineage-only, or outside `DOC`.
+
+### P2 (Widened history/view routing surface)
+
+- `P2-C1-S1`: land one widened history/view routing surface for the remaining old-`S0` line
+- `P2-C1-S2`: wire that surface into the existing old-`S0` reader routing set without collapsing it back into the working ledger
+
+### P2-C1-S1 (Widened history/view routing surface landed | v1)
+
+- The first widened remainder-routing surface now exists at `docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md`.
+- This first widened surface intentionally answers one reader-facing question only:
+  - `what is the full remaining old-S0 line after the current surfaced DOC set, and how should I route into it?`
+- The landed surface now makes three points explicit without dropping readers into the support-only working ledger first:
+  - the remaining line is the full `63`-row non-surfaced remainder
+  - that remainder splits into `45` already-adjudicated rows plus `18` still-unresolved `S0F` rows
+  - current first-open routing differs by series because `S0B`/`S0C`/`S0D`/`S0E` now have only adjudicated remainder while `S0F` still mixes adjudicated and unresolved remainder
+
+### P2-C1-S2 (Widened routing wired into the old-`S0` reader set | v1)
+
+- The old-`S0` reader-routing set now explicitly includes the new remainder-routing surface.
+- `view-old-s0-absorption-coverage-overview-v1.md` now points readers to `view-old-s0-remaining-history-line-routing-v1.md` when the question is the non-surfaced remainder itself rather than the surfaced set or the aggregate counts.
+- This keeps the new routing answer reader-facing while leaving the support-only working ledger in its intended working-only role.
+
+### P3 (Remaining old-`S0` history-line expansion)
+
+- `P3-C1-S1`: expand the remaining `S0F` series and adjacent retained-history line into explicit reader-facing history routing
+- `P3-C1-S2`: widen the already-adjudicated retained-history population enough that manual review no longer depends on row-by-row archaeology
+
+### P3-C1-S1 (Remaining `S0F` history line expanded | v1)
+
+- The unresolved `18`-row `S0F` subset is now widened into the same reader-facing detail surface as the already-adjudicated retained-history population.
+- This keeps the remaining `S0F` backlog visible as one explicit `standing-first unresolved` packet instead of leaving it implicit inside one series drill-down only.
+- `view-old-s0-series-s0f-standing-v1.md` now routes readers to the widened detail surface when the question broadens from `S0F` only to the full remaining old-`S0` line.
+
+### P3-C1-S2 (Adjudicated retained-history line widened for manual review | v1)
+
+- The widened detail surface now exists at `docs/governance/views/view-old-s0-remaining-history-line-detail-v1.md`.
+- The landed detail split is now explicit across four bounded remainder-line routes:
+  - `retain-direct-history`
+  - `lineage-only`
+  - `external-current-home`
+  - `standing-first unresolved`
+- This widened detail layer is intentionally still pre-screening:
+  - it exposes the exact remaining `63` rows in one readable history line
+  - it separates already-adjudicated rows from unresolved rows
+  - it does not yet convert those rows into contract-admission candidates automatically
+
+### P4 (Manual screening packet)
+
+- `P4-C1-S1`: publish one manual screening view or equivalent packet for candidate current-contract, retained-history, lineage-only, non-DOC, and outlet-adjustment rows
+- `P4-C1-S2`: fix the first human-review sequence for filtering that packet without auto-admitting a contract set
+
+### P4-C1-S1 (Manual screening packet published | v1)
+
+- The first manual-screening surface now exists at `docs/governance/views/view-old-s0-remaining-history-line-manual-screening-v1.md`.
+- The first-pass screen is intentionally conservative:
+  - `candidate current-contract`: none in the automatic first pass
+  - `candidate current-view`: none in the automatic first pass
+  - `retain as history`: `29` rows
+  - `lineage only`: `7` rows
+  - `non-DOC / external current-home`: `9` rows
+  - `standing-first unresolved`: `18` rows
+- This keeps the lane aligned with the human-review-first goal: the model now exposes the bucket structure without pretending to own the final admission filter.
+
+### P4-C1-S2 (Human-review sequence fixed | v1)
+
+- The first human-review order is now fixed as:
+  - first open `view-old-s0-remaining-history-line-routing-v1.md` for the full remainder shape
+  - then open `view-old-s0-remaining-history-line-detail-v1.md` for the widened row-by-row line
+  - then use `view-old-s0-remaining-history-line-manual-screening-v1.md` to challenge or refine the first-pass screening buckets
+  - only after that decide whether any row should move into one bounded later contract-admission or six-outlet-adjustment follow-up
+- Under this rule, `needs six-outlet adjustment` remains a later human consequence, not one auto-filled first-pass bucket.
+
+### P4-C1-S3 (Supplemental reconstructed ancestry branch attached | v1)
+
+- The lane now also publishes `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md` as one supplemental reader-facing route.
+- That surface exists for ancestry that is historically relevant to old-`S0` reading but is not part of the current counted root-log review scope.
+- The first attached anchor set is now fixed as:
+  - legacy `S0A` carry-forward anchor at `legacy/from_structured_docs/from-logs/v2-logs/log-S0A-dlq-replay-platform.md`
+  - legacy `S0B` parent decision anchor at `legacy/from_structured_docs/from-adrs/adr-S0B-docs-management-v2.md`
+  - missing-log `S0B-1A` issue-only ancestry placeholder, which remains intentionally unresolved until its GitHub issue evidence is materialized or summarized into one later bounded reconstruction packet
+- This branch intentionally does not mutate the counted `84` / `63` overview totals yet.
+- Its job is to make the current exclusion boundary explicit so the reader-facing old-`S0` view set does not falsely imply complete ancestry coverage.
+
+### P4-C2 (Supplemental reconstructed ancestry detail packet)
+
+- `P4-C2-S1`: publish one detail view for the current `S0A` / `S0B` supplemental anchor set so readers can inspect exact evidence state rather than only the existence of the branch
+- `P4-C2-S2`: wire the old-`S0` reader set so questions about exact supplemental anchors open the detail view rather than stopping at boundary-only routing
+
+### P4-C2-S1 (Supplemental reconstructed ancestry detail view published | v1)
+
+- The supplemental detail surface now exists at `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md`.
+- It expands the current early-ancestry branch row by row across:
+  - `S0A` legacy carry-forward anchor
+  - `S0B` parent legacy decision anchor
+  - `S0B-1A` issue-only missing-log placeholder
+- The detail packet intentionally uses `provisional reconstructed standing` instead of pretending that the missing issue-only evidence has already been reconstructed.
+
+### P4-C2-S2 (Supplemental exact-anchor routing wired | v1)
+
+- The old-`S0` reader set now routes exact `S0A` / `S0B` supplemental-anchor questions into the new detail surface.
+- The routing view remains the first-open exclusion-boundary answer.
+- The detail view now becomes the first-open answer when the reader needs to inspect exact local evidence and exact unresolved gaps inside that supplemental branch.
+
+### P5 (Post-screening consequence)
+
+- `P5-C1-S1`: determine whether any bounded first write-back subset is immediately safe after the screening surface lands
+- `P5-C1-S2`: determine whether the lane should stop at human-screening publication and wait for manual review feedback instead of auto-executing
+
+### P6 (Next-owner decision)
+
+- `P6-C1-S1`: fix whether the next bounded follow-up is contract-admission-first, six-outlet-adjustment-first, or no-op on most rows
+- `P6-C1-S2`: fix the next owner and stop boundary without reopening the same widened history-line inventory
+
+## Execution Checklist (unchecked)
+
+### P0 (Contract)
+
+- [x] `P0-C1-S1`: history/view-first screening boundary fixed
+- [x] `P0-C1-S2`: immediate sequencing fixed
+
+### P1 (Remaining old-`S0` history-line inventory)
+
+- [x] `P1-C1-S1`: remaining old-`S0` history-line population fixed
+- [x] `P1-C1-S2`: screening routing classes fixed
+
+### P2 (Widened history/view routing surface)
+
+- [x] `P2-C1-S1`: widened history/view routing surface landed
+- [x] `P2-C1-S2`: widened routing wired into the old-`S0` reader set
+
+### P3 (Remaining old-`S0` history-line expansion)
+
+- [x] `P3-C1-S1`: remaining `S0F` history line expanded
+- [x] `P3-C1-S2`: adjudicated retained-history line widened for manual review
+
+### P4 (Manual screening packet)
+
+- [x] `P4-C1-S1`: manual screening packet published
+- [x] `P4-C1-S2`: human-review sequence fixed
+- [x] `P4-C1-S3`: supplemental reconstructed ancestry branch attached
+- [x] `P4-C2-S1`: supplemental reconstructed ancestry detail view published
+- [x] `P4-C2-S2`: supplemental exact-anchor routing wired
+
+### P5 (Post-screening consequence)
+
+- [ ] `P5-C1-S1`: first write-back consequence determined
+- [ ] `P5-C1-S2`: stop-at-screening versus auto-execute consequence determined
+
+### P6 (Next-owner decision)
+
+- [ ] `P6-C1-S1`: next bounded follow-up type fixed
+- [ ] `P6-C1-S2`: next owner and stop boundary fixed
+
+## Current Status
+
+- `S0F-5G` is now opened as the bounded remaining old-`S0` history-line expansion lane after `S0F-5F` removed the last generic unresolved remainder from `S0E`.
+- `P0` is now complete: the lane is fixed as history/view-first and manual-screening-first rather than as another auto-admission lane.
+- `P1` is now complete: the remaining non-surfaced old-`S0` history line is now fixed as one explicit `63`-row remainder split into `45` already-adjudicated rows plus `18` still-unresolved `S0F` rows, and the later manual screening surface now has one defended six-class routing model.
+- `P2` is now complete: the repo now has one reader-facing remainder-routing surface for the full `63`-row non-surfaced old-`S0` line, and aggregate coverage routing now points readers there before they fall back to the support-only working ledger.
+- `P3` is now complete: the repo now has one widened detail/history-line surface for the full remaining `63`-row non-surfaced old-`S0` line, with the already-adjudicated retained-history population and the unresolved `18`-row `S0F` subset exposed together in one reader-facing view.
+- `P4` is now complete: the repo now has one explicit manual-screening view for the full remaining `63`-row non-surfaced old-`S0` line, and the first-pass screen intentionally leaves both candidate buckets empty so later contract admission or outlet change stays human-guided.
+- `P4-C1-S3` is now complete: the old-`S0` reader set now also exposes one supplemental reconstruction-routing view for early `S0A` / `S0B` legacy-or-issue-only ancestry, kept explicitly outside the counted `84` / `63` overview until a later bounded reconstruction packet decides whether any scope change is warranted.
+- `P4-C2` is now complete: the supplemental branch no longer stops at boundary-only routing, and readers can now inspect the exact `S0A` / `S0B` anchor set, current local evidence, and remaining `S0B-1A` unresolved gap through one detail surface.
+- The immediate next step is now `P5`: decide whether the lane should stop at screening publication and wait for your manual review, or whether one bounded first write-back subset is already safe enough to open next.
+
+## Evidence (reserved)
+
+### P0-C1-S1S2 (Remaining old-`S0` history-line expansion lane opened | 2026-04-10)
+
+- headSha: `<pending commit for S0F-5G/P0-C1-S1S2>`
+- artifacts:
+  - `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should have one explicit next lane for widening the old-`S0` history/view layer before later human contract screening
+  - the lane should not assume one automatic contract-admission packet from scaffold alone
+- observed:
+  - `S0F-5G` now fixes the boundary, sequencing, and manual-screening-first rule for remaining old-`S0` history/view expansion
+  - the parent spine now routes the next follow-up through this lane rather than through ad hoc remaining-row review
+
+### P1-C1-S1S2 (Remaining old-`S0` history-line inventory and screening classes fixed | 2026-04-10)
+
+- headSha: `<pending commit for S0F-5G/P1-C1-S1S2>`
+- artifacts:
+  - `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the remaining old-`S0` line should stop reading as one vague `outside surfaced set` bucket and instead become one explicit remainder population for widened history/view routing
+  - the later manual screening surface should have one explicit routing-class model before any human contract filtering begins
+- observed:
+  - the remaining old-`S0` line is now fixed as the full `63`-row non-surfaced remainder, split into `45` already-adjudicated rows plus `18` still-unresolved `S0F` rows
+  - the later manual screening surface now has one defended six-class routing model that keeps unresolved rows separate from candidate current-contract/current-view, retained-history, lineage-only, and non-DOC rows
+
+### P2-C1-S1S2 (Remaining old-`S0` routing surface landed and wired | 2026-04-10)
+
+- headSha: `<pending commit for S0F-5G/P2-C1-S1S2>`
+- artifacts:
+  - `docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md`
+  - `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+  - `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - readers should gain one first-open remainder-routing answer for the full non-surfaced old-`S0` line
+  - the aggregate coverage layer should now route non-surfaced questions to that new view rather than leaving readers to infer the remainder from counts alone
+- observed:
+  - `view-old-s0-remaining-history-line-routing-v1.md` now exposes the full `63`-row remainder split and the current first-open routing by series
+  - `view-old-s0-absorption-coverage-overview-v1.md` now routes the non-surfaced-remainder question into that new reader-facing surface
+
+### P3-C1-S1S2 (Remaining old-`S0` detail/history line widened | 2026-04-10)
+
+- headSha: `<pending commit for S0F-5G/P3-C1-S1S2>`
+- artifacts:
+  - `docs/governance/views/view-old-s0-remaining-history-line-detail-v1.md`
+  - `docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md`
+  - `docs/governance/views/view-old-s0-series-s0f-standing-v1.md`
+  - `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - readers should gain one detailed remaining-line view that exposes the already-adjudicated history rows and the unresolved `S0F` subset together
+  - the unresolved `S0F` remainder should stop reading as one series-only blind spot once the reader broadens back out to the full remaining line
+- observed:
+  - `view-old-s0-remaining-history-line-detail-v1.md` now widens the remaining line across direct retained history, lineage-only, external-current-home, and standing-first unresolved routes
+  - the routing view and the `S0F` series standing view now point readers into that widened detail surface when the question broadens beyond one series or beyond counts alone
+
+### P4-C1-S1S2 (Manual screening packet published with human-first sequence | 2026-04-10)
+
+- headSha: `<pending commit for S0F-5G/P4-C1-S1S2>`
+- artifacts:
+  - `docs/governance/views/view-old-s0-remaining-history-line-manual-screening-v1.md`
+  - `docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md`
+  - `docs/governance/views/view-old-s0-remaining-history-line-detail-v1.md`
+  - `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+  - `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - readers should gain one human-reviewable screening surface on top of the widened detail line
+  - the first pass should stay conservative enough that later contract admission remains a manual decision instead of a model-only filter
+- observed:
+  - `view-old-s0-remaining-history-line-manual-screening-v1.md` now separates the full remaining line into explicit human-review buckets while leaving both candidate buckets empty in the automatic first pass
+  - the aggregate, routing, and detail layers now all route manual-screening questions into that new surface instead of forcing readers back into the support-only ledger
+
+### P4-C1-S3 (Supplemental reconstructed ancestry routing attached | 2026-04-10)
+
+- headSha: `<pending local changes for S0F-5G/P4-C1-S3>`
+- artifacts:
+  - `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+  - `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md`
+  - `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+  - `docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md`
+  - `docs/governance/views/view-old-s0-remaining-history-line-manual-screening-v1.md`
+- expected:
+  - the reader-facing old-`S0` view set should acknowledge earlier `S0A` / `S0B` ancestry that currently sits outside the counted root-log review scope
+  - that acknowledgement should not silently change the counted `84` / `63` overview totals before one later explicit reconstruction packet exists
+- observed:
+  - one supplemental reconstruction-routing view now exposes the known early `S0A` and `S0B` anchors plus the unresolved `S0B-1A` issue-only placeholder
+  - the aggregate overview and counted-remainder routing surfaces now point readers to that supplemental branch when the question is about excluded early ancestry rather than counted old-`S0` rows
+
+### P4-C2-S1S2 (Supplemental reconstructed ancestry detail packet published and wired | 2026-04-10)
+
+- headSha: `<pending local changes for S0F-5G/P4-C2-S1S2>`
+- artifacts:
+  - `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md`
+  - `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-routing-v1.md`
+  - `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+  - `docs/governance/views/view-old-s0-remaining-history-line-routing-v1.md`
+  - `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
+- expected:
+  - readers should be able to inspect each known supplemental `S0A` / `S0B` anchor with current evidence state and current unresolved gaps instead of stopping at a boundary-only routing note
+  - the detail surface should stay evidence-first and should not fabricate a stronger `S0B-1A` standing than the current local evidence can defend
+- observed:
+  - one supplemental detail view now separates `S0A` as supplemental direct history, the `S0B` ADR as lineage-support anchor, and `S0B-1A` as unresolved issue-only placeholder
+  - the overview and routing layers now point exact-anchor questions into that detail surface while keeping the counted `84` / `63` overview totals unchanged
+
+## Recent changes (for traceability, optional)
+
+- 2026-04-10: opened `S0F-5G` as the bounded remaining old-`S0` history-line expansion and manual-screening lane after `S0F-5F` completed the remaining `S0E` standing adjudication.
+- 2026-04-10: completed `P1` by fixing the full remaining old-`S0` non-surfaced population and the minimum routing classes for later manual screening.
+- 2026-04-10: completed `P2` by landing the first remainder-routing view for the full non-surfaced old-`S0` line and wiring aggregate coverage routing to that new surface.
+- 2026-04-10: completed `P3` by widening the full remaining old-`S0` detail/history line into one reader-facing surface and by routing the unresolved `S0F` subset back into that wider remainder line.
+- 2026-04-10: completed `P4` by publishing the first human-reviewable screening view for the remaining old-`S0` line and by fixing the conservative manual-first review sequence on top of the widened routing and detail surfaces.
+- 2026-04-10: attached the `P4` supplemental reconstruction branch so the reader-facing old-`S0` view set now acknowledges early `S0A` / `S0B` ancestry outside the counted root-log scope without silently changing the `84` / `63` overview totals.
+- 2026-04-10: expanded the supplemental reconstruction branch into one exact-anchor detail surface so readers can now inspect the current `S0A` / `S0B` evidence set and the still-unresolved `S0B-1A` gap directly.


### PR DESCRIPTION
## Metadata

- Requested ID: `S0F-5G`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0f-5g`
- Source log: `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`
- Labels: `EVOLUTION, s0/knowledge system, drills`
- Development issue: #443

## Summary

- Open the bounded lane for remaining old-`S0` history-line expansion.
- Fix one explicit rule that history/view widening happens before manual contract screening.
- Keep later six-outlet adjustment and contract admission human-guided instead of auto-filtered from partial row review.

## Execution Checklist

- [x] `P0-C1-S1`: history/view-first screening boundary fixed
- [x] `P0-C1-S2`: immediate sequencing fixed
- [x] `P1-C1-S1`: remaining old-`S0` history-line population fixed
- [x] `P1-C1-S2`: screening routing classes fixed
- [x] `P2-C1-S1`: widened history/view routing surface landed
- [x] `P2-C1-S2`: widened routing wired into the old-`S0` reader set
- [x] `P3-C1-S1`: remaining `S0F` history line expanded
- [x] `P3-C1-S2`: adjudicated retained-history line widened for manual review
- [x] `P4-C1-S1`: manual screening packet published
- [x] `P4-C1-S2`: human-review sequence fixed
- [x] `P4-C1-S3`: supplemental reconstructed ancestry branch attached
- [x] `P4-C2-S1`: supplemental reconstructed ancestry detail view published
- [x] `P4-C2-S2`: supplemental exact-anchor routing wired

## Links

- Log: `docs/logs/log-S0F-5G-remaining-old-s0-history-line-expansion-and-manual-screening.md`

Closes #443
