### PR TITLE
S0F-5I/P0-P4: old-S0 narrative history widening across counted series v1

### DIFF
--- a/docs/governance/views/view-old-s0-narrative-history-packet-s0d-s0c-v1.md
+++ b/docs/governance/views/view-old-s0-narrative-history-packet-s0d-s0c-v1.md
@@ -1,0 +1,104 @@
+# Old S0 Narrative History Packet S0D S0C v1
+
+## Purpose
+
+- This view is the first counted-series narrative-history packet after the early `S0A + S0B` pilot.
+- It exists so readers can understand why the combined `S0D + S0C` packet appeared, what problems its rows addressed, what results they left behind, and where those results later read now.
+- It reuses the `S0F-5H` eight-field narrative model on one bounded counted-series packet before the lane widens into the larger mixed `S0E` series.
+
+## Packet Boundary
+
+- This packet covers one bounded combined counted-series set only:
+  - `S0D-1A`
+  - `S0D-2A`
+  - `S0D-3A`
+  - `S0D-4A`
+  - `S0D-5A`
+  - `S0D-6A`
+  - `S0C-1A`
+  - `S0C-2A`
+  - `S0C-3A`
+  - `S0C-3A-1A`
+  - `S0C-3A-2A`
+  - `S0C-3A-3A`
+  - `S0C-4A`
+  - `S0C-4A-1A`
+  - `S0C-5A`
+- It intentionally starts with the smallest fully-defended counted series and does not yet widen into `S0E` or the still-unresolved `S0F` subset.
+
+## Narrative Model
+
+| field | job |
+| --- | --- |
+| `source log` | the exact historical source under review |
+| `why it appeared` | the trigger or pressure that caused the row to exist |
+| `scoped problem` | the boundary or problem the row tried to repair |
+| `decision / result` | the result, decision, or stabilized outcome it left behind |
+| `what changed after it` | the later inheritance or concentration path |
+| `current historical role` | the current reader-facing role of the row |
+| `current first-open home` | where readers should open next after understanding the row |
+| `reader note` | compact ambiguity, exclusion, or caution note |
+
+## Narrative History Rows
+
+| source log | why it appeared | scoped problem | decision / result | what changed after it | current historical role | current first-open home | reader note |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0D-1A` | `once the repo accumulated more logs, evidence packets, and phase slices, the line needed one explicit orchestration grammar instead of ad hoc child-log sprawl` | `entry drift, naming drift, and broken evidence closure would grow if parent logs and phase logs kept evolving without one shared bookkeeping pattern` | `the row fixes the parent-spine plus phase-log model, the `P/C/S` numbering habit, and the reusable log templates that later make bounded execution logs mechanically readable` | `that orchestration result later survives as one structural prerequisite for current DOC history reading and for later log grammar adoption outside the original slice` | `structural prerequisite` | `view-doc-history-and-lineage-v1.md` | `this row is already surfaced because later DOC history reading depends on the parent-spine and phase-log grammar it stabilized` |
+| `S0D-2A` | `as drills and hard-gate runs multiplied, manual evidence bookkeeping stopped scaling and the line needed one reusable automation structure` | `run directories, result ledgers, and write-gate summaries would drift if each drill or workflow packed evidence differently` | `the row defines one reusable drills/evidence automation structure: fixed run-dir layout, machine-readable run summaries, and shared evidence-chain bookkeeping` | `later workflow artifact helpers, snapshot roots, and retained run ledgers now carry the live implementation of that automation contract` | `retained governance evidence` | `backend/scripts/ci/workflow_artifacts.py` plus `docs/labs/_snapshot/auto/` and `artifacts/*runs*.json` | `the historical row matters because it fixed the evidence-governance shape, but current reading now starts from the live helper and snapshot surfaces rather than from the old log itself` |
+| `S0D-3A` | `once runbooks started to proliferate, the line needed one rule for when a topic deserved a stable operator entry and when it should remain a log-only history item` | `without one top-level-scope runbook strategy, operator entrypoints would sprawl into many competing thin docs or disappear into logs` | `the row adopts top-level-scope runbooks, fixes runbook-thinness and reference rules, and separates operator procedure from log or issue history` | `later runbook templates and stable operator-entry surfaces inherit that rule as the normal repo-local runbook grammar` | `retained governance evidence` | `docs/runbook/_template-runbook.md` plus `docs/runbook/run-S5B-security-governance-hard-gates.md` and `docs/runbook/run-S6A-evidence-drills-spine.md` | `the row remains direct governance history, but its active meaning now reads through the adopted runbook template and current operator entries` |
+| `S0D-4A` | `frontend fixes were accumulating without a durable lightweight evidence path, but pushing every UI issue into the heavy backend evidence flow was too expensive` | `the repo lacked one bounded way to record UI workflow bugs, visual proof, and escalation decisions without turning every fix into a hard-gate log` | `the row establishes the UI evidence-lite track: note template, layered escalation rule, and asset-handling contract for front-end fixes` | `that result later lives through the UI evidence-lite README, template, and asset rules rather than through the original governance log` | `retained governance evidence` | `docs/UI&UX/README.md` plus `docs/UI&UX/UI-FIX-NOTE-TEMPLATE.md` and `docs/UI&UX/assets/README.md` | `this row sits outside the DOC surfaced set because its current meaning belongs to repo-local UI evidence practice rather than DOC history concentration` |
+| `S0D-5A` | `after drills automation existed, repeated workflow runs still packed success and failure evidence inconsistently and needed one packing contract` | `single-scenario runs were uploading unrelated snapshot material, while failure triage still needed one downloadable evidence bundle` | `the row unifies evidence packing around one minimal-success and failure-bundle contract, keeping workflow artifacts machine-readable and operator-friendly` | `later reusable workflow code and artifact helpers now own the active packaging behavior for drill and failure workflows` | `retained governance evidence` | `.github/workflows/reusable-labs-scenario-runner.yml` plus `backend/scripts/ci/workflow_artifacts.py` and `.github/workflows/drill-failures.yml` | `the row remains bounded packing-governance history while current packing behavior now reads through the workflow and helper surfaces` |
+| `S0D-6A` | `roadmaps, demos, and legacy ADR materials had started to sprawl across inconsistent containers and needed one structured organization rule` | `without one structured container model, roadmap lineage, demo assets, and retained legacy materials would remain hard to find and hard to evolve safely` | `the row fixes structured roadmap and demo containers: milestone-based roadmap templates, bounded demo roots, and legacy-readonly relocation rules` | `later roadmap templates, bridge-aware roadmap surfaces, and demo roots now carry that organizational result directly` | `retained governance evidence` | `docs/roadmap/road-template-main-roadmap.md` plus `docs/roadmap/road-template-branch-roadmap.md` and `docs/demo/demo-001/` | `this row stays as historical container-governance context and is secondary to later direct roadmap bridge and demo surfaces` |
+| `S0C-1A` | `as logs kept multiplying, readers needed each log to expose the decision and current state quickly instead of reading long diary-style prose` | `without one explicit decision-first log structure, conclusions, non-goals, and validation boundaries would stay scattered and hard to hand off` | `the row introduces the reusable log-extension grammar: top-level decision or outcome, single status field, and current-effective-body discipline` | `that result later becomes one structural prerequisite for current DOC history reading and for later log-template concentration` | `structural prerequisite` | `view-doc-history-and-lineage-v1.md` | `this row is already surfaced because later DOC history reading depends on the decision-first log structure it stabilized` |
+| `S0C-2A` | `legacy integration suites kept failing even though they no longer described the current system, so the line needed one defended retirement rule instead of endless compatibility repair` | `old module layouts and removed domain APIs were creating false regressions that blocked current-system delivery without protecting live behavior` | `the row retires the legacy integration suites through explicit module-level skip and shifts protection to current application, repository, and invariant-focused tests` | `current protection now reads through the current library integration and invariant test surfaces instead of through those retired legacy narratives` | `retired legacy suite lineage` | `backend/api/app/tests/test_library/test_integration_round_trip.py` and `backend/api/app/tests/test_integration_four_modules.py` | `this row remains important because it marks where the repo stopped treating old integration narratives as active quality gates` |
+| `S0C-3A` | `the giant CLI entrypoint had become a context and maintenance bottleneck, so the line needed one thinner structure instead of one increasingly overloaded command file` | `parser logic, scenario behavior, and evidence packing were too entangled inside `cli.py`, making both engineering and tool-assisted reading unstable` | `the row adopts the thin-entry plus scenario-module model: `cli.py` becomes dispatch-first while handlers and shared CLI machinery move into `cli_app`` | `current command behavior now reads through the thin CLI entry and the `cli_app` execution modules rather than through the original breakdown log` | `retained governance evidence` | `backend/scripts/cli.py` and `backend/scripts/cli_app/` | `the row is counted history, but the live repo surfaces now carry the active CLI structure directly` |
+| `S0C-3A-1A` | `the CLI could not be moved safely in one shot, so the line needed a migration bridge that preserved behavior while new handlers landed behind the old interface` | `a direct cutover risked breaking help output, arguments, exit codes, and evidence contracts that workflows and operators already depended on` | `the row fixes the shim or double-parallel migration strategy: old commands become thin bridges into registered handlers while keeping outward behavior stable` | `once the handler model settled, current CLI behavior continued through the thin entry and scenario modules while the bridge itself became historical migration evidence` | `retained governance evidence` | `backend/scripts/cli.py` and `backend/scripts/cli_app/` | `this row remains direct migration history because it explains how the repo moved from one giant entrypoint to the current module split without a hard break` |
+| `S0C-3A-2A` | `after handler migration started, repeated artifact writing and zip logic still lived in too many places and needed one explicit packing contract` | `evidence paths, `_result.json` writing, and workflow packaging would drift if each scenario or workflow kept its own hand-rolled packing code` | `the row concentrates artifacts contract and packing into shared helpers while preserving existing paths, file names, and CI-facing evidence semantics` | `later shared helper surfaces now own the active artifact write-path and workflow packaging behavior` | `retained governance evidence` | `backend/scripts/cli_app/common.py` plus workflow-side shared artifact helpers | `the row matters because it made later CLI and workflow evolution mechanically safer, but it is no longer the first-open rule surface itself` |
+| `S0C-3A-3A` | `once handlers and packing had started moving out, the remaining parser and dispatch mass still needed one final structural cutover` | `the repo still risked an oversized `cli.py` and duplicated parser definitions unless dispatch and argparse were explicitly extracted` | `the row fixes dispatch-only CLI thinning and argparse extraction as the stable CLI shape for later scenario execution` | `that result later survives directly in the thin CLI entry and parser module rather than as a standalone historical contract body` | `retained governance evidence` | `backend/scripts/cli.py` and `backend/scripts/cli_app/parser.py` | `this row closes the CLI-thinning sequence by turning the earlier migration strategy into the current parser and dispatch structure` |
+| `S0C-4A` | `workflow and scenario growth had turned drills into a maintenance-heavy cockpit, so the line needed one readable taxonomy and one catalog-driven workflow model` | `intent, pipeline, and runtime requirements were mixed together inside giant workflows, making scenario naming and workflow maintenance unstable` | `the row adopts the three-axis taxonomy, canonical scenario ids, suite-versus-runner split, and scenario catalog as the single source of truth` | `later scenario catalog, reusable runners, and operator runbooks now carry the active workflow and scenario structure` | `retained governance evidence` | `docs/runbook/run-S0C-scenarios-taxonomy.md` and `docs/labs/scenarios/catalog.yml` | `the row remains counted history because it explains the taxonomy decision, while current operator reading now starts from the runbook and catalog` |
+| `S0C-4A-1A` | `after taxonomy landed, suite workflows still risked drift unless catalog references and workflow inputs were constrained by guardrails` | `catalog ids, aliases, and workflow references could diverge silently, pushing failures to runtime instead of catching them during review` | `the row adds catalog-driven suites and minimal CI guardrails, making scenario ids, aliases, and workflow references mechanically checkable` | `current suite validation and scenario-id discipline now read through the catalog validator, guardrail workflow, and operator lookup path` | `retained governance evidence` | `docs/labs/scenarios/catalog.yml`, `backend/scripts/ci/validate_scenario_catalog.py`, and `.github/workflows/ci-scenario-guardrails.yml` | `this row is direct governance history for how the taxonomy was made enforceable rather than merely descriptive` |
+| `S0C-5A` | `once more work moved through structured logs, the repo needed one naming rule for commit and push descriptions instead of ad hoc phase wording` | `without one parsable grammar for commit and PR descriptions, later execution history would be harder to replay, audit, and concentrate into parent-spine logs` | `the row fixes the `P/C/S`-style commit and PR naming grammar and the expectation that bounded execution work should leave machine-readable phase descriptions` | `that naming result later concentrates into the parent-spine and phase-log orchestration model rather than standing alone as a current first-open surface` | `history-lineage` | `docs/logs/log-S0D-1A-log-entries-orchestration.md` plus `docs/logs/_template-log-parent-epic-spine.md` and `docs/logs/_template-log-phase-drills-evidence.md` | `this row is lineage rather than direct current-home concentration because its strongest present meaning survives inside the later log-orchestration grammar` |
+
+## Reader Summary
+
+- `S0D` explains how the repo fixed the operating containers around logs, evidence, runbooks, UI evidence-lite, workflow packaging, and roadmap or demo organization.
+- `S0C` explains how the repo fixed the change grammar and execution surfaces around logs, legacy-test retirement, CLI decomposition, scenario taxonomy, and commit-description discipline.
+- Together this packet shows one counted-series narrative shape dominated by retained governance evidence, with two surfaced structural prerequisites (`S0D-1A`, `S0C-1A`), one retired-lineage row (`S0C-2A`), and one explicit history-lineage row (`S0C-5A`).
+- The packet therefore proves the eight-field narrative model can scale from an early mixed ancestry pilot into a larger counted history packet without reopening standing results.
+
+## Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `where should I start if I want the old-S0 narrative packet set as a whole?` | `view-old-s0-narrative-history-routing-v1.md` | the aggregate router is now the first-open entry across the published packet set |
+| `why did the counted S0D + S0C packet exist, and what did it leave behind?` | `view-old-s0-narrative-history-packet-s0d-s0c-v1.md` | this packet is the first counted-series narrative answer after the early `S0A + S0B` pilot |
+| `inside S0D, what is the standing of each old log now?` | `view-old-s0-series-s0d-standing-v1.md` | the series standing view remains the current-state answer for `S0D` |
+| `inside S0C, what is the standing of each old log now?` | `view-old-s0-series-s0c-standing-v1.md` | the series standing view remains the current-state answer for `S0C` |
+| `how much of old S0 is surfaced overall?` | `view-old-s0-absorption-coverage-overview-v1.md` | aggregate absorption remains a separate count-first question |
+
+## Reader Notes
+
+- This packet exists to answer `why / problem / result / inheritance`, not merely `current home`.
+- The packet intentionally stops before `S0E`, because `S0E` is the first large fully-defended mixed series and belongs to the next counted-series stress test rather than the first bounded packet.
+- The packet also stops before unresolved `S0F`, because this lane widens narrative reading and does not reopen standing adjudication.
+
+## Source Refs
+
+- `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`
+- `docs/logs/log-S0D-1A-log-entries-orchestration.md`
+- `docs/logs/log-S0D-2A-drills-evidence-automation.md`
+- `docs/logs/log-S0D-3A-runbook-stub.md`
+- `docs/logs/log-S0D-4A-UI-layered-fix-notes.md`
+- `docs/logs/log-S0D-5A-drills-evidence-packing-unification.md`
+- `docs/logs/log-S0D-6A-structured-roadmap-and-demo.md`
+- `docs/logs/log-S0C-1A-log-extensions.md`
+- `docs/logs/log-S0C-2A-legacy-integration-suite-retired.md`
+- `docs/logs/log-S0C-3A-cli-breakdown.md`
+- `docs/logs/log-S0C-3A-1A-double-parallel.md`
+- `docs/logs/log-S0C-3A-2A-artifacts-contract-packing.md`
+- `docs/logs/log-S0C-3A-3A-dispatch-only-argparse-extraction.md`
+- `docs/logs/log-S0C-4A-scenarios-taxonomy.md`
+- `docs/logs/log-S0C-4A-1A-catalog-driven-suites-&-guardrails.md`
+- `docs/logs/log-S0C-5A-Git-commit+push-descriptions.md`
+- `docs/governance/views/view-old-s0-series-s0d-standing-v1.md`
+- `docs/governance/views/view-old-s0-series-s0c-standing-v1.md`

--- a/docs/governance/views/view-old-s0-narrative-history-packet-s0e-v1.md
+++ b/docs/governance/views/view-old-s0-narrative-history-packet-s0e-v1.md
@@ -1,0 +1,157 @@
+# Old S0 Narrative History Packet S0E v1
+
+## Purpose
+
+- This view is the second counted-series narrative-history packet after the combined `S0D + S0C` rollout.
+- It exists so readers can understand why the `S0E` series appeared, what problems its rows addressed, what results they left behind, and where those results later read now.
+- It reuses the same eight-field narrative model on the first large fully-defended mixed counted series.
+
+## Packet Boundary
+
+- This packet covers the full counted `S0E` series:
+  - `S0E-1A`
+  - `S0E-1B`
+  - `S0E-2A`
+  - `S0E-2B`
+  - `S0E-2C`
+  - `S0E-2D`
+  - `S0E-2E`
+  - `S0E-3A`
+  - `S0E-3B`
+  - `S0E-4A`
+  - `S0E-4B`
+  - `S0E-4C`
+  - `S0E-4D`
+  - `S0E-4E`
+  - `S0E-4F`
+  - `S0E-5A`
+  - `S0E-5B`
+  - `S0E-5C`
+  - `S0E-5D`
+  - `S0E-5E`
+  - `S0E-6A`
+  - `S0E-6B`
+  - `S0E-6C`
+  - `S0E-6D`
+  - `S0E-6E`
+  - `S0E-6F`
+  - `S0E-7A`
+  - `S0E-7B`
+  - `S0E-7C`
+  - `S0E-7D`
+  - `S0E-7E`
+  - `S0E-7F`
+  - `S0E-7G`
+- It intentionally follows the `S0D + S0C` packet because `S0E` is the first large counted mixed series where current-contract, current-view, retained-evidence, history-lineage, retired-lineage, and non-DOC rows coexist.
+
+## Narrative Model
+
+| field | job |
+| --- | --- |
+| `source log` | the exact historical source under review |
+| `why it appeared` | the trigger or pressure that caused the row to exist |
+| `scoped problem` | the boundary or problem the row tried to repair |
+| `decision / result` | the result, decision, or stabilized outcome it left behind |
+| `what changed after it` | the later inheritance or concentration path |
+| `current historical role` | the current reader-facing role of the row |
+| `current first-open home` | where readers should open next after understanding the row |
+| `reader note` | compact ambiguity, exclusion, or caution note |
+
+## Narrative History Rows
+
+| source log | why it appeared | scoped problem | decision / result | what changed after it | current historical role | current first-open home | reader note |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0E-1A` | `the repo needed one structured CV generation path instead of ad hoc resume variants` | `markdown, templating, and generated CV assets lacked one repeatable container and generation flow` | `the row establishes the first structured CV generator path with markdown plus template discipline` | `later demo CV roots and `scripts/cv/` carry the live tooling and output path` | `non-DOC demo/tooling row` | `docs/demo/demo-001/_cv/` plus `scripts/cv/` | `this row belongs to the demo/tooling line rather than the current DOC issue-governance family` |
+| `S0E-1B` | `after structured CV generation, the line tested whether docx export could be made minimal and repeatable` | `the repo lacked one low-overhead docx export path that justified staying in the active workflow` | `the experiment remains one bounded archived sample rather than a continued current-system path` | `markdown CVs and preserved export scripts remain the historical trace while active reading no longer starts from this row` | `retired archive lineage` | `docs/logs/log-S0E-1B-md-to-docx-minimal-sample.md` plus preserved CV export scripts | `the historical meaning survives, but it no longer acts as one current reading surface` |
+| `S0E-2A` | `issue creation had reached the point where manual translation from logs into GitHub issues was too inconsistent to scale` | `keywords, labels, and issue body structure lacked one controlled contract for semi-automated creation` | `the row fixes the first semi-automated issue-creation contract: controlled keywords, labels, and body scaffold` | `later runbook guidance and draft-generation scripts now carry the live issue-creation behavior` | `retained issue-creation contract evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus `scripts/issues/gen_issue_draft.py` | `this row matters because it fixed the first creation boundary, but current reading now starts from the runbook and script surfaces` |
+| `S0E-2B` | `once draft generation worked, the line needed one guarded real-create path rather than manual copy-paste into GitHub` | `real GitHub issue creation needed explicit opt-in and fail-closed behavior around missing metadata` | `the row establishes real issue creation as a guarded mode with deterministic create-time checks` | `current create-mode behavior now reads through the runbook and the live script entry rather than through the row itself` | `retained real-create automation evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus `scripts/issues/gen_issue_draft.py --create` | `the active result survives in the live create path rather than in a separate DOC contract body` |
+| `S0E-2C` | `after single-item create worked, the line needed one batch path for issue planning, backfill, and relationship work` | `parent-child linking, backfill, and batch issue creation lacked one reusable planning and dry-run shape` | `the row expands issue creation into batch manifests, relationship planning, and backfill tooling` | `later operator reading now starts from the runbook and batch planning scripts instead of the historical expansion row` | `retained batch-orchestration evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus `scripts/issues/plan_issue_batch.py`, `scripts/issues/plan_issue_relationships.py`, and `scripts/issues/plan_issue_backfill.py` | `this row remains bounded orchestration history while current use reads through the planning tools` |
+| `S0E-2D` | `issue creation needed a stronger source-owned contract once the first automation boundary was proven` | `metadata, English-only body shape, and relationship bridges still lacked one current-rule concentration point` | `the row fixes the source-owner issue-creation metadata and body contract that later becomes the stable DOC surface` | `that result now concentrates directly in `DOC-ICR-0001`` | `source-owner contract` | `DOC-ICR-0001` | `this is one of the absorbed current-contract rows inside the series` |
+| `S0E-2E` | `issue conclusion needed one equally explicit contract once creation semantics had stabilized` | `conclusion wording, development linkage, and close-out expectations were still too implicit and error-prone` | `the row fixes the issue-conclusion and development-linkage contract that later becomes the stable DOC conclusion surface` | `that result now concentrates directly in `DOC-ICL-0001`` | `source-owner contract` | `DOC-ICL-0001` | `this is the conclusion-side absorbed contract row in the series` |
+| `S0E-3A` | `roadmap and child-log evolution needed one explicit bridge instead of prose-only milestone tracking` | `without one milestone-log bridge, roadmap status and child-log execution would drift and become hard to audit` | `the row fixes the roadmap-milestone-log bridge as one stable lineage milestone for later governance reading` | `that result later survives inside the current DOC history view rather than as a separate current contract` | `lineage milestone` | `view-doc-history-and-lineage-v1.md` | `this row is already surfaced because later DOC history reading depends on the bridge milestone it stabilized` |
+| `S0E-3B` | `label governance needed to be split from generic issue creation once live create paths began to touch GitHub state directly` | `live label inventory and preflight behavior were still too mixed with the rest of issue generation` | `the row isolates live label preflight into one reusable create-adjacent gate` | `current enforcement now reads through the runbook and the script-level label-preflight paths` | `retained live-label preflight evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus `scripts/issues/gen_issue_draft.py` and `scripts/issues/plan_issue_batch.py` | `the row remains bounded gate history while the active enforcement lives in the runbook and scripts` |
+| `S0E-4A` | `once issues could be created, the repo needed one explicit PR automation contract instead of manual preparation` | `PR planning, commit prep, and create-time metadata still lacked one stable automation boundary` | `the row fixes the first PR automation contract and the planning/create split that current tooling reuses` | `current operator reading now starts from the runbook and the live PR planning/create surfaces` | `retained PR-automation contract evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus `scripts/issues/plan_pr_prep.py` and `scripts/issues/plan_pr_create_preflight_with_gate.py` | `the row remains historical contract evidence, but active PR flow now lives through the runbook and scripts` |
+| `S0E-4B` | `after PR automation existed, title, label, and body generation still needed one narrower formatting contract` | `PR title compression, label inheritance, and body structure could still drift between automation paths` | `the row tightens PR formatting and labeling into one reusable helper-oriented contract` | `current title/body behavior now reads through PR rewrite helpers and related prep surfaces` | `retained PR-formatting evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus `scripts/issues/rewrite_pr_body_scope_from_log.py` and PR-prep helpers | `the active result now lives in helper surfaces rather than a separate DOC body` |
+| `S0E-4C` | `PR summaries and GitHub issue relationships still needed one exact alignment after the formatting follow-up` | `development-link sections, summary wording, and issue relationship application were still split across surfaces` | `the row fixes PR summary and relationship follow-up so relationship application becomes deterministic` | `current relationship behavior now reads through the runbook and relationship planners or appliers` | `retained PR-linkage evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus `scripts/issues/plan_issue_relationships.py` and `scripts/issues/apply_issue_relationships.py` | `the row remains as history of the relationship boundary while live apply paths now own the active result` |
+| `S0E-4D` | `lifecycle orchestration needed one explicit mode split once creation and PR paths both existed` | `the repo lacked one clear boundary between review-hold and full-auto lifecycle behavior` | `the row fixes review-hold versus full-auto lifecycle orchestration as one guarded operator contract` | `current operator reading now starts from the runbook procedure and lifecycle tooling instead of the old log` | `retained lifecycle-orchestration evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` review-hold or full-auto procedure plus lifecycle planners | `this row is direct orchestration history, but the live procedure now starts elsewhere` |
+| `S0E-4E` | `PR event attribution became necessary once more automation began to rewrite or conclude GitHub state` | `the repo needed one fail-closed way to decide which source log owned a PR event` | `the row fixes the attribution problem boundary and the requirement for explicit source-log ownership` | `later attribution resolution now reads operationally through the resolver and the `S0E-7B` implementation surfaces` | `lineage for current attribution handoff` | `scripts/issues/resolve_pr_source_log_attribution.py` plus `docs/logs/log-S0E-7B-attribution-handoff-implementation-and-auto-mirroring-integration.md` | `this row remains historically relevant because later implementation inherits the boundary it defined` |
+| `S0E-4F` | `even after PR body formatting improved, metadata links still remained redundant and needed one narrower cleanup boundary` | `the repo still carried redundant metadata-link rendering inside PR bodies` | `the row removes redundant metadata-link surfaces and narrows PR body structure further` | `current body-generation behavior now reads through the runbook and helper surfaces rather than through the row itself` | `retained PR-body cleanup evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus current PR body helpers and follow-up artifacts | `the active PR body shape now lives through helper surfaces instead of a current DOC target` |
+| `S0E-5A` | `before more live lifecycle mutations could be trusted, the repo needed one audit gate and dry-run planner` | `live state validation, preflight planning, and deterministic stop conditions were still missing` | `the row fixes the lifecycle audit gate and dry-run planner as the guarded shell for later flows` | `current completeness semantics now concentrate in `GC-COMPL-0001`, while the planner shell survives as retained history` | `retained planner shell` | `GC-COMPL-0001` plus `scripts/issues/plan_lifecycle_pre_gate.py` | `this row now reads as bounded planner-shell history rather than the current rule surface itself` |
+| `S0E-5B` | `once the gate existed, guarded lifecycle mutation had to widen beyond planning into real apply surfaces` | `relationship attach, PR rewrite, and similar live mutations still lacked one guarded expansion path` | `the row expands guarded lifecycle apply across more family-owned mutation surfaces` | `current operator reading now starts from the live lifecycle planners and the runbook procedure` | `retained guarded-lifecycle expansion evidence` | `scripts/issues/plan_lifecycle_remediation.py` plus `docs/runbook/run-S0E-log-to-issue-creation.md` | `the row remains direct evidence of guarded expansion while current usage reads through live planners` |
+| `S0E-5C` | `PR create was too large to trust as one opaque guarded step and needed decomposition` | `front-half gate behavior and later stage sequencing were not explicit enough for repeatable guarded PR create` | `the row decomposes guarded PR create into explicit stages and keeps the front-half gate narrow` | `current guarded PR-create behavior now reads through the live gate and planning surfaces` | `retained guarded PR-create decomposition evidence` | `scripts/issues/plan_pr_create_preflight_with_gate.py` plus `docs/runbook/run-S0E-log-to-issue-creation.md` | `this row remains as decomposition history while the active create path now lives in the live surfaces` |
+| `S0E-5D` | `body rendering and completeness gates needed one normalized contract after multiple automation paths had diverged` | `multiple renderers and gate shapes risked drifting apart and weakening body-contract guarantees` | `the row normalizes body contract and gate shape into one reusable check surface` | `current verification and body-check behavior now reads through the live check surfaces and runbook` | `retained body-contract normalization evidence` | `scripts/issues/plan_body_completeness_check_wrapper.py`, `scripts/issues/verify_live_pr_body_contract.py`, and `docs/runbook/run-S0E-log-to-issue-creation.md` | `the row remains bounded gate-normalization history while live checks now own the active result` |
+| `S0E-5E` | `parent-issue closure quality depended on child order, but GitHub numbering and source ordering were still too easy to mix` | `parent DoD rendering needed one deterministic child-log ordering rule instead of relying on issue-number drift` | `the row fixes parent-issue DoD child ordering as a source-log-owned boundary` | `later issue-body and ordering surfaces inherit that rule rather than reading from the row as one first-open home` | `lineage for parent-issue ordering boundary` | `docs/logs/log-S0E-6F-issue-body-metadata-links-boundary-follow-up.md` plus current issue-body procedures | `the row is historically relevant because later body and ordering work inherits the boundary it fixed` |
+| `S0E-6A` | `logs were becoming harder to use for both readers and automation, so one dual-track structure was needed` | `human-readable evidence and automation-facing summaries were too mixed inside the same prose-only log bodies` | `the row fixes log-structure normalization and the dual-track evidence contract as one later history milestone` | `that result later survives inside current DOC history reading and newer structured logs` | `lineage milestone` | `view-doc-history-and-lineage-v1.md` | `this row is already surfaced because later DOC history reading depends on the structured-log milestone it stabilized` |
+| `S0E-6B` | `after log structure normalized, the repo still needed one stronger strategy for when logs could move from draft to stable` | `AI-authored logs and weakly structured flows lacked one defended log-stability and gate strategy` | `the row defines the broader log-stability and gate strategy that later narrower body and lifecycle gates inherit` | `later issue and lifecycle gate procedures absorb the active result while this row remains the broader strategy lineage` | `lineage for log-stability gate strategy` | `docs/logs/log-S0E-6A-log-structure-normalization-and-dual-track-evidence-contract.md` plus later issue/lifecycle gate procedures | `this row remains historically relevant because later concrete gates inherit the strategy it set` |
+| `S0E-6C` | `issue Context had become too inconsistent and needed one deterministic sentence contract` | `issue bodies lacked a stable Context shape and sentence-count boundary` | `the row fixes the issue-context sentence contract and gate, which later becomes the current DOC context surface` | `that result now concentrates directly in `DOC-ICT-0001`` | `source-owner contract` | `DOC-ICT-0001` | `this is the series row where Context semantics become one current DOC contract` |
+| `S0E-6D` | `after the sentence contract existed, rigid Context assembly still felt too mechanical and needed one more natural rendering path` | `source-log facts were being rendered too rigidly to produce natural issue Context prose` | `the row shifts issue-context rendering toward natural source-log-derived prose under the existing weak gate boundary` | `current context-authoring behavior now reads through the runbook and live authoring helpers` | `retained issue-context rendering evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus issue-context authoring and refresh helpers | `the row remains bounded rendering history while live context authoring now owns the active result` |
+| `S0E-6E` | `natural Context authoring still needed one explicit preserve boundary once batch refresh workflows appeared` | `single-item authoring and batch preserve behavior were too easy to blur together` | `the row fixes single-item context authoring versus batch-preserve as one explicit boundary` | `current preserve-versus-author behavior now reads through the refresh workflow and authoring procedure` | `retained context-authoring boundary evidence` | `current issue-context refresh artifacts plus the runbook's single-item authoring procedure` | `this row remains bounded boundary history while current reading now starts from the live refresh and authoring surfaces` |
+| `S0E-6F` | `issue body rendering still carried metadata-link ambiguity even after earlier PR-side cleanup work` | `Metadata and Links boundaries in issue bodies were still mixed and needed one final source-owned cleanup` | `the row cleans the issue-body metadata-links boundary and narrows where navigation links belong` | `current issue-body rendering now reads through the runbook and current rendering helpers` | `retained issue-body boundary evidence` | `docs/runbook/run-S0E-log-to-issue-creation.md` plus current issue-body rendering helpers and follow-up artifacts | `the row remains direct evidence of the final boundary cleanup while the active rendering path now lives elsewhere` |
+| `S0E-7A` | `once local lifecycle automation existed, the repo needed one explicit stance on what GitHub Actions should and should not own` | `secondary enforcement, mirroring, and GitHub-side verification were still not clearly separated from local primary flows` | `the row defines GitHub Actions as a secondary-enforcement boundary rather than the primary source-authoring path` | `later attribution handoff and workflow-failure packet surfaces inherit that posture` | `lineage for later workflow enforcement` | `docs/logs/log-S0E-7B-attribution-handoff-implementation-and-auto-mirroring-integration.md` plus the later `S0E-7D` through `S0E-7G` workflow surfaces | `the row remains historically relevant because later workflow surfaces inherit the boundary it defined` |
+| `S0E-7B` | `after the secondary-enforcement boundary was set, attribution handoff and mirroring still needed a concrete implementation path` | `the repo lacked one operational handoff from source-log ownership to workflow-side attribution and mirroring` | `the row implements attribution handoff and auto-mirroring integration as the concrete workflow-side realization of the earlier boundary` | `current operational reading now starts from the attribution resolver and workflow hooks rather than from the historical implementation row` | `retained attribution-handoff evidence` | `scripts/issues/resolve_pr_source_log_attribution.py` plus workflow-side attribution/mirroring hooks | `this row stays as retained implementation evidence while the active logic now reads through the resolver and hooks` |
+| `S0E-7C` | `the repo still had a historical lifecycle backlog that needed one bounded review and sampling path instead of ad hoc archaeology` | `older logs had unresolved lifecycle states and no deterministic mirror or review planning surface` | `the row fixes historical-log review sampling and mirror follow-up as a bounded audit-planning path` | `current audit behavior now reads through lifecycle audit planning and retained review artifacts rather than through the row itself` | `retained historical-review audit evidence` | `scripts/issues/plan_lifecycle_audit.py` plus current audit planning artifacts | `this row remains bounded review-planning history while current audit behavior reads through the planning surfaces` |
+| `S0E-7D` | `secondary workflow enforcement still needed one current rule surface for publish, verify, remediation, and failure semantics` | `failure classification, replay ordering, and remediation semantics lacked one stable current-home concentration point` | `the row fixes workflow-failure taxonomy and handling semantics as the current GC rule surface` | `that result now concentrates directly in `GC-WF-0001`, while later wrapper rows remain retained support` | `source-owner contract` | `GC-WF-0001` | `this is a non-DOC current rule row: the active meaning now lives in GC rather than DOC` |
+| `S0E-7E` | `once the workflow-failure contract existed, the repo still needed one thin orchestration surface over existing family adapters` | `multiple family-owned publish or verify paths lacked one normalized orchestration entrypoint` | `the row introduces the thin orchestration gate that reuses existing adapters under a shared vocabulary` | `its retained body now lives under support-only, while current workflow-failure meaning reads through `GC-WF-0001` and the planner surface` | `retained orchestration shell (support-only body; root stub preserved)` | `GC-WF-0001` plus `docs/logs/support-only/s0/log-S0E-7E-publish-verify-remediation-gate-thin-orchestration-entrypoint.md` and `scripts/issues/plan_publish_verify_remediation_gate.py` | `the root stub preserves exact-path landing, but the retained body now lives under support-only` |
+| `S0E-7F` | `after the thin gate existed, the repo needed one read-only wrapper to expose the same semantics without live mutation` | `secondary enforcement still lacked one wrapper that replayed the gate in a read-only posture` | `the row adopts the read-only wrapper over the thin gate as a bounded secondary-enforcement surface` | `its retained body now lives under support-only, while current rule meaning still reads through `GC-WF-0001`` | `retained wrapper evidence (support-only body; root stub preserved)` | `GC-WF-0001` plus `docs/logs/support-only/s0/log-S0E-7F-publish-verify-remediation-gate-read-only-wrapper-adoption.md` and `scripts/issues/plan_publish_verify_remediation_gate_read_only_wrapper.py` | `the root stub preserves historical citations while the retained body now lives under support-only` |
+| `S0E-7G` | `once the read-only wrapper existed, GitHub-side workflow dispatch still needed one thin transport surface` | `manual dispatch, artifact publication, and GitHub-side read-only invocation lacked one narrow workflow surface` | `the row adds the workflow_dispatch wrapper as the transport and retained artifact-publication layer` | `its retained body now lives under support-only, while current workflow-failure meaning still reads through `GC-WF-0001` and the dispatch workflow` | `retained transport evidence (support-only body; root stub preserved)` | `GC-WF-0001` plus `docs/logs/support-only/s0/log-S0E-7G-publish-verify-remediation-gate-workflow-dispatch-wrapper-surface.md` and `.github/workflows/s0e-publish-verify-remediation-gate-read-only-wrapper-dispatch.yml` | `the root stub preserves exact-path landing while the retained body now lives under support-only` |
+
+## Reader Summary
+
+- `S0E` explains how the repo turned issue and pull-request authoring from loose manual routines into one bounded automation system with explicit contracts, gates, attribution, lifecycle planning, and secondary GitHub-side enforcement.
+- Early rows establish issue and PR creation or conclusion boundaries; middle rows split lifecycle, body, and context semantics into narrower contracts and gates; later rows push those semantics into attribution, review, and workflow-failure surfaces.
+- The packet demonstrates the widest defended narrative mix so far: current DOC contracts, current DOC history milestones, retained repo-local evidence, lineage into later surfaces, retired archive lineage, and non-DOC current-rule concentration in GC.
+- The packet therefore proves the eight-field model still scales on the first large counted mixed series without reopening the field contract first.
+
+## Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `where should I start if I want the old-S0 narrative packet set as a whole?` | `view-old-s0-narrative-history-routing-v1.md` | the aggregate router is now the first-open entry across the published packet set |
+| `why did the counted S0E packet exist, and what did it leave behind?` | `view-old-s0-narrative-history-packet-s0e-v1.md` | this packet is the reader-facing narrative answer for the full `S0E` series |
+| `inside S0E, what is the standing of each old log now?` | `view-old-s0-series-s0e-standing-v1.md` | the series standing view remains the current-state answer for `S0E` |
+| `how much of old S0 is surfaced overall?` | `view-old-s0-absorption-coverage-overview-v1.md` | aggregate absorption remains a separate count-first question |
+| `which rows are already admitted into the surfaced set across all series?` | `view-old-s0-migration-ledger-v1.md` | cross-series surfaced projection stays in the migration ledger |
+
+## Reader Notes
+
+- This packet exists to answer `why / problem / result / inheritance`, not merely `current home`.
+- `S0E` is the first large counted mixed series where current-contract, current-view, retained-evidence, history-lineage, retired-lineage, and non-DOC rows all coexist in one packet.
+- `S0E-7E`, `S0E-7F`, and `S0E-7G` retain direct historical bodies under support-only while preserved root stubs remain exact-path landing surfaces for older citations and artifacts.
+
+## Source Refs
+
+- `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`
+- `docs/governance/views/view-old-s0-series-s0e-standing-v1.md`
+- `docs/logs/log-S0E-1A-structured-cv-generator.md`
+- `docs/logs/log-S0E-1B-md-to-docx-minimal-sample.md`
+- `docs/logs/log-S0E-2A-semi-automated-git-issue-creation.md`
+- `docs/logs/log-S0E-2B-real-github-issue-creation-automation.md`
+- `docs/logs/log-S0E-2C-batch-issue-creation-and-backfill-tooling.md`
+- `docs/logs/log-S0E-2D-issue-creation-metadata-and-english-body-contract.md`
+- `docs/logs/log-S0E-2E-issue-conclusion-and-development-linkage-contract.md`
+- `docs/logs/log-S0E-3A-roadmap-milestone-log-bridge.md`
+- `docs/logs/log-S0E-3B-github-label-inventory-and-live-preflight.md`
+- `docs/logs/log-S0E-4A-github-pr-automation-contract.md`
+- `docs/logs/log-S0E-4B-pr-title-label-and-body-follow-up.md`
+- `docs/logs/log-S0E-4C-pr-summary-development-link-and-issue-relationship-follow-up.md`
+- `docs/logs/log-S0E-4D-review-hold-and-full-auto-lifecycle-orchestration-follow-up.md`
+- `docs/logs/log-S0E-4E-pr-event-source-log-attribution-contract.md`
+- `docs/logs/log-S0E-4F-pr-body-metadata-links-redundancy-follow-up.md`
+- `docs/logs/log-S0E-5A-lifecycle-audit-gate-and-dry-run-planner.md`
+- `docs/logs/log-S0E-5B-guarded-lifecycle-apply-expansion.md`
+- `docs/logs/log-S0E-5C-guarded-pr-create-decomposition.md`
+- `docs/logs/log-S0E-5D-body-contract-and-gate-shape-normalization.md`
+- `docs/logs/log-S0E-5E-parent-issue-dod-child-log-ordering-and-gate.md`
+- `docs/logs/log-S0E-6A-log-structure-normalization-and-dual-track-evidence-contract.md`
+- `docs/logs/log-S0E-6B-log-stability-and-gate-strategy.md`
+- `docs/logs/log-S0E-6C-issue-context-sentence-contract-and-gate.md`
+- `docs/logs/log-S0E-6D-natural-issue-context-rendering-and-weak-gate.md`
+- `docs/logs/log-S0E-6E-single-item-context-authoring-and-batch-preserve-boundary.md`
+- `docs/logs/log-S0E-6F-issue-body-metadata-links-boundary-follow-up.md`
+- `docs/logs/log-S0E-7A-github-actions-secondary-enforcement.md`
+- `docs/logs/log-S0E-7B-attribution-handoff-implementation-and-auto-mirroring-integration.md`
+- `docs/logs/log-S0E-7C-historical-log-review-sampling-and-mirror-follow-up.md`
+- `docs/logs/log-S0E-7D-publish-verify-remediation-and-failure-semantics.md`
+- `docs/logs/support-only/s0/log-S0E-7E-publish-verify-remediation-gate-thin-orchestration-entrypoint.md`
+- `docs/logs/support-only/s0/log-S0E-7F-publish-verify-remediation-gate-read-only-wrapper-adoption.md`
+- `docs/logs/support-only/s0/log-S0E-7G-publish-verify-remediation-gate-workflow-dispatch-wrapper-surface.md`

--- a/docs/governance/views/view-old-s0-narrative-history-pilot-s0a-s0b-v1.md
+++ b/docs/governance/views/view-old-s0-narrative-history-pilot-s0a-s0b-v1.md
@@ -1,0 +1,77 @@
+# Old S0 Narrative History Pilot S0A S0B v1
+
+## Purpose
+
+- This view is the first reader-facing narrative-history pilot for old-`S0`.
+- It exists so readers can understand why the early `S0A + S0B` packet appeared, what problems it addressed, what results it left behind, and where those results later read now.
+- It complements standing and routing views; it does not replace them.
+
+## Pilot Boundary
+
+- This pilot covers one bounded five-item mixed set only:
+  - `S0A` legacy carry-forward anchor
+  - `S0B` parent ADR anchor
+  - `S0B-2A`
+  - `S0B-3A`
+  - `S0B-1A` unresolved issue-only placeholder
+- It intentionally combines counted `S0B` mainline reading with supplemental `S0A / S0B` ancestry reading.
+- It does not yet widen to `S0C`, `S0D`, `S0E`, or `S0F`.
+
+## Narrative Model
+
+| field | job |
+| --- | --- |
+| `source log` | the exact historical source or bounded ancestry item under review |
+| `why it appeared` | the trigger or pressure that caused the item to exist |
+| `scoped problem` | the boundary or problem the item tried to repair |
+| `decision / result` | the result, decision, or stabilized outcome it left behind |
+| `what changed after it` | the later inheritance or concentration path |
+| `current historical role` | the current reader-facing role of the historical item |
+| `current first-open home` | where readers should open next after understanding the row |
+| `reader note` | compact ambiguity, exclusion, or caution note |
+
+## Narrative History Rows
+
+| source log | why it appeared | scoped problem | decision / result | what changed after it | current historical role | current first-open home | reader note |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A` legacy carry-forward anchor | `once search and chronicle both needed replay safety, DLQ plus replay stopped being one projection-specific concern and became a shared platform pressure` | `failure handling, replay semantics, operator workflow, and SLO language would drift if each projection solved them separately` | `the retained `S0A` anchor defines DLQ/replay as one shared platform capability with a common contract, common operator mental model, shared SLO vocabulary, and control-group diagnosis framing` | `later repo-local worker, replay, and operational surfaces carry the implementation-level result, but no counted old-S0 row currently concentrates this early platform framing into the counted overview` | `supplemental direct history` | `view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md` | `this row remains outside the counted old-S0 overview even though it is now readable inside the supplemental ancestry branch` |
+| `S0B` parent ADR anchor | `after script sprawl, snapshot sprawl, and fragile path memory had already become chronic repo friction, the line needed one parent decision rather than only local fixes` | `the repo lacked one stable decision on directory taxonomy, front matter, cutover rules, snapshot roots, and stub preservation` | `the ADR adopts docs-management v2 as the parent decision: stable taxonomy, stable entrypoint, unified snapshot roots, front matter metadata, and cutover plus stub policy` | `counted `S0B-2A` and `S0B-3A` later act as execution-level children that apply and refine this parent decision inside the counted old-S0 mainline` | `supplemental lineage-support anchor` | `legacy/from_structured_docs/from-adrs/adr-S0B-docs-management-v2.md` | `this anchor is outside counted scope because it survives as a legacy ADR rather than a counted root log` |
+| `S0B-2A` | `cleanup of scripts and experiment outputs repeatedly exposed the same uncontrolled growth pattern` | `without taxonomy, stable entrypoint, unified snapshot roots, and cutover rules, the repo would fall back into script swamp and snapshot garbage accumulation` | `the row establishes the working governance skeleton for tools/scripts and snapshots management: species taxonomy, single CLI entry, unified evidence roots, cutover, and stub discipline` | `its current operational meaning now reads through `backend/scripts/cli.py`, script-area layout, and `docs/labs/_snapshot/` plus `docs/runbook/_snapshot/` rather than through the row as one current DOC surface` | `retained governance evidence` | `backend/scripts/cli.py` plus `docs/labs/_snapshot/` and `docs/runbook/_snapshot/`` | `this is counted `S0B` mainline history, but it remains outside the surfaced DOC set because the live repo surfaces now carry the active result` |
+| `S0B-3A` | `once directory and workflow evolution accelerated, naming, chronology, module identity, and mechanical metadata could no longer stay coupled` | `the repo needed one scheme that decoupled time order from delivery identity and made metadata mechanically maintainable across logs, labs, issues, runbooks, and ADRs` | `the row fixes unified indices, legacy taxonomy handling, and front matter as the stable naming-and-metadata model for later governance evolution` | `that result later survives as one structural prerequisite in current DOC history reading rather than as an unresolved standalone old row` | `structural prerequisite inside counted mainline` | `view-doc-history-and-lineage-v1.md` | `this row is already surfaced into the current DOC history view because later DOC reading depends on the naming and front-matter model it stabilized` |
+| `S0B-1A` unresolved issue-only placeholder | `the early docs-management line appears to have one more historically relevant child item before the counted `S0B` mainline fully stabilizes` | `the repo does not currently have one local source log, local issue artifact, or equivalent retained packet that can defend a stronger historical statement` | `no defended decision or result should be claimed yet; the correct result is currently an explicit unresolved placeholder` | `a later bounded issue-only evidence packet is required before this row can be upgraded from placeholder into direct history or lineage support` | `unresolved supplemental ancestry` | `view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md` | `this row is intentionally visible so the narrative pilot does not fake completeness where source evidence is still missing` |
+
+## Reader Summary
+
+- `S0A` explains the pre-counted platform pressure: DLQ/replay became infrastructure rather than one narrow script fix.
+- The `S0B` parent ADR turns that pressure into one governance decision package for taxonomy, metadata, cutover, and snapshot roots.
+- `S0B-2A` applies that package as concrete tooling and evidence-governance structure.
+- `S0B-3A` tightens the naming/index/front-matter side and later becomes a structural prerequisite for current DOC history reading.
+- `S0B-1A` remains the explicit early gap: historically relevant, but still not materially reconstructable from local source-owned evidence.
+
+## Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `where should I start if I want the old-S0 narrative packet set as a whole?` | `view-old-s0-narrative-history-routing-v1.md` | the aggregate router is now the first-open entry across the published packet set |
+| `why did the early S0A + S0B packet exist, and what did it leave behind?` | `view-old-s0-narrative-history-pilot-s0a-s0b-v1.md` | this pilot is the first reader-facing answer to that narrative question |
+| `which exact early anchors exist outside counted scope?` | `view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md` | the supplemental detail view remains the exact-anchor inventory |
+| `inside counted S0B, what is the current standing of each row?` | `view-old-s0-series-s0b-standing-v1.md` | the counted series standing view remains the current-state answer |
+| `how much of old S0 is surfaced overall?` | `view-old-s0-absorption-coverage-overview-v1.md` | aggregate absorption remains a separate count-first question |
+
+## Reader Notes
+
+- This pilot exists to answer `why / problem / result / inheritance`, not merely `current home`.
+- Narrative history and standing classification are complementary:
+  - use this pilot when the reader needs the change story
+  - use standing or routing views when the reader needs current placement, surfaced status, or manual-screening state
+- The unresolved `S0B-1A` row is part of the pilot by design so the field model proves it can represent missing historical evidence honestly.
+
+## Source Refs
+
+- `docs/logs/log-S0F-5H-old-s0-narrative-history-view-pilot.md`
+- `legacy/from_structured_docs/from-logs/v2-logs/log-S0A-dlq-replay-platform.md`
+- `legacy/from_structured_docs/from-adrs/adr-S0B-docs-management-v2.md`
+- `docs/logs/log-S0B-2A-scripts-snapshots-management.md`
+- `docs/logs/log-S0B-3A-unified-indices-legacy taxonomy -front matter.md`
+- `docs/governance/views/view-old-s0-series-s0b-standing-v1.md`
+- `docs/governance/views/view-old-s0-issue-only-reconstructed-ancestry-detail-v1.md`

--- a/docs/governance/views/view-old-s0-narrative-history-routing-v1.md
+++ b/docs/governance/views/view-old-s0-narrative-history-routing-v1.md
@@ -1,0 +1,51 @@
+# Old S0 Narrative History Routing v1
+
+## Purpose
+
+- This view is the aggregate narrative-routing surface for old-`S0`.
+- It exists so readers can choose the right narrative-history packet without inferring packet boundaries from standing views, ancestry routes, or aggregate coverage tables.
+- It complements the existing packet views; it does not replace them.
+
+## Boundary
+
+- This routing surface covers the currently published old-`S0` narrative packet set:
+  - supplemental early `S0A + S0B` narrative pilot
+  - counted `S0D + S0C` packet
+  - counted `S0E` packet
+- It also records the current not-yet-published boundary for the reviewed `S0F` subset so readers do not mistake the current packet set for full counted-series completeness.
+
+## Packet Set Snapshot
+
+| packet | scope now | open first | why |
+| --- | --- | --- | --- |
+| `early supplemental packet` | early `S0A + S0B` ancestry outside counted root-log scope | `view-old-s0-narrative-history-pilot-s0a-s0b-v1.md` | this packet explains the earliest pressure, parent decision, counted `S0B` execution anchors, and the still-unresolved `S0B-1A` gap |
+| `first counted packet` | counted `S0D + S0C` | `view-old-s0-narrative-history-packet-s0d-s0c-v1.md` | this packet explains the first bounded counted-series rollout across structural prerequisites, retained governance evidence, retired lineage, and history-lineage |
+| `second counted packet` | counted `S0E` | `view-old-s0-narrative-history-packet-s0e-v1.md` | this packet explains the large mixed issue/PR/lifecycle/workflow automation series where current-contract, current-view, retained-evidence, lineage, retired-lineage, and non-DOC rows coexist |
+| `reviewed S0F subset` | not yet published as one narrative packet | `view-old-s0-series-s0f-standing-v1.md` plus `view-old-s0-remaining-history-line-detail-v1.md` | the current repo has standing and remainder routing for `S0F`, but one separate bounded narrative packet for the reviewed subset has not yet been published |
+
+## Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `where should I start if I want the old-S0 narrative packet set as a whole?` | `view-old-s0-narrative-history-routing-v1.md` | this surface is the first-open narrative router across the currently published packet set |
+| `what is the earliest old-S0 narrative packet, including ancestry outside counted scope?` | `view-old-s0-narrative-history-pilot-s0a-s0b-v1.md` | the early pilot remains the first answer for supplemental ancestry and early packet emergence |
+| `what is the first counted narrative packet after the early pilot?` | `view-old-s0-narrative-history-packet-s0d-s0c-v1.md` | the combined `S0D + S0C` packet is the first counted-series rollout |
+| `what is the large mixed counted automation packet?` | `view-old-s0-narrative-history-packet-s0e-v1.md` | `S0E` is the first large counted mixed packet with multiple standing/result shapes |
+| `what is the current state of S0F before a later narrative packet exists?` | `view-old-s0-series-s0f-standing-v1.md` and `view-old-s0-remaining-history-line-detail-v1.md` | `S0F` currently reads through standing plus remainder detail rather than through one published narrative packet |
+| `how much of old S0 is surfaced overall?` | `view-old-s0-absorption-coverage-overview-v1.md` | aggregate absorption remains a separate count-first question |
+
+## Reader Notes
+
+- Separate packet views are no longer sufficient as the only first-open narrative entry, because there is now more than one published packet and the packet set spans both supplemental and counted scope.
+- This router intentionally does not claim full narrative completeness for all old-`S0` rows.
+- The reviewed `S0F` subset remains an explicit later follow-up boundary rather than an implied missing row inside the current packet set.
+- Current `S0F` reading is still split across surfaced standing, adjudicated remainder reading, and `18` unresolved standing-first rows, so a later `S0F` narrative packet should open as its own bounded follow-up rather than as an extension silently implied by this router.
+
+## Source Refs
+
+- `docs/governance/views/view-old-s0-narrative-history-pilot-s0a-s0b-v1.md`
+- `docs/governance/views/view-old-s0-narrative-history-packet-s0d-s0c-v1.md`
+- `docs/governance/views/view-old-s0-narrative-history-packet-s0e-v1.md`
+- `docs/governance/views/view-old-s0-series-s0f-standing-v1.md`
+- `docs/governance/views/view-old-s0-remaining-history-line-detail-v1.md`
+- `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`

--- a/docs/governance/views/view-old-s0-series-s0c-standing-v1.md
+++ b/docs/governance/views/view-old-s0-series-s0c-standing-v1.md
@@ -1,0 +1,74 @@
+# Old S0 Series S0C Standing v1
+
+## Purpose
+
+- This view is the fourth bounded series drill-down surface for old-`S0` absorption reading.
+- It exists so readers can inspect `S0C` log by log and see which rows are already surfaced, which current reading home they now use, and which rows still remain outside the surfaced set.
+
+## Series Boundary
+
+- This fourth bounded drill-down covers `S0C` only.
+- `S0C` is the larger unfinished small-series follow-up after `S0D`, so publishing its standing surface is the remaining prerequisite for bounded series review under the same drill-down model already proven for `S0B`, `S0D`, `S0E`, and `S0F`.
+
+## Drill-Down Model
+
+| field | job |
+| --- | --- |
+| `source log` | exact old-`S0` source log in this series |
+| `series` | fixed series bucket for this drill-down surface |
+| `currently surfaced` | whether the row is already admitted into the current old-`S0 -> DOC` surfaced set |
+| `reader-facing standing` | one bounded current-reading classification from the `S0F-6B/P1` vocabulary |
+| `current family` | current owning family when known |
+| `current reading home` | current contract body, current `view`, or unresolved state |
+| `history role` | bounded historical role such as structural prerequisite or unresolved |
+| `notes` | short reader-facing explanation |
+
+## S0C Drill-Down
+
+| source log | series | currently surfaced | reader-facing standing | current family | current reading home | history role | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0C-1A` | `S0C` | `yes` | `current-view` | `DOC` | `view-doc-history-and-lineage-v1` | `structural prerequisite` | `already admitted into the surfaced set as one pre-DOC structural prerequisite for current DOC history reading` |
+| `S0C-2A` | `S0C` | `no` | `retired-lineage` | `repo current-library test surfaces` | `backend/api/app/tests/test_library/test_integration_round_trip.py` and `backend/api/app/tests/test_integration_four_modules.py` (module-level skipped) | `retired legacy suite lineage` | `the row records the defended retirement of legacy integration narratives whose failures no longer indicate current-system regressions; the historical meaning survives, but current protection now reads through current library application, repository, and invariant-focused tests instead of through these suites as active quality gates` |
+| `S0C-3A` | `S0C` | `no` | `retained-evidence` | `repo CLI and scenario execution surfaces` | `backend/scripts/cli.py` and `backend/scripts/cli_app/` | `retained CLI-structure governance evidence` | `the row remains bounded CLI thinning and scenario-handler decomposition governance, while current command behavior now reads through the live dispatch-only entry and `cli_app` execution modules rather than through one DOC-facing history surface` |
+| `S0C-3A-1A` | `S0C` | `no` | `retained-evidence` | `repo CLI and scenario execution surfaces` | `backend/scripts/cli.py` and `backend/scripts/cli_app/` | `retained migration-bridge evidence` | `the row records the temporary double-parallel migration bridge that preserved CLI behavior while handlers moved into `cli_app`; current behavior now reads through the landed thin-entry and scenario modules rather than through the bridge log itself` |
+| `S0C-3A-2A` | `S0C` | `no` | `retained-evidence` | `repo CLI artifact-contract and workflow evidence surfaces` | `backend/scripts/cli_app/common.py` plus workflow-side shared artifact helpers | `retained artifact-contract convergence evidence` | `the row remains bounded evidence-contract and packing convergence history, while current artifact write-path and packing behavior now read through the shared helper surfaces instead of through the old convergence log as a current rule source` |
+| `S0C-3A-3A` | `S0C` | `no` | `retained-evidence` | `repo CLI parser and dispatch surfaces` | `backend/scripts/cli.py` and `backend/scripts/cli_app/parser.py` | `retained dispatch-thinning evidence` | `the row records the later dispatch-only and argparse-extraction cutover, while current parser and callback wiring now read through the thin CLI entry and parser module rather than through the historical cutover log` |
+| `S0C-4A` | `S0C` | `no` | `retained-evidence` | `repo scenario catalog and operator-entry surfaces` | `docs/runbook/run-S0C-scenarios-taxonomy.md` and `docs/labs/scenarios/catalog.yml` | `retained scenario-taxonomy governance evidence` | `the row remains bounded taxonomy and suite-entry convergence history, while current operator discovery now reads through the stable runbook and catalog single source of truth rather than through one DOC-facing history surface` |
+| `S0C-4A-1A` | `S0C` | `no` | `retained-evidence` | `repo scenario catalog, guardrail, and suite workflow surfaces` | `docs/labs/scenarios/catalog.yml`, `backend/scripts/ci/validate_scenario_catalog.py`, and `.github/workflows/ci-scenario-guardrails.yml` | `retained catalog-guardrail evidence` | `the row records the guardrail and catalog-driven suite closure that current drills already reuse, while live catalog validation and workflow references now read through the stable catalog and guardrail surfaces rather than through the old convergence log` |
+| `S0C-5A` | `S0C` | `no` | `history-lineage` | `repo log-orchestration and naming surfaces` | `docs/logs/log-S0D-1A-log-entries-orchestration.md` plus `docs/logs/_template-log-parent-epic-spine.md` and `docs/logs/_template-log-phase-drills-evidence.md` | `lineage for current log grammar` | `the row is historically relevant because its step/cycle naming and PR-description discipline later concentrate into the parent-spine and template-based log-orchestration model; it remains outside the DOC surfaced set and does not justify a separate cleanup move` |
+
+## Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `inside S0C, what is the standing of each old log now?` | `view-old-s0-series-s0c-standing-v1.md` | this surface is the bounded per-log standing answer for the `S0C` series |
+| `why did the counted S0C packet exist, and what did it leave behind?` | `view-old-s0-narrative-history-packet-s0d-s0c-v1.md` | the counted narrative packet answers the change-story question that the standing table does not |
+| `how much of old S0 is surfaced by series overall?` | `view-old-s0-absorption-coverage-overview-v1.md` | aggregate counts and distribution are not repeated here |
+| `which admitted rows exist across all series?` | `view-old-s0-migration-ledger-v1.md` | cross-series admitted-row projection stays in the migration ledger |
+| `how did one current DOC surface emerge from this history?` | `view-old-s0-contract-history-chain-doc-drb-0001-v1.md` or the later matching chain view | current-surface-first evolution reading belongs in the history-chain layer, not in the series standing table |
+
+## Reader Notes
+
+- Read this view when the question is `inside S0C, what is the standing of each old log now?`
+- Use `view-old-s0-absorption-coverage-overview-v1.md` when the question is still aggregate and series-level only.
+- Use `view-old-s0-migration-ledger-v1.md` when the question is `which rows are already admitted into the surfaced set across all series?`
+- Use `view-old-s0-narrative-history-packet-s0d-s0c-v1.md` when the question is no longer current standing but `why did these S0C rows exist and what did they leave behind?`
+- This fourth `S0C` surface closed the last missing small-series drill-down prerequisite before row-level review, and the bounded `P6` review now resolves the remaining eight rows without widening the current `DOC` surfaced set.
+- `S0C-1A` remains the only already surfaced row in the series.
+- `S0C-2A` now reads as retired legacy-suite lineage, `S0C-3A` through `S0C-4A-1A` now read as retained repo-local CLI/scenario governance evidence, and `S0C-5A` now reads as history-lineage for the current log-orchestration grammar rather than as one cleanup-admission candidate.
+
+## Source Refs
+
+- `docs/logs/log-S0F-6B-old-s0-absorption-coverage-and-history-chain-views.md`
+- `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+- `docs/governance/views/view-old-s0-migration-ledger-v1.md`
+- `docs/logs/log-S0F-5E-small-series-review-sequencing-and-standing-surface-completion.md`
+- `docs/logs/log-S0C-1A-log-extensions.md`
+- `docs/logs/log-S0C-2A-legacy-integration-suite-retired.md`
+- `docs/logs/log-S0C-3A-cli-breakdown.md`
+- `docs/logs/log-S0C-3A-1A-double-parallel.md`
+- `docs/logs/log-S0C-3A-2A-artifacts-contract-packing.md`
+- `docs/logs/log-S0C-3A-3A-dispatch-only-argparse-extraction.md`
+- `docs/logs/log-S0C-4A-scenarios-taxonomy.md`
+- `docs/logs/log-S0C-4A-1A-catalog-driven-suites-&-guardrails.md`
+- `docs/logs/log-S0C-5A-Git-commit+push-descriptions.md`

--- a/docs/governance/views/view-old-s0-series-s0d-standing-v1.md
+++ b/docs/governance/views/view-old-s0-series-s0d-standing-v1.md
@@ -1,0 +1,67 @@
+# Old S0 Series S0D Standing v1
+
+## Purpose
+
+- This view is the third bounded series drill-down surface for old-`S0` absorption reading.
+- It exists so readers can inspect `S0D` log by log and see which rows are already surfaced, which current reading home they now use, and which rows still remain outside the surfaced set.
+
+## Series Boundary
+
+- This third bounded drill-down covers `S0D` only.
+- `S0D` is the next smallest unfinished old-`S0` series after `S0B`, so publishing its standing surface is the lowest-risk way to make the next unresolved remainder reviewable before the larger `S0C` follow-up.
+
+## Drill-Down Model
+
+| field | job |
+| --- | --- |
+| `source log` | exact old-`S0` source log in this series |
+| `series` | fixed series bucket for this drill-down surface |
+| `currently surfaced` | whether the row is already admitted into the current old-`S0 -> DOC` surfaced set |
+| `reader-facing standing` | one bounded current-reading classification from the `S0F-6B/P1` vocabulary |
+| `current family` | current owning family when known |
+| `current reading home` | current contract body, current `view`, or unresolved state |
+| `history role` | bounded historical role such as structural prerequisite or unresolved |
+| `notes` | short reader-facing explanation |
+
+## S0D Drill-Down
+
+| source log | series | currently surfaced | reader-facing standing | current family | current reading home | history role | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0D-1A` | `S0D` | `yes` | `current-view` | `DOC` | `view-doc-history-and-lineage-v1` | `structural prerequisite` | `already admitted into the surfaced set as one pre-DOC structural prerequisite for current DOC history reading` |
+| `S0D-2A` | `S0D` | `no` | `retained-evidence` | `repo tooling and evidence surfaces` | `backend/scripts/ci/workflow_artifacts.py` plus `docs/labs/_snapshot/auto/` and `artifacts/*runs*.json` | `retained drills/evidence automation governance` | `run_dir discovery, summary-ledger shape, and hard-gate evidence bookkeeping now read through live artifact helper and snapshot/ledger surfaces; the old row remains bounded historical automation-governance detail rather than one DOC-history prerequisite` |
+| `S0D-3A` | `S0D` | `no` | `retained-evidence` | `repo runbook and operator-entry surfaces` | `docs/runbook/_template-runbook.md` plus `docs/runbook/run-S5B-security-governance-hard-gates.md` and `docs/runbook/run-S6A-evidence-drills-spine.md` | `retained runbook-governance evidence` | `top-level runbook entry rules, thinness guidance, and validation expectations now read through the live runbook template and adopted operator entry surfaces; the old row remains bounded strategy and adoption history rather than one DOC-history row` |
+| `S0D-4A` | `S0D` | `no` | `retained-evidence` | `repo UI evidence-lite surfaces` | `docs/UI&UX/README.md` plus `docs/UI&UX/UI-FIX-NOTE-TEMPLATE.md` and `docs/UI&UX/assets/README.md` | `retained UI evidence-lite governance` | `frontend light-track boundaries, note fields, and asset rules now read through the current UI evidence-lite surfaces and note corpus; the old row remains bounded governance history rather than one DOC-related current-reading target` |
+| `S0D-5A` | `S0D` | `no` | `retained-evidence` | `repo drills packaging and workflow evidence surfaces` | `.github/workflows/reusable-labs-scenario-runner.yml` plus `backend/scripts/ci/workflow_artifacts.py` and `.github/workflows/drill-failures.yml` | `retained evidence-packing governance` | `minimal-success versus failure-bundle packing rules now read through the live workflow and artifact-helper surfaces; the old row remains bounded packaging-governance detail rather than one new DOC surface` |
+| `S0D-6A` | `S0D` | `no` | `retained-evidence` | `repo roadmap and demo surfaces` | `docs/roadmap/road-template-main-roadmap.md` plus `docs/roadmap/road-template-branch-roadmap.md` and `docs/demo/demo-001/` | `retained roadmap/demo container governance` | `roadmap and demo-container organization now read through the current roadmap templates, bridge-aware roadmap surfaces, and structured demo container roots; the old row remains bounded container-evolution context and is secondary to the direct roadmap bridge contract in S0E-3A` |
+
+## Reader Routing
+
+| question | open first | why |
+| --- | --- | --- |
+| `inside S0D, what is the standing of each old log now?` | `view-old-s0-series-s0d-standing-v1.md` | this surface is the bounded per-log standing answer for the `S0D` series |
+| `why did the counted S0D packet exist, and what did it leave behind?` | `view-old-s0-narrative-history-packet-s0d-s0c-v1.md` | the counted narrative packet answers the change-story question that the standing table does not |
+| `how much of old S0 is surfaced by series overall?` | `view-old-s0-absorption-coverage-overview-v1.md` | aggregate counts and distribution are not repeated here |
+| `which admitted rows exist across all series?` | `view-old-s0-migration-ledger-v1.md` | cross-series admitted-row projection stays in the migration ledger |
+| `how did one current DOC surface emerge from this history?` | `view-old-s0-contract-history-chain-doc-drb-0001-v1.md` or the later matching chain view | current-surface-first evolution reading belongs in the history-chain layer, not in the series standing table |
+
+## Reader Notes
+
+- Read this view when the question is `inside S0D, what is the standing of each old log now?`
+- Use `view-old-s0-absorption-coverage-overview-v1.md` when the question is still aggregate and series-level only.
+- Use `view-old-s0-migration-ledger-v1.md` when the question is `which rows are already admitted into the surfaced set across all series?`
+- Use `view-old-s0-narrative-history-packet-s0d-s0c-v1.md` when the question is no longer current standing but `why did these S0D rows exist and what did they leave behind?`
+- This third `S0D` surface now shows one mixed result: `S0D-1A` remains the only already surfaced `DOC` history row, while `S0D-2A` through `S0D-6A` resolve outside the surfaced set as retained governance evidence for repo-local tooling, runbook, UI, workflow-packing, and roadmap/demo surfaces.
+- `S0D` therefore no longer carries generic unresolved remainder; later follow-up, if any, should begin from narrower cleanup or concentration questions rather than from another first-pass standing review.
+
+## Source Refs
+
+- `docs/logs/log-S0F-6B-old-s0-absorption-coverage-and-history-chain-views.md`
+- `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+- `docs/governance/views/view-old-s0-migration-ledger-v1.md`
+- `docs/logs/log-S0F-5E-small-series-review-sequencing-and-standing-surface-completion.md`
+- `docs/logs/log-S0D-1A-log-entries-orchestration.md`
+- `docs/logs/log-S0D-2A-drills-evidence-automation.md`
+- `docs/logs/log-S0D-3A-runbook-stub.md`
+- `docs/logs/log-S0D-4A-UI-layered-fix-notes.md`
+- `docs/logs/log-S0D-5A-drills-evidence-packing-unification.md`
+- `docs/logs/log-S0D-6A-structured-roadmap-and-demo.md`

--- a/docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md
+++ b/docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md
@@ -1,0 +1,390 @@
+# log-S0F-5I (Phase 5I: old-S0 narrative history widening across counted series)
+
+---
+
+**id**: `S0F-5I`
+**kind**: `log`
+**title**: `old-S0 narrative history widening across counted series v1`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Governance, Records, Views, History, Narrative, Reader, epic/s0, sub/5i`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-5H-old-s0-narrative-history-view-pilot.md`
+  **reference_log_1**: `docs/logs/log-S0F-5H-old-s0-narrative-history-view-pilot.md`
+  **reference_log_2**: `docs/governance/views/view-old-s0-narrative-history-pilot-s0a-s0b-v1.md`
+  **reference_log_3**: `docs/governance/views/view-old-s0-series-s0c-standing-v1.md`
+  **reference_log_4**: `docs/governance/views/view-old-s0-series-s0d-standing-v1.md`
+  **reference_log_5**: `docs/governance/views/view-old-s0-series-s0e-standing-v1.md`
+  **reference_log_6**: `docs/governance/views/view-old-s0-series-s0f-standing-v1.md`
+**issue_keyword**: `migration`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/5`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-10`
+**updated**: `2026-04-10`
+
+---
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-5I` opens as the immediate widening follow-up after `S0F-5H`.
+- This lane exists because the repo now has one proven `S0A + S0B` narrative-history pilot, but it still does not have the same reader-facing why/problem/result/inheritance layer across the counted old-`S0` series that already have standing views.
+- The next job is not to redesign the field model again first; it is to reuse the proven eight-field narrative model across the counted `S0C` / `S0D` / `S0E` / `S0F` population in one bounded rollout sequence.
+
+**Default choices (phase defaults / v1)**:
+
+- Reuse the `S0F-5H` eight-field narrative model without adding new pilot-only fields.
+- Prefer widening first into rows whose standing and current-home reading are already defended, so the narrative layer explains history instead of reopening standing adjudication.
+- Keep supplemental early `S0A / S0B` ancestry as the already-landed pilot packet; `S0F-5I` is the counted-series rollout lane, not a second ancestry-reconstruction lane.
+- Widen series by bounded batches rather than attempting one all-series prose dump.
+
+## Problem Statement
+
+- After `S0F-5H`, readers can understand the early `S0A + S0B` packet narratively, but they still cannot read the larger counted old-`S0` line through the same why/problem/result/inheritance contract.
+- The counted series already have standing views, but standing answers alone still leave one gap:
+  - why did the row appear?
+  - what exact problem boundary did it address?
+  - what result or decision did it leave behind?
+  - what later surface inherited that result?
+- Without the counted-series widening lane, the narrative pilot remains locally convincing but not yet reusable at the scale where most old-`S0` history reading still happens.
+
+## Exported Sections / Outlet Ownership
+
+- This slice starts as a reader-surface widening lane.
+- The default expected landing is in `view` only.
+
+**Outlet ownership**:
+
+- `contract`: no-op by default; this lane widens historical explanation rather than current-rule landing
+- `runbook`: no-op by default; this lane is for reader interpretation, not operator procedure
+- `view`: expected landing surface for counted-series narrative-history rollout
+- `index/front-door`: possible later update only if the widened narrative layer materially changes first-open reading order
+- `disposition/placement`: no-op by default; the lane does not move files or alter standing outcomes on scaffold
+- `log-retained core`: keep this source log for widening order, bounded rollout decisions, and evidence ledger
+
+## Constraints
+
+- Do not reopen defended standing results just to make narrative wording cleaner.
+- Do not redesign the field model first unless counted-series rollout proves a real missing field rather than a row-specific authoring gap.
+- Do not collapse counted-series widening into one aggregate mega-table that readers cannot scan.
+- Do not fabricate narrative motives or inheritance paths that the source-owned text and current reader surfaces cannot defend.
+
+## Scope
+
+- `P0`: open `S0F-5I`, wire it into the parent spine, and fix the counted-series widening boundary
+- `P1`: fix the counted-series widening order and bounded batch shape
+- `P2`: publish the first counted-series narrative-history packet under the reused field model
+- `P3`: continue counted-series rollout and wire narrative routing from the affected standing surfaces
+- `P4`: determine whether the counted-series rollout is sufficient as separate packets or whether one later aggregate narrative router is still needed
+
+## Success Criteria (DoD)
+
+- Readers can open counted old-`S0` series under the same narrative why/problem/result/inheritance contract already proven on `S0A + S0B`.
+- The widening lane reuses the `S0F-5H` field model without reopening the pilot decision unnecessarily.
+- The repo gains one explicit next widening owner after the pilot instead of leaving counted-series rollout implicit.
+
+## P0 (Contract | v1)
+
+### P0-C1-S1 (Counted-series narrative-widening boundary fixed | v1)
+
+- `S0F-5I` is now opened as the counted-series widening follow-up after `S0F-5H`.
+- This slice does not redesign the narrative model first.
+- It fixes only that the next job is to widen the already-proven narrative-history reader contract across counted old-`S0` series.
+
+### P0-C1-S2 (Immediate widening sequence fixed | v1)
+
+- The immediate next work after scaffold is now fixed as:
+  - first decide one bounded counted-series widening order
+  - then publish the first counted-series narrative packet under the existing field model
+  - then continue rollout and reader routing only where the first packet proves reusable
+- Under the current boundary, the widening lane should prefer rows with already-defended standing and current-home reading before any harder unresolved packet enters.
+
+## Plan (draft)
+
+### P1 (Counted-series widening order)
+
+- `P1-C1-S1`: fix the counted-series widening order
+- `P1-C1-S2`: fix the first bounded counted-series packet
+
+### P1-C1-S1 (Counted-series widening order fixed | v1)
+
+- The counted-series widening order is now fixed as:
+  - `S0D` first
+  - `S0C` second
+  - `S0E` third
+  - reviewed `S0F` subset last under this lane's current boundary
+- This widening order is defended as the lowest-risk reuse path for the `S0F-5H` narrative model:
+  - `S0D` is the smallest counted series with fully defended standing and mostly one retained-governance reading shape
+  - `S0C` is still fully defended, but it adds a slightly wider mix of retained evidence, retired lineage, and history-lineage without introducing unresolved rows
+  - `S0E` is the first large fully-defended mixed series and therefore the first real stress test for one narrative packet that must carry current-contract, current-view, retained-evidence, history-lineage, retired-lineage, and non-DOC outcomes together
+  - `S0F` remains last because the series still contains unresolved rows, so widening it first would blur the boundary between narrative rollout and standing adjudication
+- Under this rule, `S0F-5I` should widen from the cleanest defended series to the densest mixed defended series before it enters any counted packet that still depends on later standing decisions.
+
+### P1-C1-S2 (First bounded counted-series packet fixed | v1)
+
+- The first bounded counted-series narrative packet is now fixed as one combined `S0D + S0C` packet.
+- This first packet is defended because it gives the widening lane one compact but still meaningful rollout target:
+  - both series already have standing views and defended row outcomes
+  - both series are small enough to read in one pass without becoming a mega-table
+  - together they already prove the narrative model can move beyond the early `S0A + S0B` packet into counted rows that are not current-contract concentration points
+  - the pair also introduces multiple defended narrative shapes at once: retained-governance evidence, retired lineage, and history-lineage into current repo-local surfaces
+- The non-first-packet boundary is now fixed as:
+  - `S0E` stays outside the first counted packet because it is the first large mixed series and should enter only after the smaller defended packet proves readable
+  - unresolved `S0F` rows stay outside the first counted packet because `S0F-5I` is not the lane that reopens their standing outcomes
+  - reviewed `S0F` rows may enter only in a later bounded packet after `S0D + S0C` and `S0E` prove the counted-series rollout shape first
+- Under this rule, `P2` should publish one first counted-series narrative view centered on the combined `S0D + S0C` packet under the reused eight-field model.
+
+### P2 (First counted-series narrative packet)
+
+- `P2-C1-S1`: publish the first counted-series narrative-history packet
+- `P2-C1-S2`: confirm the reused field model is sufficient on that packet without pre-widening revision
+
+### P2-C1-S1 (First counted-series narrative packet published | v1)
+
+- The first counted-series narrative-history packet now exists at `docs/governance/views/view-old-s0-narrative-history-packet-s0d-s0c-v1.md`.
+- It applies the `S0F-5H` eight-field narrative model to the full combined `S0D + S0C` packet fixed in `P1`.
+- The landed packet proves the model can now narrate one bounded counted-series set containing:
+  - surfaced structural prerequisites
+  - retained governance evidence
+  - retired lineage
+  - history-lineage into later repo-local surfaces
+  without falling back to one standing-only table or one long prose essay.
+
+### P2-C1-S2 (Reused field model confirmed on the first counted packet | v1)
+
+- The reused eight-field narrative model is now confirmed as sufficient on the first counted-series packet.
+- No pre-`S0E` revision is required because the `S0D + S0C` packet already proves the model can carry:
+  - one combined multi-series packet rather than one single-series table
+  - both surfaced and non-surfaced counted rows
+  - multiple defended current roles and current first-open homes
+  - several different inheritance patterns into repo-local tooling, runbook, workflow, test, and log-orchestration surfaces
+- Under this result, the immediate next job is not field-model repair; it is to widen rollout and reader routing into the next counted packet.
+
+### P3 (Counted-series rollout and routing)
+
+- `P3-C1-S1`: continue counted-series rollout under the same field model
+- `P3-C1-S2`: wire narrative routing from the affected standing surfaces
+
+### P3-C1-S1 (Next counted-series narrative packet published for `S0E` | v1)
+
+- The next counted-series narrative-history packet now exists at `docs/governance/views/view-old-s0-narrative-history-packet-s0e-v1.md`.
+- It reuses the same eight-field narrative model across the full `S0E` series, which is the first large defended mixed counted packet after `S0D + S0C`.
+- This landed packet proves the model now carries, in one bounded series view:
+  - current-contract rows
+  - current-view lineage milestones
+  - retained-evidence rows
+  - history-lineage rows
+  - retired-lineage rows
+  - non-DOC current-home rows
+  without reopening standing results or collapsing into one count-first inventory.
+
+### P3-C1-S2 (Standing-surface narrative routing widened | v1)
+
+- The affected counted standing surfaces now route narrative-history questions into the published packet views.
+- `S0D` and `S0C` standing views now route readers to the existing combined `S0D + S0C` narrative packet when the question becomes `why did these rows exist and what did they leave behind?`
+- `S0E` standing view now routes readers to the new `S0E` narrative packet for the same narrative question.
+- Under this routing change, standing views remain the current-state answer, while packet views become the first-open answer for counted-series historical change-reading.
+
+### P4 (Post-rollout boundary)
+
+- `P4-C1-S1`: determine whether separate counted-series packets are sufficient
+- `P4-C1-S2`: determine whether one later aggregate narrative router is still needed
+- `P4-C2-S1`: determine whether the reviewed `S0F` subset should continue inside `S0F-5I`
+- `P4-C2-S2`: fix whether later `S0F` narrative work belongs in a new lane instead
+
+### P4-C1-S1 (Separate packets are not sufficient as the only narrative front door | v1)
+
+- Separate packet views are no longer sufficient as the only narrative front door.
+- That decision is now defended because the repo currently has:
+  - one supplemental early packet
+  - one first counted packet for `S0D + S0C`
+  - one second counted packet for `S0E`
+  - one still-pending reviewed `S0F` subset
+- Without one aggregate narrative router, readers would still have to infer which packet to open from aggregate coverage, ancestry routing, or per-series standing views.
+- Under this rule, packet views remain the narrative bodies, but they should no longer be treated as self-discoverable from the wider old-`S0` reader set.
+
+### P4-C1-S2 (Aggregate narrative router required and published | v1)
+
+- One aggregate narrative router is now required and published at `docs/governance/views/view-old-s0-narrative-history-routing-v1.md`.
+- The router now gives one first-open narrative entry across:
+  - early supplemental `S0A + S0B`
+  - counted `S0D + S0C`
+  - counted `S0E`
+  - the explicit not-yet-published boundary for the reviewed `S0F` subset
+- Under this result, the current packet set is now reader-discoverable without forcing the coverage overview or the standing surfaces to act as an implicit packet index.
+
+### P4-C2-S1 (Reviewed `S0F` subset should not continue as a same-lane packet inside `S0F-5I` | v1)
+
+- The reviewed `S0F` subset should not continue as one more same-lane counted-series packet inside `S0F-5I`.
+- This decision is now defended because the current `S0F` reading surface still mixes three materially different states:
+  - already surfaced `DOC` rows
+  - already-adjudicated external-current-home or retained-history rows
+  - `18` still-unresolved standing-first rows
+- Under the `S0F-5I` lane contract, widening was allowed only where standing and current-home reading were already defended strongly enough for narrative explanation to describe history without reopening adjudication.
+- The current `S0F` population no longer meets that same-lane rollout condition as one bounded packet.
+
+### P4-C2-S2 (Later `S0F` narrative work should open as a new bounded lane, not as another `S0F-5I` packet | v1)
+
+- Any later `S0F` narrative follow-up should open as one new bounded lane rather than as another `C` that keeps `S0F-5I` silently alive.
+- That later lane should begin only after one narrower `S0F` subset is defended as packet-worthy without reopening unresolved standing inside the narrative slice itself.
+- Under this rule, `S0F-5I` remains the widening lane for the currently published packet set, while any future `S0F` narrative packet becomes a separate follow-up with its own boundary, ordering, and evidence ledger.
+
+## Execution Checklist (unchecked)
+
+### P0 (Contract)
+
+- [x] `P0-C1-S1`: counted-series narrative-widening boundary fixed
+- [x] `P0-C1-S2`: immediate widening sequence fixed
+
+### P1 (Counted-series widening order)
+
+- [x] `P1-C1-S1`: counted-series widening order fixed
+- [x] `P1-C1-S2`: first counted-series packet fixed
+
+### P2 (First counted-series narrative packet)
+
+- [x] `P2-C1-S1`: first counted-series narrative packet published
+- [x] `P2-C1-S2`: reused field model confirmed on the first packet
+
+### P3 (Counted-series rollout and routing)
+
+- [x] `P3-C1-S1`: counted-series rollout continued
+- [x] `P3-C1-S2`: standing-surface narrative routing widened
+
+### P4 (Post-rollout boundary)
+
+- [x] `P4-C1-S1`: separate-packet sufficiency decided
+- [x] `P4-C1-S2`: aggregate-router need decided
+- [x] `P4-C2-S1`: same-lane `S0F` continuation rejected
+- [x] `P4-C2-S2`: later `S0F` narrative work moved to future bounded lane
+
+## Current Status
+
+- `S0F-5I` is now opened as the next widening follow-up after `S0F-5H`.
+- `P0` is now complete: the counted-series narrative-widening boundary is fixed, and the immediate next step is to decide one bounded widening order rather than to reopen the pilot field model.
+- `P1` is now complete: the counted-series widening order is fixed as `S0D -> S0C -> S0E -> reviewed S0F subset`, and the first bounded rollout packet is fixed as one combined `S0D + S0C` narrative packet.
+- `P2` is now complete: the repo now has one first counted-series narrative-history packet for the combined `S0D + S0C` set, and that packet confirms the reused eight-field model remains sufficient before the lane widens into `S0E`.
+- `P3` is now complete: the repo now has the next counted-series narrative packet for `S0E`, and the affected `S0D` / `S0C` / `S0E` standing surfaces now route narrative questions into the counted packet views.
+- `P4` is now complete: separate packet views are not sufficient as the only narrative front door, and the repo now has one aggregate narrative router across the published packet set.
+- `P4-C2` is now complete: the reviewed `S0F` subset should not continue as one more same-lane packet inside `S0F-5I`, and any later `S0F` narrative packet should open as one new bounded lane instead.
+- `S0F-5I` is now stable as the current old-`S0` counted-series narrative-history widening lane: the packet rollout boundary is explicit, the published packet set is reader-discoverable, and the reviewed `S0F` subset remains an explicit later follow-up that now requires its own lane rather than an implicit omission.
+- The immediate next step is now optional and bounded: open one later follow-up only if one narrower `S0F` subset can be defended as packet-worthy without reopening unresolved standing, or if the router later needs to absorb that future packet explicitly.
+
+## Evidence (reserved)
+
+### P0-C1-S1S2 (Counted-series narrative-widening scaffold landed | 2026-04-10)
+
+- headSha: `<pending commit for S0F-5I/P0-C1-S1S2>`
+- artifacts:
+  - `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should have one explicit owner for counted-series narrative rollout after the first `S0A + S0B` pilot succeeds
+  - later widening work should not need to reopen whether the next step is field-model revision or counted-series reuse
+- observed:
+  - `S0F-5I` is now opened as the counted-series widening follow-up after `S0F-5H`
+  - the immediate next step is now to decide one bounded widening order under the existing eight-field narrative model
+
+### P1-C1-S1S2 (Counted-series widening order and first packet fixed | 2026-04-10)
+
+- headSha: `<pending commit for S0F-5I/P1-C1-S1S2>`
+- artifacts:
+  - `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the widening lane should have one defended order that prefers already-defended series before denser or partially unresolved packets
+  - the first counted-series packet should be bounded enough to prove readability before the lane widens into the largest mixed series
+- observed:
+  - the counted-series widening order is now fixed as `S0D -> S0C -> S0E -> reviewed S0F subset`
+  - the first bounded counted-series narrative packet is now fixed as one combined `S0D + S0C` packet under the reused eight-field model
+
+### P2-C1-S1S2 (First counted-series narrative packet published and model confirmed | 2026-04-10)
+
+- headSha: `<pending commit for S0F-5I/P2-C1-S1S2>`
+- artifacts:
+  - `docs/governance/views/view-old-s0-narrative-history-packet-s0d-s0c-v1.md`
+  - `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the lane should publish one first counted-series narrative packet that proves the pilot field model can scale beyond the early `S0A + S0B` set
+  - the first counted packet should be strong enough to answer whether the eight-field model needs revision before `S0E`
+- observed:
+  - the repo now has one combined `S0D + S0C` narrative-history packet that explains why those rows appeared, what they fixed, and where their results later read now
+  - the reused eight-field model remains sufficient on the first counted packet, so the next step stays with widening and routing rather than field-model redesign
+
+### P3-C1-S1S2 (Next counted-series packet published and standing routes widened | 2026-04-10)
+
+- headSha: `<pending commit for S0F-5I/P3-C1-S1S2>`
+- artifacts:
+  - `docs/governance/views/view-old-s0-narrative-history-packet-s0e-v1.md`
+  - `docs/governance/views/view-old-s0-series-s0d-standing-v1.md`
+  - `docs/governance/views/view-old-s0-series-s0c-standing-v1.md`
+  - `docs/governance/views/view-old-s0-series-s0e-standing-v1.md`
+  - `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the widening lane should publish the next bounded counted-series packet after `S0D + S0C`
+  - the standing surfaces affected by counted narrative rollout should start routing change-story questions into the packet views instead of leaving them implicit in standing-only tables
+- observed:
+  - the repo now has one full `S0E` narrative-history packet, which proves the eight-field model also scales to the first large mixed counted series
+  - the counted `S0D` / `S0C` / `S0E` standing surfaces now route narrative questions into the published packet views directly
+
+### P4-C1-S1S2 (Aggregate narrative front door fixed across packet set | 2026-04-10)
+
+- headSha: `2eca41fec`
+- artifacts:
+  - `docs/governance/views/view-old-s0-narrative-history-routing-v1.md`
+  - `docs/governance/views/view-old-s0-absorption-coverage-overview-v1.md`
+  - `docs/governance/views/view-old-s0-narrative-history-pilot-s0a-s0b-v1.md`
+  - `docs/governance/views/view-old-s0-narrative-history-packet-s0d-s0c-v1.md`
+  - `docs/governance/views/view-old-s0-narrative-history-packet-s0e-v1.md`
+  - `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the lane should answer whether separate packet views are already sufficient as the only reader-facing front door
+  - if not, the repo should gain one aggregate router so readers can discover the packet set without inferring it from unrelated surfaces
+- observed:
+  - separate packet views are now judged insufficient as the only narrative front door because the packet set spans multiple counted and supplemental boundaries
+  - the repo now has one aggregate narrative router that routes readers across the published packet set while keeping the reviewed `S0F` subset as an explicit later follow-up boundary
+
+### P4-C2-S1S2 (Later `S0F` narrative work moved out of the current widening lane | 2026-04-10)
+
+- headSha: `802b1d43c`
+- artifacts:
+  - `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+  - `docs/governance/views/view-old-s0-narrative-history-routing-v1.md`
+- expected:
+  - the lane should answer whether the reviewed `S0F` subset is mature enough to continue as one more packet under the current widening lane
+  - if not, the repo should make the lane boundary explicit so later `S0F` narrative work opens as a separate bounded follow-up rather than as a silent `5I` extension
+- observed:
+  - the current `S0F` reader state still mixes surfaced rows, adjudicated external-current-home or retained-history rows, and `18` unresolved standing-first rows, so one same-lane `S0F` packet is not yet justified
+  - any later `S0F` narrative packet should now open as its own bounded lane after a narrower subset is defended without reopening unresolved standing
+
+## Recent changes (for traceability, optional)
+
+- 2026-04-10: opened `S0F-5I` as the counted-series narrative-history widening follow-up after `S0F-5H` proved the first `S0A + S0B` pilot.
+- 2026-04-10: completed `P1` by fixing the counted-series widening order as `S0D -> S0C -> S0E -> reviewed S0F subset` and by fixing the first bounded counted-series rollout target as one combined `S0D + S0C` narrative packet.
+- 2026-04-10: completed `P2` by publishing the first counted-series narrative-history packet for `S0D + S0C` and by confirming the reused eight-field model remains sufficient before widening into `S0E`.
+- 2026-04-10: completed `P3` by publishing the next counted-series narrative-history packet for `S0E` and by wiring narrative routes from the affected `S0D` / `S0C` / `S0E` standing surfaces into the packet views.
+- 2026-04-10: completed `P4` by deciding that separate packet views are not sufficient as the only narrative front door, publishing one aggregate narrative router across the packet set, and closing `S0F-5I` as stable for the current packet boundary.
+- 2026-04-10: completed `P4-C2` by deciding that the reviewed `S0F` subset should not continue as one more same-lane `S0F-5I` packet and that any later `S0F` narrative packet should instead open as one new bounded follow-up lane.


### PR DESCRIPTION
## Metadata

- Requested ID: `S0F-5I`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0f-5i`
- Source log: `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`
- Labels: `EVOLUTION, s0/knowledge system, drills`
- Development issue: #445

## Summary

- Fix the counted-series widening order after the `S0A + S0B` narrative pilot.
- Publish the first bounded counted-series narrative packet on the reused field model.
- Continue widening and reader routing without collapsing rollout into one mega-view.

## Execution Checklist

- [x] `P0-C1-S1`: counted-series narrative-widening boundary fixed
- [x] `P0-C1-S2`: immediate widening sequence fixed
- [x] `P1-C1-S1`: counted-series widening order fixed
- [x] `P1-C1-S2`: first counted-series packet fixed
- [x] `P2-C1-S1`: first counted-series narrative packet published
- [x] `P2-C1-S2`: reused field model confirmed on the first packet
- [x] `P3-C1-S1`: counted-series rollout continued
- [x] `P3-C1-S2`: standing-surface narrative routing widened
- [x] `P4-C1-S1`: separate-packet sufficiency decided
- [x] `P4-C1-S2`: aggregate-router need decided
- [x] `P4-C2-S1`: same-lane `S0F` continuation rejected
- [x] `P4-C2-S2`: later `S0F` narrative work moved to future bounded lane

## Links

- Log: `docs/logs/log-S0F-5I-old-s0-narrative-history-widening-across-counted-series.md`

Closes #445
