### PR TITLE
S0F-7E/P0-P6: supplement sequencing time fields and historical backfill release chronology

### DIFF
--- a/docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0002-labs-snapshot-evidence-package-governance.md
+++ b/docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0002-labs-snapshot-evidence-package-governance.md
@@ -1,0 +1,126 @@
+# DOC-WORKFLOW-LABS-0002 labs snapshot evidence package governance
+
+```yaml
+contract_record:
+  contract_family: DOC-WORKFLOW-LABS
+  contract_release: 0002
+  contract_id: DOC-WORKFLOW-LABS-0002
+  record_kind: chronology-first-contract
+  status: draft
+  release_action: simple-revision
+  release_change_summary: Keep the later S0B-2A snapshot-package revision as the current release while also admitting the accepted S0A-2A-R03 labs packet as history-backfilled earlier-labs clauses inside the same current reader.
+  summary: Govern workflow labs as replayable evidence packages, including earlier pre-runbook failure-management and projection-closure labs plus later snapshot-root, run-folder, and retention-package rules.
+  governance_area: workflow labs historical evidence, snapshot governance, and evidence-package governance
+  applies_to: earlier executable labs that precede runbook codification, labs snapshot roots, run-id evidence folders, retained lab evidence sets, golden fixtures, diff snapshots, ad-hoc dumps, and lab cleanup decisions
+  enforcement_surface: manual
+  violation_semantics: warning
+  recorded_at: 2026-04-10
+  reviewed_at: pending
+  effective_from: unknown
+  effective_until: ongoing
+  introduced_by: GitHub issue S0B/1A (#36) (issue-only source; no local log exists in workspace)
+  last_changed_by: docs/logs/support-only/ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape.md
+  source_refs:
+    - docs/logs/log-S0B-2A-scripts-snapshots-management.md
+    - docs/logs/support-only/ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape.md
+  cumulative_source_refs:
+    - GitHub issue S0B/1A (#36) (issue-only source; no local log exists in workspace)
+    - docs/logs/log-S0B-2A-scripts-snapshots-management.md
+    - docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md
+    - docs/logs/support-only/ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape.md
+  supporting_evidence_refs:
+    - docs/logs/support-only/ledger-S0B-1A-tools-labs-and-snapshots.md
+    - docs/logs/support-only/ledger-S0B-2A-tools-scripts-and-snapshots-management.md
+    - legacy/from_structured_docs/from-logs/v2-logs/log-S3A-lab-snapshots-management.md
+    - legacy/from_structured_docs/from-labs/labs-004-worker-failure-management-v1-v4.md
+    - legacy/from_structured_docs/from-labs/labs-006-search-projection-search-index-to-elastic.md
+  lineage:
+    supersedes:
+      - DOC-WORKFLOW-LABS-0001
+    superseded_by: []
+    split_from: []
+    split_into: []
+    absorbed_from: []
+    absorbed_into: []
+    retires: []
+    retired_by: []
+  notes:
+    - This draft keeps the stable DOC-WORKFLOW-LABS family and treats 0002 as the later effective release state.
+    - This release intentionally absorbs only the labs-specific slice from S0B-2A rather than the full scripts-taxonomy or cutover material tracked in the ledger.
+    - This local draft also carries one accepted earlier-labs history bucket from `S0A-2A-R03` without opening a separate historical-backfill release yet.
+    - The broader `DOC-WORKFLOW` family path remains taxonomy only; this release does not claim one split lineage from `DOC-WORKFLOW-0001`.
+    - The local repo still has no direct S0B/1A source log, so the family continues to carry issue-only sourcing from that first release alongside the later S0B-2A log source.
+```
+
+## Contract Statement Table
+
+| statement id | statement label | clause status | change action | source basis | first effective release | first effective at | last changed release | last changed at | effective from | effective until | effective status | statement text | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `DOC-WORKFLOW-LABS-0002-ST-12` | `Pre-runbook failure-management labs` | `active` | `history-backfilled` | `S0A-2A-R03-SUP-01` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | Labs may own executable failure-management experiments for stuck recovery, retry convergence, replay, failed-state auditability, and daemon runtime engineering before those lessons are later distilled into runbooks. | Later-recorded earlier clause admitted from the accepted `S0A-2A-R03` labs packet without opening a separate backfill release yet. |
+| `DOC-WORKFLOW-LABS-0002-ST-13` | `Projection-closure labs before runbook codification` | `active` | `history-backfilled` | `S0A-2A-R03-SUP-02` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | Labs may also own projection-closure and source-to-read-model validation work before those earlier experimental findings are reorganized into later operator-facing runbook codification. | This keeps the earlier search-projection closure labs visible as labs-family history rather than treating them as only pre-runbook background. |
+| `DOC-WORKFLOW-LABS-0002-ST-08` | `Snapshot class taxonomy` | `active` | `carried-forward` | `S0B-1A-R01` | `DOC-WORKFLOW-LABS-0001` | `unknown` | `DOC-WORKFLOW-LABS-0001` | `unknown` | `unknown` | `ongoing` | `in-force` | Snapshot outputs inside that package should still be classified into explicit roles: golden fixtures, diff snapshots, and ad-hoc dumps. | The taxonomy remains materially present in `0002`, but now reads inside the evidence-package framing. |
+| `DOC-WORKFLOW-LABS-0002-ST-10` | `Safe-to-purge cleanup` | `active` | `carried-forward` | `S0B-1A-R03` | `DOC-WORKFLOW-LABS-0001` | `unknown` | `DOC-WORKFLOW-LABS-0001` | `unknown` | `unknown` | `ongoing` | `in-force` | Once conclusions are codified into repeatable scripts and verifiable assertions, historical diff/ad-hoc artifacts should become safe to purge rather than remain indefinitely. | Earlier cleanup rule remains materially present without needing one new direct labs source beyond the carried-forward family state. |
+| `DOC-WORKFLOW-LABS-0002-ST-01` | `Labs as replayable evidence packages` | `active` | `amended` | `S0B-1A-R01; S0B-2A-R03` | `DOC-WORKFLOW-LABS-0001` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | Labs outputs must be governed as replayable evidence packages rather than left to accumulate as an unbounded debugging heap. | Later release restates the earlier labs-as-test-assets framing in the stronger evidence-package language introduced by the labs sub-slice from `S0B-2A`. |
+| `DOC-WORKFLOW-LABS-0002-ST-09` | `Minimal evidence package retention` | `active` | `amended` | `S0B-1A-R02; S0B-2A-R03` | `DOC-WORKFLOW-LABS-0001` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | Each lab should keep only the minimum evidence package needed to replay or verify the conclusion confidently. | Earlier minimal-retention rule is widened from evidence set to evidence package in the later release. |
+| `DOC-WORKFLOW-LABS-0002-ST-02` | `Stable labs evidence root` | `active` | `introduced` | `S0B-2A-R03` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | Labs evidence should land under one stable root: `docs/labs/_snapshot/`. | New clause introduced by the absorbed labs sub-slice. |
+| `DOC-WORKFLOW-LABS-0002-ST-03` | `Run-id evidence package` | `active` | `introduced` | `S0B-2A-R03` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | Each run should produce one bounded run-id folder that makes the evidence package readable and auditable. | Parent run-folder clause for the new evidence-package shape. |
+| `DOC-WORKFLOW-LABS-0002-ST-04` | `Exports subfolder` | `active` | `introduced` | `S0B-2A-R03` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | The evidence package should provide `_exports/` for trace or external exports such as Jaeger output. | Narrow child clause beneath the run-id evidence-package rule. |
+| `DOC-WORKFLOW-LABS-0002-ST-05` | `Logs subfolder` | `active` | `introduced` | `S0B-2A-R03` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | The evidence package should provide `_logs/` for stdout, stderr, or other captured run logs. | Narrow child clause beneath the run-id evidence-package rule. |
+| `DOC-WORKFLOW-LABS-0002-ST-06` | `Metrics subfolder` | `active` | `introduced` | `S0B-2A-R03` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | The evidence package should provide `_metrics/` for metrics or query output that should not be recopied by hand. | Narrow child clause beneath the run-id evidence-package rule. |
+| `DOC-WORKFLOW-LABS-0002-ST-07` | `Notes subfolder` | `active` | `introduced` | `S0B-2A-R03` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | The evidence package should provide `_notes.md` for acceptance checks, conclusions, and next steps. | Narrow child clause beneath the run-id evidence-package rule. |
+| `DOC-WORKFLOW-LABS-0002-ST-11` | `Replay-and-audit retention test` | `active` | `introduced` | `S0B-2A-R03` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `DOC-WORKFLOW-LABS-0002` | `unknown` | `unknown` | `ongoing` | `in-force` | Retention decisions should preserve replay and audit value, not file volume for its own sake. | New retention-judgment clause introduced by the absorbed labs sub-slice. |
+
+## Statement Evolution Table
+
+| change id | release id | change action | input statement ids | output statement ids | effective at | recorded at | reason | source basis | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `DOC-WORKFLOW-LABS-0002-CH-06` | `DOC-WORKFLOW-LABS-0002` | `history-backfilled` | `none` | `DOC-WORKFLOW-LABS-0002-ST-12` | `unknown` | `2026-04-12` | The accepted `S0A-2A-R03` labs packet shows that executable failure-management labs materially belonged to the labs family before later runbook codification, so the current release now keeps that earlier-history clause visible rather than treating it as only background. | `S0A-2A-R03-SUP-01` | This is recorded inside the current release reader pending any later decision to open a dedicated historical-backfill release. |
+| `DOC-WORKFLOW-LABS-0002-CH-07` | `DOC-WORKFLOW-LABS-0002` | `history-backfilled` | `none` | `DOC-WORKFLOW-LABS-0002-ST-13` | `unknown` | `2026-04-12` | The accepted `S0A-2A-R03` search-projection closure labs packet shows one earlier labs-specific rule shape that should remain visible even though later runbooks took over the operator-facing codified reader. | `S0A-2A-R03-SUP-02` | This keeps the earlier labs-versus-runbook boundary readable inside the current `0002` contract sample. |
+| `DOC-WORKFLOW-LABS-0002-CH-03` | `DOC-WORKFLOW-LABS-0002` | `carried-forward` | `DOC-WORKFLOW-LABS-001-ST-02; DOC-WORKFLOW-LABS-001-ST-03; DOC-WORKFLOW-LABS-001-ST-04; DOC-WORKFLOW-LABS-001-ST-05` | `DOC-WORKFLOW-LABS-0002-ST-08` | `unknown` | `2026-04-10` | The earlier snapshot-class taxonomy remains in force inside the later evidence-package framing. | `S0B-1A-R01` | The later release condenses the earlier taxonomy cluster into one current-release parent clause while leaving the narrower earlier release available for readers who need its first statement decomposition. |
+| `DOC-WORKFLOW-LABS-0002-CH-05` | `DOC-WORKFLOW-LABS-0002` | `carried-forward` | `DOC-WORKFLOW-LABS-001-ST-08` | `DOC-WORKFLOW-LABS-0002-ST-10` | `unknown` | `2026-04-10` | The earlier safe-to-purge rule remains materially present in the later release. | `S0B-1A-R03` | Carried-forward clauses still receive new release-local statement ids in the later release. |
+| `DOC-WORKFLOW-LABS-0002-CH-01` | `DOC-WORKFLOW-LABS-0002` | `amended` | `DOC-WORKFLOW-LABS-001-ST-01` | `DOC-WORKFLOW-LABS-0002-ST-01` | `unknown` | `2026-04-10` | The later release reframes labs outputs from general test assets into replayable evidence packages because the absorbed `S0B-2A` labs sub-slice makes package semantics explicit. | `S0B-1A-R01; S0B-2A-R03` | The clause keeps the earlier labs-asset boundary while adopting the stronger later wording. |
+| `DOC-WORKFLOW-LABS-0002-CH-04` | `DOC-WORKFLOW-LABS-0002` | `amended` | `DOC-WORKFLOW-LABS-001-ST-06; DOC-WORKFLOW-LABS-001-ST-07` | `DOC-WORKFLOW-LABS-0002-ST-09` | `unknown` | `2026-04-10` | The later release widens minimal retention from one evidence set into one evidence package. | `S0B-1A-R02; S0B-2A-R03` | This later clause keeps the earlier retention boundary while adopting the package vocabulary from `S0B-2A`. |
+| `DOC-WORKFLOW-LABS-0002-CH-02` | `DOC-WORKFLOW-LABS-0002` | `introduced` | `none` | `DOC-WORKFLOW-LABS-0002-ST-02; DOC-WORKFLOW-LABS-0002-ST-03; DOC-WORKFLOW-LABS-0002-ST-04; DOC-WORKFLOW-LABS-0002-ST-05; DOC-WORKFLOW-LABS-0002-ST-06; DOC-WORKFLOW-LABS-0002-ST-07; DOC-WORKFLOW-LABS-0002-ST-11` | `unknown` | `2026-04-10` | The absorbed labs-only `S0B-2A` slice adds new evidence-root, package-shape, and replay-or-audit retention clauses that were absent from `0001`. | `S0B-2A-R03` | These are genuinely new release-local statement ids because statement ids are release-scoped rather than family-global. |
+
+## Release Change
+
+- This release supersedes `DOC-WORKFLOW-LABS-0001` by keeping its earlier snapshot-governance core while adding the labs-only slice from `S0B-2A` that makes the evidence-package layout explicit.
+- This local draft also keeps the accepted `S0A-2A-R03` labs packet inside the current release as `history-backfilled` clause state rather than opening a separate historical-backfill release first.
+- Relative to `0001`, this release now fixes three additional points:
+  - earlier executable labs for failure management and projection closure remain readable as labs-family history before their later runbook codification
+  - labs outputs should land under one stable evidence root: `docs/labs/_snapshot/`
+  - each execution should produce one per-run folder with a repeatable evidence-package shape rather than one loose pile of files
+  - retention and cleanup should be judged against the package's replay and audit value, not against ad hoc file accumulation
+- This release intentionally does not absorb the broader scripts taxonomy, stable entrypoint, runbook snapshot-root split, cutover rules, or stub policy from the `S0B-2A` ledger draft.
+
+## Contract Statement
+
+- The tables above now separate current clause state from clause lineage; the readable statement below preserves the same current effective meaning in prose form.
+- `DOC-WORKFLOW-LABS-0002-ST-12`: Labs may own executable failure-management experiments before those lessons are later distilled into runbooks.
+- `DOC-WORKFLOW-LABS-0002-ST-13`: Labs may also own projection-closure and source-to-read-model validation work before those earlier findings are reorganized into later runbook codification.
+- `DOC-WORKFLOW-LABS-0002-ST-01`: Labs outputs must be governed as replayable evidence packages rather than left to accumulate as an unbounded debugging heap.
+- `DOC-WORKFLOW-LABS-0002-ST-02`: Labs evidence should land under one stable root: `docs/labs/_snapshot/`.
+- `DOC-WORKFLOW-LABS-0002-ST-03`: Each run should produce one bounded run-id folder that makes the evidence package readable and auditable, typically including:
+  - `DOC-WORKFLOW-LABS-0002-ST-04`: `_exports/` for trace or external exports such as Jaeger output.
+  - `DOC-WORKFLOW-LABS-0002-ST-05`: `_logs/` for stdout, stderr, or other captured run logs.
+  - `DOC-WORKFLOW-LABS-0002-ST-06`: `_metrics/` for metrics or query output that should not be recopied by hand.
+  - `DOC-WORKFLOW-LABS-0002-ST-07`: `_notes.md` for acceptance checks, conclusions, and next steps.
+- `DOC-WORKFLOW-LABS-0002-ST-08`: Snapshot outputs inside that package should still be classified into explicit roles: golden fixtures, diff snapshots, and ad-hoc dumps.
+- `DOC-WORKFLOW-LABS-0002-ST-09`: Each lab should keep only the minimum evidence package needed to replay or verify the conclusion confidently.
+- `DOC-WORKFLOW-LABS-0002-ST-10`: Once conclusions are codified into repeatable scripts and verifiable assertions, historical diff/ad-hoc artifacts should become safe to purge rather than remain indefinitely.
+- `DOC-WORKFLOW-LABS-0002-ST-11`: Retention decisions should preserve replay and audit value, not file volume for its own sake.
+
+## Current Reading
+
+- Read this release when the question is `what is the current integrated labs-family reader once earlier pre-runbook labs history and later snapshot-package governance are both kept visible in one release?`
+- Read `DOC-WORKFLOW-LABS-0001` only when the reader needs the narrower earlier release before the `S0B-2A` snapshot-policy slice was absorbed into the labs family.
+- Read the `S0B-2A` ledger draft when the question is `which parts of S0B-2A entered this release and which parts remained deferred or support-only?`
+- Read the accepted `S0A-2A` labs supplement packet when the question is `which earlier labs history was backfilled into the current release reader and why was it not left only as runbook prehistory?`
+
+## Reader Notes
+
+- This draft is the first release-style sample under the `family + release` model; it is not committed as the accepted next state yet.
+- It intentionally fuses the earlier labs-family contract with only the labs-specific `S0B-2A` slice that strengthens snapshot and evidence-package governance.
+- It now also demonstrates one second pattern under `S0F-7E`: a current later release may temporarily host `history-backfilled` clause rows from an earlier accepted ledger packet before the repo decides whether a dedicated historical-backfill release is still necessary.
+- It does not yet claim to resolve the future `workflow/scripts governance` family question or the possible OPS-side evidence family question tracked in the ledger.
+- The statement ids in this file are intentionally release-local `0002-ST-*` ids; earlier `0001-ST-*` ids remain history anchors in the statement-evolution table rather than being reused as the current ids.

--- a/docs/governance/contracts/workflow/runbook/DOC-WORKFLOW-RUNBOOK-0001-projection-operator-rebuild-replay-and-failure-recovery.md
+++ b/docs/governance/contracts/workflow/runbook/DOC-WORKFLOW-RUNBOOK-0001-projection-operator-rebuild-replay-and-failure-recovery.md
@@ -1,0 +1,88 @@
+# DOC-WORKFLOW-RUNBOOK-0001 projection operator rebuild replay and failure recovery
+
+```yaml
+contract_record:
+  contract_family: DOC-WORKFLOW-RUNBOOK
+  contract_release: 0001
+  contract_id: DOC-WORKFLOW-RUNBOOK-0001
+  record_kind: chronology-first-contract
+  status: draft
+  release_action: initial
+  release_change_summary: Establish the first runbook-family release from S0A-2A by isolating the earliest projection SOPs as durable operator guidance for rebuildability, replay, runtime verification, observability, and failure recovery.
+  summary: Projection runbooks should convert post-labs operational learning into durable operator SOPs for rebuild, replay, health and readiness verification, observability, and bounded failure recovery.
+  governance_area: workflow runbook operator recovery and runtime verification governance
+  applies_to: operator runbooks for long-lived projection systems, including rebuild procedures, replay procedures, readiness and health checks, observability checks, and failure-recovery handling
+  enforcement_surface: runbook
+  violation_semantics: warning
+  recorded_at: 2026-04-12
+  reviewed_at: 2026-04-12
+  effective_from: unknown
+  effective_until: ongoing
+  introduced_by: GitHub issue S0A-2A (#24) (issue-only source; no local log exists in workspace)
+  last_changed_by: docs/logs/support-only/ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md
+  source_refs:
+    - docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md
+    - docs/logs/support-only/ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md
+  cumulative_source_refs:
+    - GitHub issue S0A-2A (#24) (issue-only source; no local log exists in workspace)
+    - docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md
+    - docs/logs/support-only/ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md
+  supporting_evidence_refs:
+    - legacy/from_structured_docs/from-runbook/run-001-search-projection.md
+    - legacy/from_structured_docs/from-runbook/run-003-chronicle-projection.md
+  lineage:
+    supersedes: []
+    superseded_by: []
+    split_from: []
+    split_into: []
+    absorbed_from: []
+    absorbed_into: []
+    retires: []
+    retired_by: []
+  notes:
+    - This first runbook draft stays narrow to projection operator SOP governance rather than restating the whole broader workflow pipeline.
+    - The local repo currently has no S0A-2A source log, so this draft stays explicit about issue-only origin plus later direct-evidence supplementation.
+    - The decisive child-opening packet is justified by the accepted runbook SUP row on S0A-2A-R04 rather than by the broad issue packet alone.
+```
+
+## Contract Statement Table
+
+| statement id | statement label | clause status | change action | source basis | first effective release | first effective at | last changed release | last changed at | effective from | effective until | effective status | statement text | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `DOC-WORKFLOW-RUNBOOK-0001-ST-01` | `Runbooks as durable operator SOPs` | `active` | `introduced` | `S0A-2A-R04` | `DOC-WORKFLOW-RUNBOOK-0001` | `unknown` | `DOC-WORKFLOW-RUNBOOK-0001` | `2026-04-12` | `unknown` | `ongoing` | `in-force` | Runbooks should convert operational learning from projection implementation and labs into durable operator-facing SOPs rather than leaving that knowledge only in experiments or broad issue text. | Opening clause for the runbook family itself. |
+| `DOC-WORKFLOW-RUNBOOK-0001-ST-02` | `Rebuild from source of truth` | `active` | `introduced` | `S0A-2A-R04-SUP-01; S0A-2A-R04-SUP-02` | `DOC-WORKFLOW-RUNBOOK-0001` | `unknown` | `DOC-WORKFLOW-RUNBOOK-0001` | `2026-04-12` | `unknown` | `ongoing` | `in-force` | Projection runbooks should document how the read model can be rebuilt from its source-of-truth path rather than treating the projection state as unrecoverable operational history. | Both earliest runbooks treat rebuildability as a durable operator concern after projection success. |
+| `DOC-WORKFLOW-RUNBOOK-0001-ST-03` | `Runtime verification and readiness` | `active` | `introduced` | `S0A-2A-R04-SUP-01; S0A-2A-R04-SUP-02` | `DOC-WORKFLOW-RUNBOOK-0001` | `unknown` | `DOC-WORKFLOW-RUNBOOK-0001` | `2026-04-12` | `unknown` | `ongoing` | `in-force` | Runbooks should expose one minimum runtime-verification path through health or readiness checks, metrics, and direct state inspection before and during operator intervention. | Search and chronicle both elevate readiness, health, metrics, and DB-state verification into durable SOP shape. |
+| `DOC-WORKFLOW-RUNBOOK-0001-ST-04` | `Auditable replay after terminal failure` | `active` | `introduced` | `S0A-2A-R04-SUP-01; S0A-2A-R04-SUP-02` | `DOC-WORKFLOW-RUNBOOK-0001` | `unknown` | `DOC-WORKFLOW-RUNBOOK-0001` | `2026-04-12` | `unknown` | `ongoing` | `in-force` | Failed projection work should move through explicit replay-controlled recovery with audit fields and operator intent rather than through silent automatic resurrection. | The runbooks make replay and failure handling part of operator governance, not just implementation detail. |
+| `DOC-WORKFLOW-RUNBOOK-0001-ST-05` | `Bounded observability and recovery actions` | `active` | `introduced` | `S0A-2A-R04-SUP-01; S0A-2A-R04-SUP-02` | `DOC-WORKFLOW-RUNBOOK-0001` | `unknown` | `DOC-WORKFLOW-RUNBOOK-0001` | `2026-04-12` | `unknown` | `ongoing` | `in-force` | Runbooks should pair backlog or failure observability with bounded recovery actions for transient dependency failures, deterministic data problems, and draining or restart decisions. | This keeps runbook ownership on operator recovery semantics rather than on domain-specific projection design. |
+
+## Release Change
+
+- This release opens the first dedicated `DOC-WORKFLOW-RUNBOOK` family from the already accepted `S0A-2A-R04` runbook child-candidate review.
+- The decisive evidence is the earliest durable projection SOP pair:
+  - `run-001-search-projection.md`
+  - `run-003-chronicle-projection.md`
+- Those sources show the same post-projection pattern twice:
+  - projection success is not the endpoint
+  - the next long-lived operator need becomes rebuildability, replay, readiness, observability, and failure recovery
+  - that operator guidance becomes durable enough to live as runbook governance rather than only as labs or issue-level notes
+- This release intentionally does not absorb the broader workflow pipeline, logs child, labs child, or ADR child boundaries; it owns only the runbook-family operator SOP layer.
+
+## Contract Statement
+
+- The table above is the clause registry for this release; the readable statement below preserves the same effective meaning in prose form.
+- `DOC-WORKFLOW-RUNBOOK-0001-ST-01`: Runbooks should convert projection-operation learning into durable operator SOPs.
+- `DOC-WORKFLOW-RUNBOOK-0001-ST-02`: Projection systems should remain rebuildable from source-of-truth state, and runbooks should document that rebuild path.
+- `DOC-WORKFLOW-RUNBOOK-0001-ST-03`: Runbooks should expose a minimum operator verification path through readiness, health, metrics, and direct state inspection.
+- `DOC-WORKFLOW-RUNBOOK-0001-ST-04`: Terminal failure handling should require explicit, auditable replay rather than silent automatic recovery.
+- `DOC-WORKFLOW-RUNBOOK-0001-ST-05`: Runbooks should pair observability with bounded recovery actions for transient failure, deterministic failure, and runtime draining or restart situations.
+
+## Current Reading
+
+- Read this release when the question is `what runbook-layer rule first governed projection rebuild, replay, runtime verification, and failure recovery as durable operator SOPs?`
+- Read `DOC-WORKFLOW-0001` first only when the reader still needs the broader `log -> lab -> runbook -> adr` refinement boundary rather than the narrower runbook family itself.
+
+## Reader Notes
+
+- This draft is sourced from issue `S0A-2A`, but its child-opening decision depends on later direct-evidence supplementation through the accepted runbook SUP packet.
+- The opening release intentionally stays narrow to projection operator governance because the current defended evidence comes from search and chronicle projection SOPs rather than from every possible runbook shape in the repo.
+- Later releases may widen or refine this family if additional archaeology proves broader runbook governance beyond the projection-rebuild and recovery pattern captured here.

--- a/docs/logs/_template-support-only-contract-release-ledger-SUP.md
+++ b/docs/logs/_template-support-only-contract-release-ledger-SUP.md
@@ -1,0 +1,175 @@
+# support-only-contract-release-ledger-SUP-template
+
+## Purpose
+
+- Use this ledger when later evidence needs to strengthen, sharpen, narrow, revise, or reopen one routing verdict that already lives in an existing source-owned support-only contract-release ledger.
+- This SUP ledger owns `evidence admission, verdict refinement, and parent-ledger write-back recommendation`.
+- Do not use this SUP ledger to bypass the parent ledger and write directly into contracts; the parent ledger remains the owner of source-slice routing.
+
+## Naming Rule
+
+- Name SUP ledgers as `ledger-SUP-<source-id>-<sequence>-<source-summary>.md`.
+- The `<source-id>` must match the attached parent ledger.
+- The `<source-summary>` should summarize the supplement round itself and does not need to duplicate the parent-ledger summary when a narrower evidence packet name is clearer.
+- The `<sequence>` must be one append-only three-digit supplement round such as `001`, `002`, or `003` inside one stable supplement series.
+- Preferred example shapes:
+  - `ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+  - `ledger-SUP-S0B-2A-002-tools-scripts-and-snapshots-management.md`
+
+- The stable parent binding is carried by `supplement_series_id` plus `parent_ledger_id`; readers should not rely on the filename summary alone to infer attachment.
+
+## Minimal Header
+
+```yaml
+support_only_contract_release_ledger_supplement:
+  supplement_series_id: <ledger-SUP-S0A-1A>
+  supplement_sequence: <001>
+  supplement_id: <ledger-SUP-S0A-1A-001-source-summary>
+  supplement_kind: support-only-contract-release-ledger-supplement
+  status: <draft|active|completed>
+  owner_lane: <S0F-7D>
+  created_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  reviewed_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  accepted_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  writeback_started_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  writeback_completed_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  parent_ledger_id: <ledger-S0A-1A-source-summary>
+  parent_source_id: <S0A-1A>
+  parent_source_ref: <issue/log/support-only source already owned by the parent ledger>
+  supplement_scope: <what later evidence this supplement is admitting>
+  target_reading_goal: <what later reader should understand after this supplement is applied>
+```
+
+## Lifecycle Field Rule
+
+- `supplement_series_id` is the stable sequence family for repeated supplement rounds attached to one parent source.
+- `supplement_sequence` is the append-only round number inside that series; do not reuse or renumber older rounds once admitted.
+- New writes should use canonical UTC second timestamps such as `2026-04-12T15:18:05Z` for supplement-lifecycle fields.
+- Legacy day-only values may remain when older rounds do not yet have defended second-level audit timestamps.
+- Local-time display belongs in an optional mirror field or prose note only; the canonical stored timestamp should remain UTC when second-level precision is available.
+- `created_at` records when this supplement file was first created in the repo.
+- `reviewed_at` records when this supplement round first reached defended review state.
+- `accepted_at` records when the row-level verdicts are accepted for parent-ledger write-back.
+- `writeback_started_at` records when the accepted parent-ledger or contract write-back begins.
+- `writeback_completed_at` records when that write-back is complete in the repo.
+- These fields are artifact-lifecycle timestamps only; historical-effective rule timing belongs in contract chronology fields, not here.
+
+## Asset and Item Id Rule
+
+- Every SUP row must carry one `supplement_item_id`.
+- Name it as `<parent-row-id>-SUP-<n>`.
+- Every attachment beneath one SUP row must carry one stable `attachment_id`.
+- Use `<supplement-item-id>-ATT-<n>` for generic assets and `<supplement-item-id>-SHOT-<n>` when the asset is specifically a screenshot.
+- When a stable repo-local file exists, the attachment reference should be rendered as one clickable markdown link rather than as bare path prose only.
+
+## Evidence Table Shape
+
+| supplement item id | parent row id | evidence ref | evidence type | attachment ids | verification status | effect on current verdict | proposed parent-ledger action | contract impact | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `<S0A-1A-R02-SUP-01>` | `<S0A-1A-R02>` | `<code path|md path|issue|oral note|other evidence anchor>` | `<code|md|issue|log|oral|screenshot|other>` | `<S0A-1A-R02-SUP-01-SHOT-01>` | `<pending|verified|rejected>` | `<supports-existing|sharpens-existing|narrows-existing|revises-existing|conflicts-needs-review>` | `<no-change|add-supporting-evidence|rewrite-parent-row|split-parent-row|reopen-routing>` | `<none|rewrite-current-draft|open-new-release|defer-contract-change>` | `<why this evidence should or should not change the parent-ledger reading>` |
+
+## Approval-Facing Attachment Review Rule
+
+- Keep the main `Evidence Table` focused on routing and verdict semantics; do not turn it into an image gallery.
+- When screenshot or other attached-file evidence materially supports the SUP verdict, add one `Attachment Review Table`.
+- The attachment ref in that review table should be one clickable markdown link whenever a stable repo-local asset exists.
+- If table-cell rendering is too weak for the active review surface, add one table-external `Attachment Quick Review` block with standalone links and optional inline previews.
+- `review status` records whether the attachment is merely listed, accepted as sufficient for this packet, still too weak, or rejected.
+- `approval basis` should stay short and claim-facing: it explains why the visible attachment is good enough to support the packet judgment.
+- `review note` should stay compact and reviewer-facing: record what was checked, what was visible, or why the evidence is still insufficient.
+
+## Actor and Provenance Field Rule
+
+- When packet-level evidence accountability matters, add one `Actor and Provenance Review Table` beneath the attachment-review surfaces.
+- Keep this field set minimal: `submitted by`, `evidence owner`, `verified by`, `verification method`, `approved by`, `approval state`, and `approval basis`.
+- These fields describe packet-level accountability only; they do not replace the routing verdict, the attachment review record, or any later permissions model.
+- Historical packets may use defended partial values such as `unknown`, `pending`, role-based labels, or delegated labels instead of inventing named actors.
+- Prefer one concise `provenance note` when the actor chain is incomplete but still bounded enough for the packet to remain useful.
+
+## Incomplete-History Representation Rule
+
+- Use `unknown` when the packet cannot currently defend the actor identity.
+- Use `pending` when the actor or state is expected to be filled later but is not yet resolved.
+- Use `role:<role-name>` when the packet can defend the responsible role but not the named person.
+- Use `delegated:<role-name>` when the packet can defend that authority was delegated to one role boundary without yet naming the final actor.
+- Do not fabricate named individuals or over-precise authority chains merely to fill the table.
+- A packet may remain partially specified when the evidence remains useful and the missing actor detail is stated explicitly in `provenance note`.
+
+## Actor and Provenance Review Table
+
+Use this when the packet needs explicit accountability for submission, verification, and approval.
+
+| supplement item id | submitted by | evidence owner | verified by | verification method | approved by | approval state | approval basis | provenance note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `<S0A-1A-R02-SUP-01>` | `<unknown|pending|role:operator|delegated:review-lead|name>` | `<unknown|pending|role:workflow-owner|name>` | `<unknown|pending|role:reviewer|name>` | `<direct-screenshot-inspection|source-path-check|manual-replay|transcript-comparison|other>` | `<unknown|pending|role:approver|delegated:records-lead|name>` | `<pending|accepted-for-packet|needs-better-evidence|rejected>` | `<why this approval state is currently defended>` | `<why any actor fields remain partial or how the current provenance chain is bounded>` |
+
+## Attachment Review Table
+
+Use this when screenshot or other file-backed evidence needs direct reviewer access from the packet.
+
+| attachment id | supplement item id | click-through asset ref | review status | approval basis | review note |
+| --- | --- | --- | --- | --- | --- |
+| `<S0A-1A-R02-SUP-01-SHOT-01>` | `<S0A-1A-R02-SUP-01>` | `[open asset](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)` | `<pending|accepted-for-packet|needs-better-evidence|rejected>` | `<why this attachment is good enough, or not good enough, for the current packet>` | `<what the reviewer checked or what remains missing>` |
+
+## Optional Attachment Quick Review
+
+Use this when reviewers need one table-external place to open or visually inspect attachments directly.
+
+- `Attachment`: `[S0A-1A-R02-SUP-01-SHOT-01](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)`
+- `Preview`:
+
+  ![S0A-1A-R02-SUP-01-SHOT-01 preview](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)
+
+- `Review focus`: `<what the reviewer should confirm from this attachment>`
+
+- Use this block only when direct human review readability matters enough to justify the extra vertical space.
+- Keep the main packet verdict in `Evidence Table` and `Attachment Review Table`; this block is a review aid, not the canonical routing surface.
+
+## Optional Evidence Time Audit
+
+Use this when one supplement row needs explicit audit of source execution time, source recording time, or historical-effective range.
+
+| supplement item id | source observed at | source recorded at | source effective from | source effective until | time precision | timezone note | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `<S0A-1A-R02-SUP-01>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|ongoing|unknown>` | `<second|day|month|year|unknown>` | `<optional source-local zone or offset note>` | `<why this evidence time audit matters>` |
+
+- `source observed at` is the best known time the evidence event, experiment, or source snapshot was executed or observed.
+- `source recorded at` is the best known time the evidence document itself was written or admitted.
+- `source effective from` and `source effective until` describe the best known historical-effective range for the rule signal carried by that evidence row.
+- `time precision` must remain evidence-bound; if the source proves only a day, keep `day` rather than inventing seconds.
+
+## Required Rules
+
+- Every SUP row must point to one existing `parent row id`; a SUP ledger may not invent free-floating new slices.
+- `supplement_item_id` is required for every admitted evidence item.
+- `attachment ids` should stay empty when no attached asset is needed; when assets exist, each asset should receive one stable id rather than being referenced only by prose.
+- Screenshot-backed verdicts should prefer one `Attachment Review Table` row per attachment whenever direct reviewer click-through matters.
+- When table-cell links are not sufficiently reviewable in the active editor or preview surface, prefer adding one `Attachment Quick Review` section rather than overloading the main evidence tables.
+- When actor/provenance accountability matters, prefer one `Actor and Provenance Review Table` row per supplement item rather than scattering those fields across prose notes.
+- `verification status` records whether the evidence is merely proposed, verified enough for judgment, or rejected for this SUP round.
+- `effect on current verdict` states how the admitted evidence relates to the current parent-ledger judgment.
+- `proposed parent-ledger action` states what the parent ledger should do if that effect is accepted.
+- `contract impact` is downstream-only guidance; it may not be applied before the parent ledger is updated or explicitly left unchanged.
+
+## Escalation Rule
+
+- When the effect is `supports-existing` or `sharpens-existing`, prefer `add-supporting-evidence` or another minimal parent-ledger write-back.
+- When the effect is `narrows-existing` or `revises-existing`, prefer `rewrite-parent-row` or `split-parent-row` before any contract rewrite.
+- When the effect is `conflicts-needs-review`, prefer `reopen-routing`; do not write directly into contract release fields.
+- If a SUP row cannot be tied to one existing parent row id, open a new bounded source or continuation packet instead of forcing the evidence into this SUP ledger.
+
+## Completion Rule
+
+- A SUP ledger may be marked `completed` only when every admitted evidence row has one explicit `verification status` and one explicit proposed parent-ledger action.
+- A SUP ledger is not complete merely because evidence has been collected; the row verdicts must be explicit.
+
+## Optional Rollup
+
+- `parent-ledger rows to update`:
+  - list the exact parent row ids that should be rewritten or supplemented
+- `attachment inventory`:
+  - list screenshot, transcript, export, or similar asset ids admitted in this round
+- `contract changes deferred until parent write-back`:
+  - list any contract records that may need change only after the parent ledger is updated
+- `rejected evidence`:
+  - list proposed evidence rows that were intentionally not admitted in this round

--- a/docs/logs/_template-support-only-contract-release-ledger.md
+++ b/docs/logs/_template-support-only-contract-release-ledger.md
@@ -1,0 +1,112 @@
+# support-only-contract-release-ledger-template
+
+## Purpose
+
+- Use this ledger when one source issue, log, or retained support-only body is being split across multiple contract families, release actions, or retained-only destinations.
+- This ledger owns `source routing, extraction accounting, and later consumption tracking`.
+- Do not use contract lineage fields to replace this ledger; lineage stays contract-to-contract, while this ledger explains how mixed source material was mapped into later contract work.
+
+## Naming Rule
+
+- Name ledgers as `ledger-<source-id>-<source-summary>.md`.
+- The `<source-id>` should match the source log or issue identifier being routed.
+- The `<source-summary>` should reuse the source summary itself, normalized to filename shape rather than inventing a second naming scheme.
+- Preferred example shapes:
+  - `ledger-S0B-2A-tools-scripts-and-snapshots-management.md`
+  - `ledger-S0A-2A-structured-doc-refinement-pipeline.md`
+
+## Minimal Header
+
+```yaml
+support_only_contract_release_ledger:
+  ledger_id: <ledger-S0B-2A-source-summary>
+  ledger_kind: support-only-contract-release-ledger
+  status: <draft|active|completed>
+  owner_lane: <S0F-7B>
+  created_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  reviewed_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  accepted_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  source_id: <S0B-2A>
+  source_ref: <issue/log/support-only source being split>
+  source_scope: <what portion of the source this ledger covers>
+  target_reading_goal: <what later reader should understand after this ledger is applied>
+```
+
+## Lifecycle Field Rule
+
+- New writes should use canonical UTC second timestamps such as `2026-04-12T15:18:05Z` for artifact-lifecycle fields.
+- Legacy day-only values such as `2026-04-12` may remain when older records do not yet have defended second-level audit timestamps.
+- If a reader still needs local-time display, keep it as one display-only mirror or prose note; do not replace the canonical UTC value.
+- `created_at` records when this ledger file was first created in the repo.
+- `reviewed_at` records when the ledger routing was first reviewed tightly enough to count as one defended packet rather than one raw staging draft.
+- `accepted_at` records when the ledger is accepted as the current parent routing surface for later supplement or contract work.
+- These fields are artifact-lifecycle timestamps only; they do not claim to describe when the underlying historical rule first became effective.
+
+## Optional Row Chronology Audit
+
+Use this when one parent-ledger row also needs explicit time audit for source observation, source recording, or historical-effective range without overloading the main routing table.
+
+| row id | source observed at | source recorded at | source effective from | source effective until | time precision | timezone note | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `<S0A-1A-R01>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|ongoing|unknown>` | `<second|day|month|year|unknown>` | `<optional source-local zone or offset note>` | `<why this row's time audit matters>` |
+
+- `source observed at` is the best known time the underlying source event or evidence was observed or executed.
+- `source recorded at` is the best known time that source material itself was written down, published, or admitted.
+- `source effective from` and `source effective until` describe the best known historical-effective range for the routed source slice.
+- `time precision` must reflect the strongest defended precision only; do not fabricate seconds when the source proves only a date.
+
+## Routing Table Shape
+
+| row id | source slice | meaning owned here | target family | target release action | contract lineage impact | retained-only action | resolution status | resolved by contract id | consumed scope | resolution notes | notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `<S0A-1A-R01>` | `<source heading or bounded paragraph set>` | `<what rule/boundary the slice carries>` | `<DOC-WORKFLOW-LABS>` | `<new-release|revise-release|new-family|no-contract>` | `<supersede|split|absorb|retire|none-source-only>` | `<keep-in-log|support-only|defer>` | `<draft|applied|partially-applied|deferred|retained-support-only|re-routed|rejected>` | `<DOC-WORKFLOW-LABS-0002|none>` | `<full|partial|none>` | `<how this slice was finally consumed or why it was not>` | `<why this routing is correct>` |
+
+## Required Rules
+
+- `row id` is required for every routed slice and should stay stable even when the prose wording in `source slice` tightens later.
+- Name `row id` as `<source-id>-R<n>` with zero-padded sequence numbers inside one ledger.
+- `target family` names the stable semantic family, not one specific release number.
+- `target release action` states what the receiving contract work should do:
+  - `new-family`
+  - `new-release`
+  - `revise-release`
+  - `no-contract`
+- `contract lineage impact` may stay `none-source-only` when the source slice is new material that is not itself one earlier contract.
+- `retained-only action` is required when a source slice is not promoted into a contract release.
+- `resolution status` records the terminal or current consumption state of that slice:
+  - `draft`
+  - `applied`
+  - `partially-applied`
+  - `deferred`
+  - `retained-support-only`
+  - `re-routed`
+  - `rejected`
+- `resolved by contract id` should name the later release that consumed the slice when consumption actually happened.
+- `consumed scope` states whether the slice was consumed fully, partially, or not at all.
+- If one later release absorbs new non-contract source material, record that fact here and carry the source forward in the later release metadata; do not fabricate `absorbed_from` links to sources that were never contracts.
+
+## Completion Rule
+
+- A ledger may be marked `completed` only when every source slice has one explicit resolution state.
+- Leaving a row undecided is not completion.
+- A slice counts as resolved only when it is marked as one of:
+  - `applied`
+  - `partially-applied`
+  - `deferred`
+  - `retained-support-only`
+  - `re-routed`
+  - `rejected`
+- Under this rule, the ledger remains the durable place to answer `what was consumed`, `what was not consumed`, and `where each slice ended up later`.
+
+## Optional Rollup
+
+- `new releases expected`:
+  - list the release records that should exist after this ledger is applied
+- `row id map`:
+  - list any stable row ids whose prose labels were tightened after initial creation
+- `cumulative sources to carry forward`:
+  - list the sources that later release metadata must keep visible
+- `deferred slices`:
+  - list source slices that still need judgment later
+- `unconsumed slices`:
+  - list source slices that were intentionally not promoted into a release

--- a/docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md
+++ b/docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md
@@ -1,0 +1,700 @@
+# log-S0F-7D (Phase 7D: ledger supplement admission and old-log continuation)
+
+---
+
+**id**: `S0F-7D`
+**kind**: `log`
+**title**: `ledger supplement admission and old-log continuation`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Governance, Ledger, Evidence, Migration, epic/s0, sub/7d`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-7C-old-log-decomposition-application-lane.md`
+  **reference_log_1**: `docs/logs/log-S0F-7C-old-log-decomposition-application-lane.md`
+  **reference_log_2**: `docs/logs/_template-support-only-contract-release-ledger.md`
+  **reference_log_3**: `docs/governance/contracts/_template-contract-record.md`
+  **reference_log_4**: `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+**issue_keyword**: `evidence`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/7`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-11`
+**updated**: `2026-04-11`
+**reviewed**: `2026-04-11`
+
+---
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-7D` opens as the bounded follow-up after `S0F-7C` for supplement-ledger admission and future old-log continuation.
+- This lane exists because `7C` has already proved one first application packet, and later work now needs one stricter continuation rule: mixed later evidence must attach to an existing source-owned ledger before it can influence contract meaning.
+
+**Default choices (phase defaults / v1)**:
+
+- Do not let later code, markdown, screenshots, oral recall, or operator validation material write directly into contracts.
+- Admit later evidence only through one bounded supplement ledger that is anchored to an existing parent source-owned ledger.
+- Prefer current logs or new bounded logs for future extraction work; reopen older sources only when an existing ledger lacks enough evidence to defend or revise one already-known slice.
+- Keep `7D` focused on supplement-ledger admission and continuation discipline first; broader provenance, approval, and organizational authority fields remain out of scope for this first scaffold.
+
+## Problem Statement
+
+- `S0F-7C` proved that one old mixed source can be decomposed into ledgers and child contracts, but it also exposed the next missing control surface: later evidence is now likely to arrive from code, old markdown, screenshots, or verified oral explanation rather than from the original source packet alone.
+- If that later evidence writes directly into contracts, the repo loses the defended `source packet -> ledger -> contract` chain that `7B` and `7C` just established.
+- The repo therefore needs one bounded continuation lane that answers three questions before more old-log work continues broadly:
+  - how supplement evidence is admitted without bypassing the parent source-owned ledger
+  - how one supplement ledger can strengthen, sharpen, or reopen an existing routing verdict without inventing arbitrary new contract meaning
+  - when future old-log continuation should prefer current or new bounded logs instead of repeatedly extending the first `7C` packet
+
+## Exported Sections / Outlet Ownership
+
+- This slice starts as one `contract + support-only ledger + log-retained core` governance-design lane.
+- The default expected landing is one supplement-ledger admission model, one first supplement-ledger template or pilot shape, and one explicit continuation rule for future old-log reopening.
+
+**Outlet ownership**:
+
+- `contract`: no-op by default; this lane should first fix supplement-ledger and continuation rules before emitting any family-owned contract
+- `support-only ledger`: expected landing surface for the supplement-ledger template and later pilot instances
+- `view`: no-op by default; reader projection is not the first missing boundary here
+- `index/front-door`: no-op by default; front-door work should wait until supplement-ledger practice stabilizes
+- `disposition/placement`: no-op by default
+- `log-retained core`: expected landing surface for the lane boundary, admission rules, pilot decisions, and evidence
+
+## Definitions (optional)
+
+- `parent ledger`: the existing source-owned support-only ledger that already records source slices and their routing verdicts.
+- `parent ledger row id`: the stable per-slice identifier inside one parent ledger, used as the anchor for later supplement evidence.
+- `supplement ledger`: a bounded evidence-admission ledger that attaches to one parent ledger and may strengthen, sharpen, or reopen one existing routing verdict.
+- `supplement item id`: the stable per-evidence identifier inside one supplement ledger, scoped beneath one parent-ledger row.
+- `attachment or shot id`: the stable per-asset identifier beneath one supplement item, used for screenshots, exports, transcripts, or similar attached evidence.
+- `admitted supplement evidence`: later evidence that is tied to one existing parent-ledger slice and has passed the required verification rule for this lane.
+- `continuation packet`: a later bounded old-log follow-up that reopens a source only because one explicit ledger gap or supplement-evidence need has been identified.
+
+## Constraints
+
+- Do not bind supplement ledgers directly to contracts as the primary owner; they must attach to one parent source-owned ledger first.
+- Do not allow a supplement ledger to introduce entirely new free-floating slices that never appeared in the parent ledger review surface.
+- Do not reopen old logs mechanically; a continuation packet should require one explicit unresolved ledger need.
+- Do not fold broader provenance, approval, or organizational-attestation modeling into this first lane unless the supplement-ledger pilot proves the smaller boundary insufficient.
+
+## Scope
+
+- `P0`: open `S0F-7D`, fix the supplement-ledger continuation boundary, and state why future old-log continuation moves here rather than staying in `7C`
+- `P1`: define the supplement-ledger model, including its naming, minimum header, table shape, and parent-ledger attachment rule
+- `P2`: pilot the first supplement-ledger application on one real packet, expected first on the `S0A-1A` Projects slice
+- `P3`: define the continuation rule for when future old-log work should use current logs, new bounded logs, or explicit supplement-ledger reopening instead of broad historical replay
+- `P4`: reserve any later provenance or approval-interface expansion only if the supplement-ledger pilot proves the current minimal evidence-admission model too weak
+
+## Success Criteria (DoD)
+
+- The repo has one explicit rule that supplement evidence attaches to a parent ledger before it can influence contracts.
+- The repo has one reusable supplement-ledger shape that can admit code, markdown, or other verified later evidence without bypassing source accountability.
+- The repo has one first real pilot showing how a supplement ledger affects an existing parent-ledger verdict.
+- The repo has one explicit continuation rule that keeps future old-log extraction from repeatedly extending `7C` or re-consuming older logs casually.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - `P0-P3` have fixed the supplement-ledger model, first pilot, and continuation boundary;
+  - any broader provenance or approval expansion has either been explicitly deferred or opened as a separate bounded follow-up rather than left implicit here.
+
+## P0 (Lane boundary | v1)
+
+### P0-C1-S1 (Supplement-ledger continuation lane opened after `7C` | v1)
+
+- `S0F-7D` is now the bounded continuation lane after `7C` for supplement-ledger admission and future old-log reopening.
+- Under this rule, `7C` remains the first defended application packet while `7D` owns future continuation discipline.
+
+### P0-C1-S2 (Parent-ledger-first supplement rule fixed | v1)
+
+- Later evidence must now attach to one existing parent source-owned ledger before it can influence contract reading.
+- Under this rule, supplement evidence does not write straight into child contracts or parent contracts.
+
+## P1 (Supplement-ledger model | v1)
+
+### P1-C1-S1 (Supplement-ledger naming and parent-ledger attachment fixed | v1)
+
+- A supplement ledger must now be named as `ledger-SUP-<source-id>-<source-summary>.md`.
+- The `<source-id>` and `<source-summary>` must match the existing parent source-owned ledger rather than inventing one contract-first naming scheme.
+- Under this rule:
+  - one supplement ledger always attaches to one parent ledger
+  - the parent ledger remains the owner of routing verdicts
+  - the supplement ledger may sharpen or reopen a parent-ledger row, but it does not replace the parent ledger as the packet owner
+
+### P1-C1-S2 (Minimum supplement-ledger header and row contract fixed | v1)
+
+- The minimum supplement-ledger header is now fixed as:
+  - `supplement_id`
+  - `supplement_kind`
+  - `status`
+  - `owner_lane`
+  - `parent_ledger_id`
+  - `parent_source_id`
+  - `parent_source_ref`
+  - `supplement_scope`
+  - `target_reading_goal`
+- The minimum evidence row contract is now fixed as:
+  - `parent ledger slice`
+  - `evidence ref`
+  - `evidence type`
+  - `verification status`
+  - `effect on current verdict`
+  - `proposed parent-ledger action`
+  - `contract impact`
+  - `notes`
+- Under this rule, supplement rows record how later evidence should be judged against an already-existing parent-ledger slice rather than redoing the original routing table.
+
+### P1-C1-S3 (Allowed verdict effects and escalation rule fixed | v1)
+
+- Allowed `effect on current verdict` values are now fixed as:
+  - `supports-existing`
+  - `sharpens-existing`
+  - `narrows-existing`
+  - `revises-existing`
+  - `conflicts-needs-review`
+- Allowed `proposed parent-ledger action` values are now fixed as:
+  - `no-change`
+  - `add-supporting-evidence`
+  - `rewrite-parent-row`
+  - `split-parent-row`
+  - `reopen-routing`
+- Under this rule:
+  - supplement evidence may update or reopen a parent-ledger row
+  - supplement evidence may not write directly into contract lineage or release fields first
+  - any contract rewrite must happen only after the parent ledger has absorbed or rejected the supplement verdict
+
+### P1-C2-S1 (Parent-ledger row-id model fixed | v1)
+
+- Parent-ledger rows must now carry one stable `row_id` per routed slice.
+- The naming rule is now fixed as `<source-id>-R<n>`, using zero-padded sequence numbers inside one parent ledger.
+- Under this rule:
+  - `S0A-1A-R01` means the first stable routed slice inside the `S0A-1A` parent ledger
+  - row ids stay ledger-scoped rather than becoming contract ids
+  - wording in `source slice` may later tighten without breaking supplement references, because the stable anchor is the `row_id`
+
+### P1-C2-S2 (Supplement item-id and attachment-id model fixed | v1)
+
+- Supplement evidence items must now carry one stable `supplement_item_id` beneath one parent-ledger row.
+- The naming rule is now fixed as `<parent-row-id>-SUP-<n>`.
+- Attachments or screenshots beneath one supplement item must now carry one stable `attachment_id`, using `ATT` as the generic asset suffix and `SHOT` when the asset is specifically a screenshot.
+- Under this rule:
+  - `S0A-1A-R02-SUP-01` means the first supplement item attached to parent row `S0A-1A-R02`
+  - `S0A-1A-R02-SUP-01-SHOT-01` means the first screenshot asset beneath that supplement item
+  - attachment ids remain evidence-layer identifiers and do not become contract ids
+
+### P1-C2-S3 (ID boundary versus contract boundary fixed | v1)
+
+- `row_id`, `supplement_item_id`, and `attachment_id` are now fixed as ledger-layer and evidence-layer identifiers rather than contract identifiers.
+- Under this rule:
+  - contracts may cite these ids when needed for auditability or reader traceability
+  - contracts should not promote these ids into primary release identity fields
+  - the stable identity split is now: `ledger_id` for the file, `row_id` for the routed slice, `supplement_item_id` for the admitted evidence item, and `attachment_id` for attached assets such as screenshots
+
+### P1-C3-S1 (On-disk supplement naming normalized to `SUP` | v1)
+
+- The on-disk artifact naming for supplement-ledger records is now normalized from `ledger-supplement-...` to `ledger-SUP-...`.
+- Under this rule:
+  - `SUP` is the on-disk abbreviation for supplement-ledger records
+  - the conceptual boundary still remains `supplement ledger`, but filenames and `supplement_id` values now use the shorter `SUP` prefix
+  - existing and future supplement-ledger references should prefer the `ledger-SUP-<source-id>-<source-summary>.md` shape
+
+## Plan (draft)
+
+### P1 (Supplement-ledger model)
+
+- `P1-C1-S1`: define supplement-ledger naming and parent-ledger attachment
+- `P1-C1-S2`: define the minimum supplement-ledger header and evidence row contract
+- `P1-C1-S3`: define allowed verdict effects such as `supports-existing`, `sharpens-existing`, `revises-existing`, and `reopen-routing`
+- `P1-C2-S1`: define stable row ids for parent-ledger slices
+- `P1-C2-S2`: define supplement item ids plus screenshot or attachment ids
+- `P1-C2-S3`: define the boundary between ledger-layer ids and contract-layer ids
+- `P1-C3-S1`: normalize on-disk supplement-ledger naming to the `SUP` prefix
+
+### P2 (First pilot)
+
+- `P2-C1-S1`: pilot the first supplement-ledger against `S0A-1A` Projects evidence
+- `P2-C1-S2`: decide whether the first pilot only sharpens the current Projects child or actually reopens its parent-ledger row
+
+### P2-C1-S2 (First Projects SUP write-back accepted as sharpening-only | v1)
+
+- The first Projects SUP pilot is now accepted as one sharpening-only write-back rather than one routing reversal.
+- Under this rule:
+  - parent row `S0A-1A-R02` should be sharpened through supporting-evidence write-back
+  - `DOC-WORKFLOW-GITHUB-PROJECTS-0001` should be widened to describe the now-evidenced status-board, table, and timeline readings
+  - no reroute or parent-row split is required from the current evidence batch
+
+### P2-C2-S1 (SUP write-back defaults to current-release amendment | v1)
+
+- When one supplement ledger sharpens or revises a parent-ledger row that is already resolved into one current contract release, the default write-back target remains that same current release.
+- Under this rule:
+  - supplement-ledger write-back does not create one new contract release merely because the current release text is being sharpened, widened, narrowed, or otherwise amended from admitted parent-ledger evidence
+  - a new contract release should be opened only when one genuinely new release event is occurring, such as one new bounded extraction from another source issue or log, one lineage-changing reroute, or one contract-family change that can no longer be defended as amendment of the current release text
+  - if the admitted supplement still depends on the same parent release ledger and does not cross that release boundary, the contract should be edited in place while expanding its release change summary, supporting evidence, and reader-visible wording as needed
+
+### P2-C3-S1 (Contract statement-table model fixed without collapsing contract into ledger | v1)
+
+- A contract release may now carry one optional statement table so clause-level identity, replacement, and carry-forward can be tracked without forcing readers to reconstruct meaning from prose diffs alone.
+- Under this rule:
+  - statement ids should be named as `<contract_id>-ST-<nn>`
+  - the statement table should track clause status, change action, source basis, first effective release, last changed release, effective status, statement text, and notes
+  - the statement table does not replace source routing or supplement admission, because the parent ledger still owns routed slices and the supplement ledger still owns later evidence admission
+
+### P2-C3-S2 (LABS-0001 sample now demonstrates contract clause ids and ledger linkage | v1)
+
+- `DOC-WORKFLOW-LABS-001` may now serve as the first concrete sample for contract statement-table management.
+- Under this rule:
+  - the `S0B-1A` parent ledger should expose stable row ids so the labs contract can cite exact source basis anchors
+  - the labs contract may keep one readable prose statement while also exposing one clause-level table that points back to `S0B-1A-R01/R02/R03`
+  - this linkage remains one contract-facing clause registry, not one second routing table embedded inside the contract body
+
+### P2-C4-S1 (Contract statement labels fixed as contract-facing quick labels | v1)
+
+- Contract statement tables may now carry one `statement label` column so readers can see one short contract-facing title for each clause without confusing that title with the source-owned `source slice` field from the ledger.
+- Under this rule:
+  - `statement label` is the short human-readable identifier for the current contract clause
+  - `statement label` should stay contract-facing and concise rather than copying raw source-packet wording wholesale
+  - the full clause meaning still lives in `statement text`, while the ledger continues to own `source slice`
+
+### P2-C4-S2 (Source-basis multiplicity fixed with primary-first stable-anchor rule | v1)
+
+- Contract statement tables may now record more than one `source basis` anchor when one clause truly depends on multiple upstream bases.
+- Under this rule:
+  - `source basis` should use one or more stable ids rather than raw file paths
+  - additional anchors should be limited to directly decisive parent-row, supplement-item, or prior-statement ids rather than general supporting evidence
+  - this multiplicity rule is now superseded by `P2-C5-S1S2`, which separates evidence anchors from statement lineage and no longer treats basis order as the carrier of causal semantics
+
+### P2-C5-S1 (Source basis narrowed to evidence-only anchors | v1)
+
+- `source basis` now records only the directly decisive evidence anchors for one contract clause or clause-change event.
+- Under this rule:
+  - `source basis` may still hold one or more stable ids
+  - `source basis` should not carry primary/supporting causal logic, split history, merge history, or replacement lineage
+  - clause lineage should move to one separate statement-evolution surface instead of being implied through basis formatting
+
+### P2-C5-S2 (Statement-evolution table fixed as the clause-lineage surface | v1)
+
+- A contract release may now carry one optional `Statement Evolution Table` that records split, merge, replacement, retirement, amendment, and carry-forward events between statement ids.
+- Under this rule:
+  - statement evolution should use one stable `change id` named as `<contract_id>-CH-<nn>`
+  - `input statement ids` and `output statement ids` should carry the clause lineage and causal relationship
+  - `source basis` may still appear in the evolution table, but only as the decisive evidence anchors for the change event
+
+### P2-C5-S3 (LABS-0001 sample now demonstrates split handling across two contract tables | v1)
+
+- `DOC-WORKFLOW-LABS-001` may now serve as the first sample where one over-dense cleanup clause is decomposed into two narrower clauses while lineage is retained separately from evidence anchors.
+- Under this rule:
+  - the contract statement table now keeps the narrower current clauses
+  - the statement-evolution table records the split event and its reason
+  - the sample no longer uses `primary/supporting` inside `source basis`
+
+### P2-C6-S1 (Later-release statement ids fixed as release-local rather than reused lineage ids | v1)
+
+- Statement ids in one later release should now be minted under that later release's `contract_id` rather than reusing earlier-release statement ids as the current ids.
+- Under this rule:
+  - a carried-forward or amended clause in `DOC-WORKFLOW-LABS-0002` should now be named as `DOC-WORKFLOW-LABS-0002-ST-<nn>`
+  - earlier ids such as `DOC-WORKFLOW-LABS-001-ST-06` remain historical lineage anchors only
+  - the continuity between releases should be recorded in the statement-evolution table, not by keeping the old statement id as the current id
+
+### P2-C6-S2 (S0B-2A ledger now exposes row ids for LABS-0002 clause anchoring | v1)
+
+- The `S0B-2A` routing ledger may now expose stable row ids so `LABS-0002` can cite exact later-release evidence anchors in its contract statement table.
+- Under this rule:
+  - the labs-only snapshot-policy slice should anchor as `S0B-2A-R03`
+  - unconsumed or deferred slices remain ledger-visible but do not need to appear in the labs contract unless the release actually consumes them
+
+### P2-C6-S3 (LABS-0002 sample now revised to the paired-table clause model | v1)
+
+- `DOC-WORKFLOW-LABS-0002` may now serve as the first later-release sample under the paired contract-clause model.
+- Under this rule:
+  - `LABS-0002` should carry one `Contract Statement Table` for current clause state
+  - `LABS-0002` should carry one `Statement Evolution Table` for carry-forward, amendment, and introduction relationships back to `LABS-0001`
+  - `source basis` in both tables should stay evidence-only and point to stable ledger rows such as `S0B-1A-R01` and `S0B-2A-R03`
+
+### P2-C7-S1 (Contract statement-table ordering fixed by semantic origin first | v1)
+
+- The current `Contract Statement Table` should now be ordered by semantic origin before current-release novelty.
+- Under this rule:
+  - clauses with smaller `first effective release` values should appear earlier
+  - when `first effective release` is the same, `carried-forward` clauses should appear first, `amended` clauses second, and `introduced` clauses third
+  - within the same bucket, one reader-friendly order should be kept rather than forcing pure lexical id order
+
+### P2-C7-S2 (LABS-0002 first-effective and last-changed semantics normalized | v1)
+
+- `LABS-0002` may now normalize clause timing fields so carried-forward and amended clauses preserve their earlier first-effective origin while only later-introduced clauses start at `0002`.
+- Under this rule:
+  - carried-forward clauses from `LABS-0001` should keep `first effective release: DOC-WORKFLOW-LABS-0001`
+  - amended clauses whose meaning first existed in `LABS-0001` should also keep `first effective release: DOC-WORKFLOW-LABS-0001` while updating `last changed release: DOC-WORKFLOW-LABS-0002`
+  - introduced clauses that first appear in the later release should keep both fields at `DOC-WORKFLOW-LABS-0002`
+
+### P2-C8-S1 (S0A-2A selective-backfill ledger now exposes row ids for SUP anchoring | v1)
+
+- The `S0A-2A` selective-backfill ledger may now expose stable row ids so later direct evidence can attach to exact workflow-layer slices instead of relying on mutable prose labels alone.
+- Under this rule:
+  - the runbook layer should now anchor as `S0A-2A-R04`
+  - later SUP rows may now attach to exact `logs`, `labs`, `runbook`, or `ADR` slices without reopening the whole issue-level packet at once
+
+### P2-C8-S2 (S0A-2A runbook-direct-evidence SUP opened from the earliest projection SOPs | v1)
+
+- `ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md` now serves as the first direct-evidence SUP round for the `S0A-2A` runbook layer.
+- Under this rule:
+  - legacy runbooks `run-001-search-projection.md` and `run-003-chronicle-projection.md` now count as direct evidence that the runbook layer was already being extracted from successful projection work, failure-management labs, and long-lived operator verification needs
+  - the current draft SUP judgment is that this evidence revises the earlier `bounded-background` reading for the runbook layer strongly enough to justify parent-row rewrite and later child-promotion review
+  - this round is prioritized because broader roadmap/log skeleton reorganization is still unresolved, while earlier workflow-layer contract extraction can keep advancing through defended direct-evidence packets
+
+### P2-C8-S3 (S0A-2A runbook parent-row verdict rewritten from accepted SUP evidence | v1)
+
+- The `S0A-2A` parent ledger may now write back the accepted runbook SUP reading directly onto parent row `S0A-2A-R04`.
+- Under this rule:
+  - the runbook layer should no longer read as issue-only `bounded-background`; it now enters explicit `DOC-WORKFLOW-RUNBOOK` child-candidate review because the earliest projection SOPs already prove durable operator-facing extraction
+  - the reason for runbook emergence is now recorded at phase level as well: once projection paths existed, the durable next need moved to rebuildability, replay, readiness, observability, runtime failure handling, and operator-safe verification rather than to further labs-only experimentation
+  - actual child-contract opening remains deferred until one defended runbook packet is promoted, so the parent row now records stronger review status without pretending that a runbook contract already exists
+
+### P2-C8-S4 (DOC-WORKFLOW-RUNBOOK-0001 child-opening packet drafted from the accepted runbook packet | v1)
+
+- `DOC-WORKFLOW-RUNBOOK-0001` may now open as the first dedicated runbook-family child draft under the accepted `S0A-2A-R04` review outcome.
+- Under this rule:
+  - the first runbook child should stay narrow to projection operator rebuild, replay, readiness, observability, and failure-recovery governance rather than restating the whole broader workflow pipeline
+  - parent row `S0A-2A-R04` may now resolve to `DOC-WORKFLOW-RUNBOOK-0001`, while `DOC-WORKFLOW-0001` remains unchanged as the broader workflow-layer reader
+  - current sourcing remains explicit about issue-only origin plus later direct runbook evidence from `run-001` and `run-003`, so the child-opening packet does not overclaim broader repo-wide runbook semantics
+
+### P3 (Future continuation discipline)
+
+- `P3-C1-S1`: define when future work should prefer current logs or new bounded logs instead of old-log reopening
+- `P3-C1-S2`: define when an older packet may be reopened only through explicit supplement-ledger need
+
+## Execution Checklist (unchecked)
+
+### P0 (Lane boundary)
+
+- [x] `P0-C1-S1`: open `S0F-7D` as the supplement-ledger continuation lane after `7C`
+- [x] `P0-C1-S2`: fix the parent-ledger-first supplement rule
+
+### P1 (Supplement-ledger model)
+
+- [x] `P1-C1-S1`: define supplement-ledger naming and attachment
+- [x] `P1-C1-S2`: define header and row contract
+- [x] `P1-C1-S3`: define allowed verdict effects
+- [x] `P1-C2-S1`: define stable row ids for parent-ledger slices
+- [x] `P1-C2-S2`: define supplement item ids plus screenshot or attachment ids
+- [x] `P1-C2-S3`: define the boundary between ledger-layer ids and contract-layer ids
+- [x] `P1-C3-S1`: normalize on-disk supplement-ledger naming to the `SUP` prefix
+
+### P2 (First pilot)
+
+- [x] `P2-C1-S1`: pilot the first supplement-ledger on `S0A-1A` Projects evidence
+- [x] `P2-C1-S2`: decide whether the pilot sharpens or reopens the parent-ledger verdict
+- [x] `P2-C2-S1`: fix the release-boundary rule for accepted SUP write-back
+- [x] `P2-C3-S1`: fix the contract statement-table model
+- [x] `P2-C3-S2`: wire `LABS-0001` as the first clause-table sample linked back to its parent ledger
+- [x] `P2-C4-S1`: fix the contract-facing statement-label rule
+- [x] `P2-C4-S2`: fix the multi-anchor source-basis rule
+- [x] `P2-C5-S1`: narrow `source basis` to evidence-only anchors
+- [x] `P2-C5-S2`: fix the statement-evolution table model
+- [x] `P2-C5-S3`: split the LABS cleanup sample across statement-state and statement-evolution tables
+- [x] `P2-C6-S1`: fix later-release statement ids as release-local
+- [x] `P2-C6-S2`: expose `S0B-2A` row ids for later-release clause anchoring
+- [x] `P2-C6-S3`: revise `LABS-0002` to the paired-table clause model
+- [x] `P2-C7-S1`: fix semantic-origin-first statement-table ordering
+- [x] `P2-C7-S2`: normalize `LABS-0002` first-effective and last-changed semantics
+- [x] `P2-C8-S1`: expose `S0A-2A` row ids for later SUP anchoring
+- [x] `P2-C8-S2`: open the first runbook-direct-evidence SUP round for `S0A-2A`
+- [x] `P2-C8-S3`: write back the accepted runbook SUP judgment onto parent row `S0A-2A-R04`
+- [x] `P2-C8-S4`: draft the first `DOC-WORKFLOW-RUNBOOK-0001` child-opening packet from the accepted runbook evidence packet
+
+### P3 (Future continuation discipline)
+
+- [ ] `P3-C1-S1`: define current-log or new-log preference for future work
+- [ ] `P3-C1-S2`: define explicit reopen conditions for older packets
+
+## Current Status
+
+- `S0F-7D` is now opened as the bounded continuation lane after `S0F-7C`.
+- The lane now fixes one immediate baseline: supplement evidence must attach to a parent source-owned ledger before it can affect contract meaning.
+- `P1-C1-S1S2S3` are now complete: supplement-ledger naming, minimum header, evidence row shape, and allowed verdict effects are now fixed, and the first reusable template is now ready for direct pilot work.
+- `P1-C2-S1S2S3` are now complete: stable row ids, supplement item ids, and screenshot or attachment ids are now fixed across the ledger layer, and the contract boundary is now explicit enough for real pilot intake.
+- `P1-C3-S1` is now complete: on-disk supplement-ledger naming now uses the shorter `SUP` prefix, and the reusable template plus first pilot file now follow that same artifact naming model.
+- `P2-C1-S1` is now complete: the first screenshot-backed Projects SUP pilot now exists at a stable repo-local path and reads as one sharpen-the-draft supplement rather than as one routing-reversal packet.
+- `P2-C1-S2` is now complete: the first Projects SUP pilot is accepted as sharpening-only write-back, the parent ledger now sharpens `S0A-1A-R02`, and `PROJECTS-0001` now reflects status-board, table, and timeline readings without changing the underlying routing boundary.
+- `P2-C2-S1` is now complete: accepted SUP write-back is now fixed as amendment of the current resolved release by default, not as one automatic new contract release.
+- `P2-C3-S1` is now complete: the repo now has one explicit contract statement-table model for clause-level identity and carry-forward without collapsing contracts into ledgers.
+- `P2-C3-S2` is now complete: `LABS-0001` now acts as the first clause-table sample, and the `S0B-1A` parent ledger now exposes row ids so the contract can cite exact source-basis anchors.
+- `P2-C4-S1` is now complete: contract statement tables now explicitly distinguish one short `statement label` from the ledger-owned `source slice` field.
+- `P2-C4-S2` is now complete: `source basis` is now fixed as one-or-more stable anchors with a primary-first rule, and `LABS-0001` demonstrates the first multi-anchor sample row.
+- `P2-C5-S1` is now complete: `source basis` is now narrowed back to evidence-only anchors and no longer carries primary/supporting causal semantics.
+- `P2-C5-S2` is now complete: the repo now has one explicit `Statement Evolution Table` model for clause lineage, split, merge, replacement, and carry-forward events.
+- `P2-C5-S3` is now complete: `LABS-0001` now demonstrates the paired-table model by splitting the earlier cleanup sample into two narrower clauses and recording the split in a separate evolution table.
+- `P2-C6-S1` is now complete: later-release statement ids are now fixed as release-local ids, with earlier-release statement ids retained only as lineage anchors.
+- `P2-C6-S2` is now complete: the `S0B-2A` ledger now exposes stable row ids so `LABS-0002` can cite exact later-release evidence anchors.
+- `P2-C6-S3` is now complete: `LABS-0002` now follows the paired-table clause model, with current clause state separated from clause lineage back to `LABS-0001`.
+- `P2-C7-S1` is now complete: current statement tables now sort by smaller `first effective release` first, then by `carried-forward`, `amended`, and `introduced` buckets.
+- `P2-C7-S2` is now complete: `LABS-0002` now preserves `0001` as the first-effective origin for carried-forward and amended clauses while keeping later introductions at `0002`.
+- `P2-C8-S1` is now complete: the `S0A-2A` selective-backfill ledger now exposes stable row ids so the runbook layer can receive later SUP evidence through an exact parent-row anchor.
+- `P2-C8-S2` is now complete: the first `S0A-2A` runbook-direct-evidence SUP round now uses `run-001` and `run-003` to argue that runbooks had already become durable operator-facing extraction rather than only broad issue-level background.
+- `P2-C8-S3` is now complete: parent row `S0A-2A-R04` no longer stays at `bounded-background` only, and the accepted write-back now records one explicit runbook child-candidate review state while still deferring actual `DOC-WORKFLOW-RUNBOOK` contract opening.
+- `P2-C8-S4` is now complete: the repo now has one first `DOC-WORKFLOW-RUNBOOK-0001` child draft, and parent row `S0A-2A-R04` now resolves to that dedicated runbook release rather than stopping at child-candidate review.
+- The next execution step is to reuse this same `7D` lane when earlier packets such as `S0A-2A` need later evidence admitted through one parent-ledger-first SUP write-back.
+
+## Evidence (reserved)
+
+### P0-C1-S1S2 (Supplement-ledger continuation lane scaffolded | 2026-04-11)
+
+- headSha: `54d4f529e`
+- artifacts:
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+- expected:
+  - the repo should gain one new bounded lane after `7C` for supplement-ledger admission and future old-log continuation
+  - the lane should explicitly keep supplement evidence attached to a parent source-owned ledger instead of letting it write directly into contracts
+- observed:
+  - `S0F-7D` now exists as the next bounded follow-up after `7C`
+  - the lane now fixes the parent-ledger-first supplement rule as its opening boundary
+
+### P1-C1-S1S2S3 (Supplement-ledger model fixed and templated | 2026-04-11)
+
+- headSha: `54d4f529e`
+- artifacts:
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+- expected:
+  - the repo should gain one explicit supplement-ledger naming and attachment rule that stays anchored to an existing parent source-owned ledger
+  - the repo should gain one reusable supplement-ledger template with a fixed header and evidence-row contract
+  - the repo should fix the allowed verdict effects and parent-ledger escalation rule before any real pilot starts
+- observed:
+  - supplement-ledger naming is now fixed as `ledger-SUP-<source-id>-<source-summary>.md` with mandatory parent-ledger attachment
+  - one reusable template now exists for supplement-ledger work with explicit header and evidence-row fields
+  - the lane now fixes a narrow verdict set and requires any later contract rewrite to happen only after the parent ledger absorbs or rejects the supplement result
+
+### P1-C2-S1S2S3 (Ledger-layer item and asset ids fixed | 2026-04-11)
+
+- headSha: `5d7c70b84`
+- artifacts:
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/_template-support-only-contract-release-ledger.md`
+  - `docs/logs/_template-support-only-contract-release-ledger-supplement.md`
+  - `docs/logs/support-only/ledger-S0A-1A-tools-github-issues-projects-and-tags.md`
+- expected:
+  - parent ledgers should gain one stable per-row id so supplement evidence can anchor to routed slices without depending on mutable prose labels
+  - supplement items and screenshot or attachment assets should gain stable ids at the evidence layer
+  - the repo should state clearly that these ids remain below the contract layer rather than becoming release identifiers
+- observed:
+  - parent ledger rows now have one stable `row_id` model
+  - supplement items plus screenshot or attachment assets now have one stable id model beneath the parent row
+  - the lane now keeps those ids ledger-scoped and evidence-scoped rather than promoting them into contract identity
+
+### P1-C3-S1 (SUP artifact naming normalized | 2026-04-11)
+
+- headSha: `354e08ec0`
+- artifacts:
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+- expected:
+  - the repo should normalize on-disk supplement-ledger naming to the shorter `SUP` prefix without changing the underlying conceptual boundary
+  - the reusable template and first pilot should use the same naming shape
+- observed:
+  - the on-disk supplement-ledger naming now uses the `ledger-SUP-...` prefix
+  - the reusable template and first pilot now match that same artifact naming rule
+
+### P2-C1-S1 (First screenshot-backed Projects SUP pilot stabilized | 2026-04-11)
+
+- headSha: `354e08ec0`
+- artifacts:
+  - `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+  - `docs/logs/support-only/S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png`
+  - `docs/logs/support-only/S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png`
+  - `docs/logs/support-only/S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png`
+- expected:
+  - the first Projects supplement should move from chat-only placeholder evidence to stable repo-local screenshot-backed evidence
+  - the pilot should remain a sharpening supplement rather than an outright routing reversal
+- observed:
+  - the first Projects SUP pilot now cites stable repo-local screenshot paths and records the three screenshots as verified evidence items
+  - the current reading still keeps `S0A-1A-R02 -> DOC-WORKFLOW-GITHUB-PROJECTS-0001` unchanged while preparing write-back that sharpens the parent row and widens the current Projects draft wording
+
+### P2-C1-S2 (First Projects SUP write-back accepted | 2026-04-11)
+
+- headSha: `e4989e235`
+- artifacts:
+  - `docs/logs/support-only/ledger-S0A-1A-tools-github-issues-projects-and-tags.md`
+  - `docs/governance/contracts/workflow/github/projects/DOC-WORKFLOW-GITHUB-PROJECTS-0001-project-views-support-execution-priority.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+- expected:
+  - the first SUP pilot should either reopen routing or be accepted as a sharpening-only write-back
+  - accepted write-back should sharpen the parent-ledger row and the current Projects draft without inventing a new routing boundary
+- observed:
+  - the current evidence batch is accepted as sharpening-only write-back rather than as a reroute or split
+  - parent row `S0A-1A-R02` now explicitly reads Projects as status-board, lookup, timeline, and bounded reprioritization support
+  - `PROJECTS-0001` now incorporates those three evidenced view classes while keeping GitHub Issues as the canonical hierarchy owner
+
+### P2-C2-S1 (Current-release amendment rule fixed for SUP write-back | 2026-04-11)
+
+- headSha: `e4989e235`
+- artifacts:
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - accepted supplement-ledger write-back should clarify whether current-release text is amended in place or automatically promoted into one new contract release
+  - the lane should state that new release numbering is reserved for genuinely new release events rather than for every supporting-evidence amendment
+- observed:
+  - `7D` now fixes current-release amendment as the default write-back rule when admitted supplement evidence stays within the same parent-ledger and routing boundary
+  - the lane now reserves new contract-release numbering for genuinely new release events such as new bounded extraction, lineage-changing reroute, or family-level contract change
+
+### P2-C3-S1S2 (Contract statement-table model and LABS sample wired in workspace | 2026-04-11)
+
+- headSha: `6b2d8d28f`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0001-tools-labs-and-snapshots.md`
+  - `docs/logs/support-only/ledger-S0B-1A-tools-labs-and-snapshots.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should clarify how one contract can track clause-level identity and source-basis linkage without turning the contract itself into one second ledger
+  - one concrete sample should show how a contract statement table points back to parent-ledger row ids
+- observed:
+  - the contract template now documents one optional statement-table model with stable statement ids and explicit source-basis fields
+  - `LABS-0001` now demonstrates one clause-table registry, while the `S0B-1A` parent ledger now exposes stable row ids that those clauses can cite
+
+### P2-C4-S1S2 (Statement labels and multi-anchor source basis fixed in workspace | 2026-04-11)
+
+- headSha: `6b2d8d28f`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0001-tools-labs-and-snapshots.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should distinguish contract-facing clause labels from ledger-owned source-slice labels
+  - the repo should clarify whether one contract clause may depend on more than one stable source-basis anchor and how that multiplicity should be written
+- observed:
+  - the contract template now recommends `statement label` as the short contract-facing clause title
+  - the template now permits one-or-more stable `source basis` anchors under a primary-first rule, and `LABS-0001` now demonstrates the first multi-anchor basis row
+
+### P2-C5-S1S2S3 (Evidence-only source basis and statement-evolution model fixed in workspace | 2026-04-11)
+
+- headSha: `6b2d8d28f`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0001-tools-labs-and-snapshots.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should keep `source basis` as evidence-only anchors rather than overloading it with clause causality
+  - the repo should publish one second clause-management table for split, merge, replacement, and retirement history
+  - the labs sample should show one clause split handled across the two-table model
+- observed:
+  - the contract template now distinguishes `Contract Statement Table` from `Statement Evolution Table`
+  - `source basis` is now documented as evidence-only, while clause lineage moves to `change id`, `input statement ids`, and `output statement ids`
+  - `LABS-0001` now demonstrates the paired-table model by splitting the cleanup sample into two narrower clauses and recording the split separately
+
+### P2-C6-S1S2S3 (Release-local statement ids and LABS-0002 paired-table model wired in workspace | 2026-04-11)
+
+- headSha: `a910e7a5d`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/logs/support-only/ledger-S0B-2A-tools-scripts-and-snapshots-management.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0002-labs-snapshot-evidence-package-governance.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - later-release statement ids should be clarified as release-local ids rather than reused earlier-release ids
+  - the `S0B-2A` ledger should expose stable row ids for `LABS-0002` clause anchoring
+  - the `LABS-0002` contract should be upgraded to the same paired-table clause model now used by `LABS-0001`
+- observed:
+  - the template now states that later releases mint their own `ST` ids and keep earlier statement ids only as lineage anchors
+  - the `S0B-2A` ledger now exposes stable row ids, including `S0B-2A-R03` for the labs snapshot-policy slice consumed by `LABS-0002`
+  - `LABS-0002` now carries both a `Contract Statement Table` and a `Statement Evolution Table`, with current `0002-ST-*` ids linked back to `001-ST-*` history through explicit evolution rows
+
+### P2-C7-S1S2 (Statement-table ordering and clause timing semantics normalized in workspace | 2026-04-11)
+
+- headSha: `a910e7a5d`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0002-labs-snapshot-evidence-package-governance.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - current statement tables should read older semantic origins first, then newer release-local introductions
+  - `LABS-0002` should preserve `0001` as the first-effective origin for carried-forward and amended clauses that began earlier
+- observed:
+  - the template now fixes semantic-origin-first ordering with `carried-forward`, `amended`, and `introduced` bucket order inside one release-origin group
+  - `LABS-0002` now orders carried-forward clauses first, amended clauses second, and introduced clauses third, while preserving `0001` as the first-effective origin for earlier clauses
+
+### P2-C8-S1S2 (S0A-2A runbook SUP round opened in workspace | 2026-04-12)
+
+- headSha: `0611fb60b`
+- artifacts:
+  - `docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md`
+  - `legacy/from_structured_docs/from-runbook/run-001-search-projection.md`
+  - `legacy/from_structured_docs/from-runbook/run-003-chronicle-projection.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the `S0A-2A` parent ledger should gain stable row ids so the runbook slice can receive later direct-evidence SUP rows by exact anchor rather than by mutable prose label
+  - the repo should gain one first `S0A-2A` SUP ledger that tests whether direct runbook evidence is strong enough to revise the current `bounded-background` verdict for the runbook layer
+  - the lane should record why this direct-evidence extraction round is being prioritized ahead of broader roadmap/log skeleton reorganization
+- observed:
+  - the `S0A-2A` parent ledger now exposes row ids, including `S0A-2A-R04` for the runbook layer
+  - one new SUP ledger now attaches `run-001-search-projection.md` and `run-003-chronicle-projection.md` to that exact runbook-layer row as verified direct evidence
+  - the current draft SUP judgment is that the runbook layer should no longer be treated as issue-only bounded background by default, and this extraction round is now prioritized while broader roadmap/log restructuring remains unsettled
+
+### P2-C8-S3 (S0A-2A runbook parent-row write-back accepted | 2026-04-12)
+
+- headSha: `b0ad217cd`
+- artifacts:
+  - `docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md`
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - parent row `S0A-2A-R04` should stop reading as issue-only `bounded-background` once the accepted SUP evidence proves durable runbook extraction from the earliest projection SOPs
+  - the lane should record the runbook-emergence reason explicitly at phase level, not only inside the support-only SUP ledger
+  - the write-back should strengthen the runbook verdict without falsely claiming that a `DOC-WORKFLOW-RUNBOOK` contract has already been opened
+- observed:
+  - `S0A-2A-R04` now reads as explicit `DOC-WORKFLOW-RUNBOOK` child-candidate review while still keeping actual release opening deferred
+  - `S0F-7D` now records that runbooks emerged because durable operator needs shifted toward rebuildability, replay, readiness, observability, runtime failure handling, and operator-safe verification after projection paths had succeeded
+  - the parent-ledger write-back now sharpens the verdict materially without inventing a non-existent runbook contract
+
+### P2-C8-S4 (DOC-WORKFLOW-RUNBOOK-0001 child-opening packet drafted | 2026-04-12)
+
+- headSha: `42987ad37`
+- artifacts:
+  - `docs/governance/contracts/workflow/runbook/DOC-WORKFLOW-RUNBOOK-0001-projection-operator-rebuild-replay-and-failure-recovery.md`
+  - `docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md`
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should gain one first dedicated runbook-family child draft from the accepted `S0A-2A-R04` packet instead of stopping at child-candidate review only
+  - the draft should stay narrow to the earliest projection SOP pattern: rebuildability, replay, runtime verification, observability, and failure recovery
+  - parent row `S0A-2A-R04` should resolve to the new child draft without widening logs, labs, or ADR ownership from the same broad issue source
+- observed:
+  - `DOC-WORKFLOW-RUNBOOK-0001` now exists as the first dedicated runbook-family draft sourced from the accepted `S0A-2A` runbook packet plus the two earliest projection SOPs
+  - `S0A-2A-R04` now resolves to `DOC-WORKFLOW-RUNBOOK-0001` with full consumed scope while keeping the rest of the mixed `S0A-2A` packet unchanged
+  - `S0F-7D` now carries the child-opening step explicitly so this runbook extraction remains visible in the same supplement-ledger continuation lane
+
+## Numbering
+
+- `S<n>`: Step.
+- `C<n>`: Cycle.
+
+**Commit / PR naming**:
+
+- `S0F-7D/P<phase>-C<cycle>-S<steps>: <summary>`, where `<steps>` can be a single step (`1`, meaning `...-S1`) or multiple consecutive steps grouped within the same phase / cycle.
+
+**Branch convention**:
+
+- `S0F-7D` work should continue on the top-level `S0F-docs-management-v6` branch unless the lane later opens one narrower bounded follow-up that warrants its own child branch.
+
+**Commit discipline (recommended)**:
+
+- Keep scaffold, template, and first pilot commits separated so supplement-ledger model changes do not get buried inside one larger old-log continuation packet.

--- a/docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md
+++ b/docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md
@@ -1,0 +1,453 @@
+# log-S0F-7E (Phase 7E: supplement sequencing time fields and historical backfill release chronology)
+
+---
+
+**id**: `S0F-7E`
+**kind**: `log`
+**title**: `supplement sequencing time fields and historical backfill release chronology`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Governance, Ledger, Records, Evidence, epic/s0, sub/7e`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  **reference_log_1**: `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  **reference_log_2**: `docs/governance/contracts/_template-contract-record.md`
+  **reference_log_3**: `docs/logs/_template-support-only-contract-release-ledger.md`
+  **reference_log_4**: `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  **reference_log_5**: `docs/logs/_template-log-phase-drills-evidence.md`
+**issue_keyword**: `records`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/7`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-12`
+**updated**: `2026-04-12`
+
+---
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-7E` opens as the bounded follow-up after `S0F-7D` for four coupled chronology problems that `7D` exposed but did not yet fix: repeated supplement rounds on one parent source, artifact-lifecycle time versus historical-effective time, historical-backfill contract releases, and reader-safe chronology views that do not require family renumbering.
+- This lane exists because `7D` proved parent-ledger-first supplement admission, but later review now needs a stricter second layer: each supplement round must stay separately identifiable, each artifact class must expose its own lifecycle timestamps, and historical backfill must not force renumbering or rewrite of already-admitted family releases.
+
+**Default choices (phase defaults / v1)**:
+
+- Treat supplement sequence identity as append-only within one parent source series; do not reuse one unnumbered supplement file for multiple later evidence rounds.
+- Separate artifact-lifecycle timestamps from historical-effective timestamps; do not overload one `created` or `reviewed` field to mean both repository admission time and real historical rule time.
+- Treat contract release ids as append-only registry ids, not as guaranteed historical-first ordering.
+- Prefer explicit `historical-backfill` release handling plus lineage write-back over any attempt to renumber already-admitted family releases.
+- Keep this lane focused on chronology contract and field rules first; do not widen immediately into global view automation until the timestamp and backfill model is fixed.
+
+## Problem Statement
+
+- `S0F-7D` now allows multiple rounds of later evidence admission, but the current supplement naming shape still risks mixing unrelated rounds into one file when the same parent source needs repeated supplementation.
+- The current ledger and contract shapes also blur at least two distinct time meanings:
+  - when a file or review artifact was created, reviewed, accepted, or written back in the repo
+  - when the governed rule or historical state actually first became effective or stopped being effective
+- Without a stricter model, later historical archaeology such as a pre-`LABS-0001` packet will force one false choice:
+  - either renumber existing family releases
+  - or lose the earlier history because the current numbering system cannot represent backfilled chronology safely
+- The repo therefore needs one bounded lane that answers four questions before more backfill work continues broadly:
+  - how repeated supplement rounds on one parent source are named and sequenced
+  - which minimum time fields belong on ledgers, supplement ledgers, and contract releases
+  - how one historical-backfill release may be admitted without renumbering later already-admitted family releases
+  - how future reader views should distinguish registry order, recorded order, and effective historical order
+
+## Exported Sections / Outlet Ownership
+
+- This slice starts as one `contract-template + support-only ledger model + log-retained core` chronology-design lane.
+- The expected landing is one fixed supplement-sequencing rule, one minimum timestamp-field set by artifact type, one historical-backfill release rule, and one explicit chronology-reading rule for future views.
+
+**Outlet ownership**:
+
+- `contract`: expected landing surface for contract-template chronology field rules once the lane is ready to write them
+- `runbook`: no-op by default; operator procedure should wait until the chronology rules are stabilized
+- `view`: no-op by default; the lane should first fix chronology semantics before emitting a reader-facing history view contract
+- `index/front-door`: no-op by default
+- `disposition/placement`: support-only ledger and supplement-ledger templates are the expected mutable landing surfaces for sequence and time-field rules
+- `log-retained core`: expected landing surface for the lane boundary, chronology decisions, field rules, and evidence
+
+## Definitions (optional)
+
+- `supplement series id`: the stable unchanging family id for repeated supplement rounds on one parent source, for example `ledger-SUP-S0A-2A`.
+- `supplement sequence`: the append-only round number inside one supplement series, for example `001`, `002`, or `003`.
+- `artifact-lifecycle time`: repository-side timestamps such as file creation, review, acceptance, and write-back completion.
+- `historical-effective time`: the real-world or source-historical time when a rule or contract state first became effective or ceased to apply.
+- `historical-backfill release`: a later-recorded contract release that documents an earlier historical state without renumbering already-admitted later family releases.
+- `registry order`: append-only contract-release numbering order inside one family.
+- `recorded order`: the order in which records were actually created or admitted in the repo.
+- `effective order`: the order in which rule states became historically effective.
+
+## Constraints
+
+- Do not renumber already-admitted family releases only because earlier history is discovered later.
+- Do not let one supplement file accumulate multiple unrelated evidence rounds once separate review questions or write-back outcomes exist.
+- Do not treat one timestamp field as sufficient for both repo-admission chronology and historical-effective chronology.
+- Do not push chronology complexity into future views before the source records expose stable sequence and time semantics.
+- Do not require every old source file to become a first-class contract release; evidence-only or support-only placement remains valid when direct rule ownership is not strong enough.
+
+## Scope
+
+- `P0`: open `S0F-7E`, fix the chronology problem statement after `7D`, and state why supplement sequencing and backfill chronology require their own bounded lane
+- `P1`: define supplement-series naming, append-only sequence numbering, and minimum lifecycle fields for parent ledgers and supplement ledgers
+- `P2`: define the minimum chronology fields for contracts, including registry order, recorded order, and historical-effective order
+- `P3`: define the historical-backfill release rule, including how later-discovered earlier states enter a family without renumbering existing releases
+- `P4`: land the first sequence-bearing supplement samples and parent-ledger write-back sample on `S0A-2A`
+- `P5`: define one current-release merge sample where earlier accepted history is carried as `history-backfilled` clauses inside `LABS-0002` together with the minimum contract chronology fields
+
+## Success Criteria (DoD)
+
+- The repo has one explicit rule for repeated supplement rounds named as sequence-bearing files rather than as one unbounded supplement bucket.
+- The repo has one minimum field set that distinguishes artifact-lifecycle time from historical-effective time across ledgers, supplement ledgers, and contracts.
+- The repo has one explicit historical-backfill release rule that preserves existing family numbering.
+- The repo has one explicit downstream reading rule stating how future views should sort registry order, recorded order, and effective order independently.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - `P0-P3` have fixed supplement sequencing, minimum chronology fields, and the historical-backfill rule;
+  - `P4-P5` have either fixed the minimum current sample model for supplement sequencing plus current-release historical merge, or explicitly deferred the remaining view-order question into a narrower later follow-up.
+
+## P0 (Lane boundary | v1)
+
+### P0-C1-S1 (Chronology follow-up lane opened after supplement-ledger admission | v1)
+
+- `S0F-7E` is now the bounded follow-up after `7D` for supplement sequencing, time-field separation, and historical-backfill chronology.
+- Under this rule, `7D` remains the admission lane, while `7E` owns the next chronology-safe expansion of that model.
+
+### P0-C1-S2 (Append-only family numbering preserved by default | v1)
+
+- Already-admitted contract family release ids should remain append-only registry ids.
+- Under this rule, later-discovered earlier history must not automatically force renumbering of `0001`, `0002`, `0003`, or later family releases.
+
+### P0-C1-S3 (Three chronology layers distinguished up front | v1)
+
+- The repo should now distinguish:
+  - artifact-lifecycle chronology
+  - recorded chronology
+  - historical-effective chronology
+- Under this rule, one later field design or view model must not collapse these into one ambiguous ordering surface.
+
+## P1 (Supplement sequence and artifact-lifecycle fields | v1)
+
+### P1-C1-S1 (Supplement series id and append-only sequence naming fixed | v1)
+
+- Repeated supplement rounds attached to one parent source must now use one stable supplement series plus one append-only sequence-bearing file name.
+- Under this rule:
+  - the stable series id is `ledger-SUP-<source-id>`
+  - the on-disk file id is `ledger-SUP-<source-id>-<sequence>-<source-summary>.md`
+  - the `<sequence>` must use three-digit append-only numbering such as `001`, `002`, or `003`
+  - later rounds may not reuse or rename earlier sequence numbers once one supplement file has been admitted into repo history
+
+### P1-C1-S2 (Minimum lifecycle fields for parent ledgers and supplement ledgers fixed | v1)
+
+- Parent ledgers and supplement ledgers must now expose minimum artifact-lifecycle timestamps directly in their headers.
+- Under this rule:
+  - parent ledgers must carry `created_at`, `reviewed_at`, and `accepted_at`
+  - supplement ledgers must carry `supplement_series_id`, `supplement_sequence`, `created_at`, `reviewed_at`, `accepted_at`, `writeback_started_at`, and `writeback_completed_at`
+  - these fields record repository-side artifact lifecycle only and do not stand in for historical-effective rule time
+  - historical-effective timing remains reserved for later contract chronology fields under `P2`
+
+## P2 (Contract chronology fields | v1)
+
+### P2-C1-S1 (Minimum contract chronology fields fixed | v1)
+
+- Contracts must now expose one minimum chronology field set that keeps append-only registry order distinct from recorded and historical-effective time.
+- Under this rule:
+  - `contract_release` remains the append-only registry order inside one family
+  - `recorded_at` records when the release entered the repo as one defended contract record
+  - `reviewed_at` records when the release reached its current defended review state
+  - `effective_from` and `effective_until` record the best currently known historical-effective range for the release state
+  - these chronology fields may use `unknown`, `pending`, or `ongoing` where the repo does not yet have a stronger time reconstruction
+
+### P2-C1-S2 (Statement-table chronology range fields fixed | v1)
+
+- Contract statement tables and statement-evolution tables must now distinguish clause-state ranges from change-event times when time-bound reading matters.
+- Under this rule:
+  - the `Contract Statement Table` should add `first effective at`, `last changed at`, `effective from`, and `effective until`
+  - the `Statement Evolution Table` should add `effective at` and `recorded at`
+  - `first effective release` and `last changed release` stay as release ids, while the new time columns carry best-known chronology separate from registry numbering
+  - time-bound clause reading may therefore represent later-recorded earlier states without forcing release renumbering
+
+## P3 (Historical-backfill release rule | v1)
+
+### P3-C1-S1 (`historical-backfill` release action and no-renumber rule fixed | v1)
+
+- A later-recorded earlier historical state must now enter one family through a new append-only release record rather than by renumbering already-admitted releases.
+- Under this rule:
+  - `historical-backfill` is now one explicit `release_action` value
+  - the backfilled release receives the next available append-only `contract_release` id in that family
+  - `effective_from` may still be earlier than older registry releases such as `0001` or `0002`
+  - already-admitted later family releases must keep their current ids even when the backfilled state is historically earlier
+
+### P3-C1-S2 (Minimum lineage updates for later-recorded earlier states fixed | v1)
+
+- Historical-backfill releases must now update a minimum lineage set so readers can traverse the earlier state without forcing immediate full-family rewrites.
+- Under this rule:
+  - the backfilled release must name at least one nearest later relationship through `superseded_by`, `absorbed_into`, `split_into`, or `retired_by` unless it remains the current effective reader
+  - the nearest later affected release should eventually add the reciprocal back-link through `supersedes`, `absorbed_from`, `split_from`, or `retires`
+  - only directly affected later clause metadata or evolution rows should be rewritten; family renumbering remains forbidden
+  - this minimum lineage update is sufficient to admit the earlier state even when broader family cleanup must happen asynchronously later
+
+## Numbering
+
+- `S<n>`: Step.
+- `C<n>`: Cycle.
+
+**Commit / PR naming**:
+
+- `S0F-7E/P<phase>-C<cycle>-S<steps>: <summary>`, where `<steps>` can be a single step (`1`, meaning `...-S1`) or multiple consecutive steps grouped within the same phase / cycle.
+
+**Branch convention**:
+
+- `S0F-7E` work should continue on the top-level `S0F-docs-management-v6` branch unless the lane later opens one narrower bounded follow-up that warrants its own child branch.
+
+**Commit discipline (recommended)**:
+
+- Keep sequence-model, time-field, historical-backfill, and chronology-view commits separated when practical so future archaeology can read which chronology rule changed at which step.
+
+## Plan (draft)
+
+### P1 (Supplement sequence and artifact-lifecycle fields)
+
+- `P1-C1-S1`: define supplement series id plus append-only sequence naming
+- `P1-C1-S2`: define minimum lifecycle fields for parent ledgers and supplement ledgers
+
+### P2 (Contract chronology fields)
+
+- `P2-C1-S1`: define minimum contract chronology fields for registry order, recorded order, and historical-effective order
+- `P2-C1-S2`: define how the contract statement tables should carry chronology range fields when time-bound rule reading matters
+
+### P3 (Historical-backfill release rule)
+
+- `P3-C1-S1`: define `historical-backfill` release action and the no-renumber rule
+- `P3-C1-S2`: define minimum lineage updates when a later-recorded earlier state is admitted into an existing family
+
+### P4 (Sequence-bearing supplement samples)
+
+- `P4-C1-S1`: land the first sequence-bearing `S0A-2A` supplement samples by rehoming the existing runbook SUP as `001` and opening a new labs-focused `002` round
+- `P4-C1-S2`: write back the accepted `002` labs SUP judgment onto parent row `S0A-2A-R03` while still deferring any `DOC-WORKFLOW-LABS` historical-backfill release opening
+
+### P5 (Current-release historical merge sample)
+
+- `P5-C1-S1`: define statement-table and statement-evolution ordering so `history-backfilled` clauses appear ahead of carried-forward, amended, and introduced rows inside one later current release
+- `P5-C1-S2`: widen `DOC-WORKFLOW-LABS-0002` into one local chronology sample by adding contract chronology fields plus the accepted `S0A-2A-R03` labs packet as `history-backfilled` clauses
+
+### P6 (UTC-second timestamps and time-audit fields)
+
+- `P6-C1-S1`: define canonical UTC second timestamps for artifact-lifecycle and recorded chronology fields, while allowing evidence-bound date precision for historical-effective time
+- `P6-C1-S2`: add parent-row and supplement-evidence time-audit surfaces so issue rows and SUP items can record source observed time, source recorded time, effective range, and defended precision
+
+## Execution Checklist (unchecked)
+
+### P0 (Lane boundary)
+
+- [x] `P0-C1-S1`: open `S0F-7E` as the chronology follow-up after `7D`
+- [x] `P0-C1-S2`: preserve append-only family numbering by default
+- [x] `P0-C1-S3`: distinguish artifact-lifecycle, recorded, and historical-effective chronology up front
+
+### P1 (Supplement sequence and artifact-lifecycle fields)
+
+- [x] `P1-C1-S1`: define supplement series id plus append-only sequence naming
+- [x] `P1-C1-S2`: define minimum lifecycle fields for parent ledgers and supplement ledgers
+
+### P2 (Contract chronology fields)
+
+- [x] `P2-C1-S1`: define minimum contract chronology fields for registry order, recorded order, and historical-effective order
+- [x] `P2-C1-S2`: define statement-table chronology range fields when time-bound reading matters
+
+### P3 (Historical-backfill release rule)
+
+- [x] `P3-C1-S1`: define `historical-backfill` release action and no-renumber handling
+- [x] `P3-C1-S2`: define minimum lineage updates for later-recorded earlier states
+
+### P4 (Sequence-bearing supplement samples)
+
+- [x] `P4-C1-S1`: land the first sequence-bearing `S0A-2A` supplement samples
+- [x] `P4-C1-S2`: write back the accepted `002` labs SUP judgment onto parent row `S0A-2A-R03`
+
+### P5 (Current-release historical merge sample)
+
+- [x] `P5-C1-S1`: define `history-backfilled` clause ordering inside one later current release
+- [x] `P5-C1-S2`: widen `DOC-WORKFLOW-LABS-0002` into one local chronology sample with `S0A-2A-R03` history-backfilled clauses and contract time fields
+
+### P6 (UTC-second timestamps and time-audit fields)
+
+- [x] `P6-C1-S1`: define canonical UTC-second timestamps and legacy precision handling
+- [x] `P6-C1-S2`: add time-audit surfaces for parent-ledger rows and supplement-evidence items
+
+## Current Status
+
+- `S0F-7E` is now opened as the chronology follow-up after `S0F-7D`.
+- The lane boundary is now fixed: supplement sequencing, time-field separation, historical-backfill releases, and chronology-safe reader ordering should no longer remain implicit inside ad hoc contract or supplement edits.
+- `P1-C1-S1` is now complete: repeated supplement rounds now have one append-only sequence-bearing naming model under one stable supplement series id.
+- `P1-C1-S2` is now complete: parent ledgers and supplement ledgers now expose distinct minimum artifact-lifecycle fields without overloading them as historical-effective rule timestamps.
+- `P2-C1-S1` is now complete: contracts now separate append-only registry order from recorded and historical-effective time through one minimum chronology field set.
+- `P2-C1-S2` is now complete: the contract template now distinguishes clause-state ranges from change-event times, and `DOC-WORKFLOW-RUNBOOK-0001` now demonstrates the new statement-table chronology columns on one live draft.
+- `P3-C1-S1` is now complete: later-recorded earlier states may now enter one family through explicit `historical-backfill` release action without renumbering already-admitted releases.
+- `P3-C1-S2` is now complete: the repo now has one minimum lineage-update rule for later-recorded earlier states, so asynchronous backfill can proceed without forcing whole-family rewrites first.
+- `P4-C1-S1` is now complete: the original runbook SUP round now reads as explicit `001`, and the repo now has one new `002` labs SUP round under the same `ledger-SUP-S0A-2A` series before any parent-row write-back starts.
+- `P4-C1-S2` is now complete: parent row `S0A-2A-R03` no longer stays at issue-only `bounded-background`, and the accepted `002` labs SUP write-back now records one explicit earlier-labs historical-review state under `DOC-WORKFLOW-LABS` while still deferring any actual historical-backfill release opening.
+- `P5-C1-S1` is now complete: the contract template now defines `history-backfilled` as the first clause-order bucket when one later current release carries earlier-discovered history alongside carried-forward, amended, and introduced state.
+- `P5-C1-S2` is now complete: `DOC-WORKFLOW-LABS-0002` now acts as one local chronology sample that carries accepted `S0A-2A-R03` labs history through `history-backfilled` clauses and explicit contract chronology fields without changing the release id.
+- `P6-C1-S1` is now complete: the repo now treats UTC second timestamps as the canonical shape for new artifact-lifecycle and recorded chronology fields, while still allowing legacy day-only values and evidence-bound date precision where stronger timestamps are not defended.
+- `P6-C1-S2` is now complete: the support-only ledger and SUP models now expose explicit time-audit surfaces for parent rows and evidence items, so source observed time, source recorded time, effective range, and precision no longer have to be hidden in prose.
+- The next step is to review whether these UTC-second and time-audit rules are sufficient, or whether the repo also needs one explicit optional local-time mirror convention in frontmatter.
+
+## Evidence (reserved)
+
+### P0-C1-S1S2S3 (Chronology follow-up lane scaffolded | 2026-04-12)
+
+- artifacts:
+  - `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should gain one new bounded lane after `S0F-7D` for supplement sequencing, time-field separation, and historical-backfill chronology
+  - the lane should preserve append-only family numbering while reserving a later rule for earlier historical states discovered after current releases already exist
+  - the lane should give the next labs-oriented supplement round one explicit home before any template or contract rewrite starts
+- observed:
+  - `S0F-7E` now exists as the next chronology-focused follow-up lane after `S0F-7D`
+  - the lane now fixes append-only family numbering and separated chronology layers as its opening boundary
+
+### P1-C1-S1S2 (Supplement sequencing and ledger lifecycle fields fixed | 2026-04-12)
+
+- headSha: `3dce87b5b`
+- artifacts:
+  - `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
+  - `docs/logs/_template-support-only-contract-release-ledger.md`
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - repeated supplement rounds should gain one stable series id plus append-only sequence numbering so future `001`, `002`, and `003` rounds do not collapse into one file
+  - parent ledger and supplement-ledger templates should expose minimum artifact-lifecycle timestamps without claiming to describe historical-effective rule time
+  - the lane should record these sequence and lifecycle rules explicitly before the next labs-oriented supplement round is opened
+- observed:
+  - supplement-ledger naming now distinguishes `supplement_series_id`, `supplement_sequence`, and one sequence-bearing on-disk file id
+  - the parent ledger template now exposes `created_at`, `reviewed_at`, and `accepted_at` as the minimum artifact-lifecycle fields
+  - the supplement-ledger template now exposes `created_at`, `reviewed_at`, `accepted_at`, `writeback_started_at`, and `writeback_completed_at` in addition to stable series and sequence fields
+
+### P2-C1-S1S2 (Contract chronology fields and statement-table time ranges fixed | 2026-04-12)
+
+- headSha: `4a472d92c`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/governance/contracts/workflow/runbook/DOC-WORKFLOW-RUNBOOK-0001-projection-operator-rebuild-replay-and-failure-recovery.md`
+  - `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - contracts should gain one minimum chronology field set that separates registry order from recorded and historical-effective time
+  - statement tables should gain chronology range fields without overloading release ids to act as time proxies
+  - the lane should prove the new contract chronology columns on one live draft before later historical-backfill work continues
+- observed:
+  - the contract template now exposes `recorded_at`, `reviewed_at`, `effective_from`, and `effective_until` as the minimum contract chronology fields
+  - the contract template now distinguishes clause-state range fields from change-event time fields across the two optional contract tables
+  - `DOC-WORKFLOW-RUNBOOK-0001` now demonstrates the new statement-table chronology columns while keeping unknown historical timing explicit rather than guessed
+
+### P3-C1-S1S2 (Historical-backfill release action and minimum lineage updates fixed | 2026-04-12)
+
+- headSha: `1f20d4479`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should gain one explicit `historical-backfill` release action so later-recorded earlier states can enter a family without renumbering existing releases
+  - the repo should define the minimum lineage updates required when one earlier historical state is admitted after newer family releases already exist
+  - asynchronous chronology cleanup should become legal through bounded reciprocal lineage updates rather than through mandatory whole-family rewrites
+- observed:
+  - the contract template now includes `historical-backfill` as one explicit release action and states that append-only family numbering must remain unchanged
+  - the template now fixes the minimum lineage update rule between one backfilled earlier state and its nearest later affected release
+  - `S0F-7E` now records that asynchronous backfill may proceed through bounded lineage updates before any broader family cleanup is attempted
+
+### P4-C1-S1 (First sequence-bearing `S0A-2A` supplement samples landed | 2026-04-12)
+
+- headSha: `c8f0e4486`
+- artifacts:
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape.md`
+  - `docs/governance/contracts/workflow/runbook/DOC-WORKFLOW-RUNBOOK-0001-projection-operator-rebuild-replay-and-failure-recovery.md`
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the first real `S0A-2A` runbook SUP round should stop using the unsuffixed legacy filename and read as one explicit `001` sequence-bearing sample under `ledger-SUP-S0A-2A`
+  - the repo should gain one new `002` labs SUP round sourced from `labs-004` and `labs-006`, attached only to `S0A-2A-R03`, without prematurely rewriting the parent ledger or opening `DOC-WORKFLOW-LABS`
+  - the naming template should no longer imply that a supplement-round filename summary must duplicate the parent-ledger summary when a narrower round-specific sample name is clearer
+- observed:
+  - the first runbook SUP round now lives at `ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md` with explicit series, sequence, and lifecycle fields
+  - the repo now has a new `ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape.md` file that admits `labs-004` and `labs-006` as defended evidence against `S0A-2A-R03`
+  - the template and dependent references now read the filename summary as supplement-round-specific while preserving stable parent attachment through `supplement_series_id` and `parent_ledger_id`
+
+### P4-C1-S2 (Accepted `002` labs SUP judgment written back onto `S0A-2A-R03` | 2026-04-12)
+
+- headSha: `4c4240e55`
+- artifacts:
+  - `docs/logs/support-only/ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape.md`
+  - `docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md`
+  - `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the accepted `002` labs SUP round should update the parent ledger so `S0A-2A-R03` stops reading as issue-only `bounded-background`
+  - the parent row should now point at the existing `DOC-WORKFLOW-LABS` family through one explicit earlier-history review state without prematurely opening a historical-backfill release
+  - the `002` SUP ledger should now read as a completed supplement round whose lifecycle closed with parent-ledger write-back rather than with contract mutation
+- observed:
+  - `S0A-2A-R03` now reads as one explicit `DOC-WORKFLOW-LABS` historical-review state with `historical-backfill` reserved as the later release action if a dedicated earlier-history packet is opened
+  - the parent ledger now keeps logs and ADR as the remaining deferred slices while separating the labs layer from pure background treatment
+  - the `002` SUP ledger now records completed review, acceptance, and write-back lifecycle timestamps while still deferring contract-level action
+
+### P5-C1-S1S2 (Current `LABS-0002` historical-merge sample fixed | 2026-04-12)
+
+- headSha: `0a9b344b4`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0002-labs-snapshot-evidence-package-governance.md`
+  - `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the contract template should define how one later current release may host earlier-discovered history through `history-backfilled` clause rows without changing the release id immediately
+  - `LABS-0002` should gain the minimum contract chronology fields and the newer time-bearing statement-table and evolution-table columns that earlier template work already introduced
+  - the local sample should show `S0A-2A-R03` merging into the current `LABS-0002` reader by placing `history-backfilled` rows ahead of carried-forward, amended, and introduced rows
+- observed:
+  - the contract template now defines `history-backfilled` as one statement-level action and gives it first ordering priority inside the current statement table when the first effective release is the same
+  - `DOC-WORKFLOW-LABS-0002` now carries `recorded_at`, `reviewed_at`, `effective_from`, and `effective_until` plus the expanded chronology-bearing statement and evolution tables
+  - the local `LABS-0002` sample now admits the accepted `S0A-2A-R03` labs packet through two `history-backfilled` clauses without renumbering the release or opening a separate backfill record yet
+
+### P6-C1-S1S2 (UTC-second timestamp rule and time-audit surfaces fixed | 2026-04-12)
+
+- headSha: `0346adfb3`
+
+- artifacts:
+  - `docs/logs/_template-support-only-contract-release-ledger.md`
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape.md`
+  - `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - new artifact-lifecycle and recorded chronology writes should prefer one canonical UTC-second timestamp shape instead of bare local time
+  - historical-effective fields should keep only the precision the source actually proves rather than fabricating seconds everywhere
+  - parent ledgers and supplement ledgers should gain explicit time-audit surfaces so row-level and evidence-level chronology can be recorded without overloading the main routing tables
+- observed:
+  - the ledger, SUP, and contract templates now all document canonical UTC-second timestamps together with legacy day-only compatibility and evidence-bound historical precision
+  - the `S0A-2A` parent ledger now demonstrates one row-level chronology-audit surface, and the `002` SUP file now demonstrates one evidence-level time-audit surface for the accepted labs packet
+  - the current `002` time audit now shows one defended day-level date from `labs-004` and explicitly leaves `labs-006` as `unknown` until narrower chronology evidence is reconstructed

--- a/docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md
+++ b/docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md
@@ -1,0 +1,62 @@
+# ledger-S0A-2A-tools-workflow-log-lab-runbook-adr
+
+```yaml
+support_only_contract_release_ledger:
+  ledger_id: ledger-S0A-2A-tools-workflow-log-lab-runbook-adr
+  ledger_kind: support-only-contract-release-ledger
+  status: draft
+  owner_lane: S0F-7C
+  created_at: 2026-04-11
+  reviewed_at: 2026-04-12
+  accepted_at: pending
+  source_id: S0A-2A
+  source_ref: GitHub issue S0A-2A (#24) (issue-only source; no local log exists in workspace)
+  source_scope: mixed issue-only source covering the workflow refinement pipeline, the logs layer, the labs layer, the runbook layer, and the ADR layer
+  target_reading_goal: show whether the earlier workflow-layer S0A-2A packet now needs explicit selective ledger backfill because the source appears broader than the single current parent contract that was extracted from it
+```
+
+## Decision Frame
+
+- This ledger is a selective-backfill scaffold, not yet a final routing verdict.
+- The current draft default is:
+  - keep the broad workflow pipeline boundary aligned to `DOC-WORKFLOW-0001`
+  - keep the logs/labs/runbook/adr operational layers visible as bounded background rather than rerouting them immediately from this source
+  - defer any actual child promotion until stronger direct evidence is found in later archaeology rather than treating this broad issue as sufficient child ownership by itself
+- The purpose of this scaffold is to make `S0A-2A` reviewable under the newer selective-ledger rule rather than leaving the old single-contract extraction as an unquestioned endpoint.
+
+## Routing And Consumption Table
+
+| row id | source slice | meaning owned here | target family | target release action | contract lineage impact | retained-only action | resolution status | resolved by contract id | consumed scope | resolution notes | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-2A-R01` | `Workflow refinement pipeline` in issue `S0A-2A (#24)` | docs refine one-way from log to lab to runbook to ADR, with links pointing back to source evidence rather than forward guesses | `DOC-WORKFLOW` | `existing-family-review` | `none-source-only` | `keep-in-issue` | `applied` | `DOC-WORKFLOW-0001` | `full` | consumed by the existing broad workflow parent contract, which remains the primary owner for this issue-level packet | This is the slice most clearly represented by the current workflow parent contract. |
+| `S0A-2A-R02` | `Logs layer` in issue `S0A-2A (#24)` | logs convert raw material into structured plans with status, what, how, and links | `DOC-WORKFLOW-LOGS` candidate | `bounded-background` | `none-source-only` | `defer` | `deferred` | `none` | `none` | keep this slice as bounded background only; later child promotion requires stronger direct evidence than this broad issue currently provides | This slice now matters because a logs child exists, but the current issue is not treated as sufficient direct owner for that child body. |
+| `S0A-2A-R03` | `Labs layer` in issue `S0A-2A (#24)` | labs are the most granular executable and backfill layer for proof and validation | `DOC-WORKFLOW-LABS` | `historical-backfill` | `none-source-only` | `keep-in-issue` | `deferred` | `none` | `none` | accepted `002` labs SUP evidence now records one explicit historical-review state for earlier labs material under the existing `DOC-WORKFLOW-LABS` family, while actual historical-backfill release opening remains deferred until one dedicated packet is drafted | This issue now anchors one earlier labs-specific evidence packet without claiming direct ownership of the later snapshot-governance releases already present in the labs family. |
+| `S0A-2A-R04` | `Runbook layer` in issue `S0A-2A (#24)` | runbooks distill invariants from labs into operator-facing troubleshooting and recovery guidance | `DOC-WORKFLOW-RUNBOOK` | `new-family` | `none-source-only` | `keep-in-issue` | `applied` | `DOC-WORKFLOW-RUNBOOK-0001` | `full` | consumed by the first dedicated runbook child contract, which now isolates projection operator rebuild, replay, readiness, observability, and failure-recovery governance from the broader workflow packet | The first runbook child stays narrow to the earliest projection SOP packet and does not reopen logs, labs, or ADR routing. |
+| `S0A-2A-R05` | `ADR layer` in issue `S0A-2A (#24)` | ADRs summarize context, decision, alternatives, and consequences without carrying full execution detail | `DOC-WORKFLOW-ADR` candidate | `bounded-background` | `none-source-only` | `defer` | `deferred` | `none` | `none` | keep this slice as bounded background only until stronger direct evidence is found in later archaeology | This slice also remains child-eligible later, but not from this source alone. |
+
+## Row Id Map
+
+- `S0A-2A-R01`: Workflow refinement pipeline
+- `S0A-2A-R02`: Logs layer
+- `S0A-2A-R03`: Labs layer
+- `S0A-2A-R04`: Runbook layer
+- `S0A-2A-R05`: ADR layer
+
+## New Releases Expected
+
+- `DOC-WORKFLOW-RUNBOOK-0001`
+
+## Deferred Slices
+
+- later direct evidence for logs and ADR child ownership that does not rely on this broad workflow issue alone
+- later dedicated `DOC-WORKFLOW-LABS` historical-backfill packet after the accepted `002` labs SUP write-back
+
+## Row Chronology Audit
+
+| row id | source observed at | source recorded at | source effective from | source effective until | time precision | timezone note | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-2A-R03` | `unknown` | `unknown` | `unknown` | `ongoing` | `unknown` | `not yet reconstructed from the issue-only parent packet` | The parent row now records one defended earlier-labs review state, but the row-level chronology still depends on the more specific SUP evidence packet for any narrower time audit. |
+
+## Reader Notes
+
+- This ledger now confirms that `S0A-2A` remains primarily parent-owned, while the runbook layer is now consumed by one dedicated child contract, the labs layer now sits in explicit historical review under the existing labs family, and the remaining narrower layers stay deferred pending stronger direct evidence.

--- a/docs/logs/support-only/ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md
+++ b/docs/logs/support-only/ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md
@@ -1,0 +1,59 @@
+# ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr
+
+```yaml
+support_only_contract_release_ledger_supplement:
+  supplement_series_id: ledger-SUP-S0A-2A
+  supplement_sequence: 001
+  supplement_id: ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr
+  supplement_kind: support-only-contract-release-ledger-supplement
+  status: completed
+  owner_lane: S0F-7D
+  created_at: 2026-04-12
+  reviewed_at: 2026-04-12
+  accepted_at: 2026-04-12
+  writeback_started_at: 2026-04-12
+  writeback_completed_at: 2026-04-12
+  parent_ledger_id: ledger-S0A-2A-tools-workflow-log-lab-runbook-adr
+  parent_source_id: S0A-2A
+  parent_source_ref: GitHub issue S0A-2A (#24) (issue-only source; no local log exists in workspace)
+  supplement_scope: first runbook-direct-evidence SUP for the S0A-2A runbook layer, using the earliest long-lived projection SOPs to test whether the runbook slice should remain bounded background or move into direct child-promotion review
+  target_reading_goal: show whether later direct runbook evidence is now strong enough to revise the S0A-2A runbook-layer verdict from deferred bounded background toward explicit DOC-WORKFLOW-RUNBOOK child review
+```
+
+## Decision Frame
+
+- This SUP ledger is attached only to parent row `S0A-2A-R04`.
+- When this round opened, the parent-ledger judgment still kept the runbook layer as bounded background because the broad issue-level source was not treated as strong enough direct owner evidence by itself.
+- The review question for this completed round was narrower:
+  - do the earliest long-lived projection SOPs merely support the existing background reading
+  - or do they revise the current verdict enough that the runbook layer should now enter direct child-promotion review
+- This round is prioritized because broader roadmap/log skeleton reorganization is still under review, while earlier workflow-layer contract extraction can keep progressing through defended direct evidence packets.
+
+## Evidence Table
+
+| supplement item id | parent row id | evidence ref | evidence type | attachment ids | verification status | effect on current verdict | proposed parent-ledger action | contract impact | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-2A-R04-SUP-01` | `S0A-2A-R04` | `legacy/from_structured_docs/from-runbook/run-001-search-projection.md` | `md` | `none` | `verified` | `revises-existing` | `rewrite-parent-row` | `open-new-release` | This SOP shows that once the search projection path had succeeded, the next durable operator question became whether projection failure, replay, rebuild, readiness, and runtime guardrails could be operated safely rather than only experimented with in labs. The file carries long-lived operator guidance across startup, migration, rebuild, metrics, failure handling, replay, and regression checks, so the runbook layer is no longer only a broad issue-level background mention. |
+| `S0A-2A-R04-SUP-02` | `S0A-2A-R04` | `legacy/from_structured_docs/from-runbook/run-003-chronicle-projection.md` | `md` | `none` | `verified` | `revises-existing` | `rewrite-parent-row` | `open-new-release` | This SOP shows the same long-lived operator extraction pattern for the chronicle projection path: once the projection path existed, the durable need moved to rebuildability, daemon runtime checks, replay, observability, and failure handling, with explicit operator steps and acceptance language. Together with `run-001`, it demonstrates that runbooks were already being extracted from experimental labs content into reusable operator-facing workflow guidance. |
+
+## Parent-Ledger Rows To Update
+
+- `S0A-2A-R04`: revise the runbook-layer row from `bounded-background` only into one explicit direct-evidence review surface, because the earliest projection SOPs now prove durable operator-facing runbook extraction beyond the broad issue summary alone.
+
+## Contract Changes Deferred Until Parent Write-Back
+
+- `DOC-WORKFLOW-RUNBOOK` candidate: if the parent-ledger rewrite is accepted, the runbook layer should move from deferred background toward explicit child-promotion review, with a later release-opening decision based on the defended runbook packet rather than on issue-level wording alone.
+
+## Preliminary Reading
+
+- The two runbooks do not overturn the broad workflow-pipeline reading already owned by `DOC-WORKFLOW-0001`.
+- They do revise the current runbook-layer verdict materially enough that `S0A-2A-R04` should no longer read as issue-only bounded background by default.
+- The resulting recommendation for this round was therefore:
+  - keep the broad workflow parent contract unchanged for now
+  - rewrite the parent runbook-layer row to acknowledge direct runbook evidence
+  - then review whether a `DOC-WORKFLOW-RUNBOOK` child-opening packet should follow
+
+## Reader Notes
+
+- These two legacy runbooks are treated here as direct evidence because they already convert projection success, failure-management labs, and runtime-verification learning into durable operator SOPs.
+- This `001` SUP round intentionally did not force immediate child-contract creation; it first asked the parent ledger to stop treating the runbook layer as background-only before `DOC-WORKFLOW-RUNBOOK-0001` was later opened.

--- a/docs/logs/support-only/ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape.md
+++ b/docs/logs/support-only/ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape.md
@@ -1,0 +1,67 @@
+# ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape
+
+```yaml
+support_only_contract_release_ledger_supplement:
+  supplement_series_id: ledger-SUP-S0A-2A
+  supplement_sequence: 002
+  supplement_id: ledger-SUP-S0A-2A-002-labs-early-failure-management-and-pre-drills-shape
+  supplement_kind: support-only-contract-release-ledger-supplement
+  status: completed
+  owner_lane: S0F-7E
+  created_at: 2026-04-12
+  reviewed_at: 2026-04-12
+  accepted_at: 2026-04-12
+  writeback_started_at: 2026-04-12
+  writeback_completed_at: 2026-04-12
+  parent_ledger_id: ledger-S0A-2A-tools-workflow-log-lab-runbook-adr
+  parent_source_id: S0A-2A
+  parent_source_ref: GitHub issue S0A-2A (#24) (issue-only source; no local log exists in workspace)
+  supplement_scope: second direct-evidence SUP round for the S0A-2A labs layer, using the early failure-management experiments and search projection closure labs to test whether the labs slice should remain deferred background or move into explicit DOC-WORKFLOW-LABS historical review
+  target_reading_goal: show whether the earlier labs evidence now sharpens S0A-2A-R03 enough to justify a parent-ledger rewrite before any DOC-WORKFLOW-LABS historical-backfill release is considered
+```
+
+## Decision Frame
+
+- This SUP ledger is attached only to parent row `S0A-2A-R03`.
+- When this round opened, the parent-ledger judgment still kept the labs layer as bounded background because the broad issue-level source was not treated as strong enough direct owner evidence by itself.
+- The review question for this completed round was narrower:
+  - do these earlier labs only support the existing background reading
+  - or do they revise the current verdict enough that the labs layer should now enter explicit historical review rather than staying deferred by default
+- This round is sequenced after the `001` runbook round because the repo now needs one concrete sample showing that repeated SUP packets under the same parent can separate runbook extraction from earlier labs archaeology.
+
+## Evidence Table
+
+| supplement item id | parent row id | evidence ref | evidence type | attachment ids | verification status | effect on current verdict | proposed parent-ledger action | contract impact | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-2A-R03-SUP-01` | `S0A-2A-R03` | `legacy/from_structured_docs/from-labs/labs-004-worker-failure-management-v1-v4.md` | `md` | `none` | `verified` | `revises-existing` | `rewrite-parent-row` | `defer-contract-change` | This labs packet is explicitly framed as a hand-controlled experiment set that should be run before later runbook codification. It captures stuck recovery, retry convergence, replay, failed-state auditability, and daemon runtime engineering as executable lab work rather than as broad issue prose, so the labs layer is no longer supported only by the mixed issue summary. |
+| `S0A-2A-R03-SUP-02` | `S0A-2A-R03` | `legacy/from_structured_docs/from-labs/labs-006-search-projection-search-index-to-elastic.md` | `md` | `none` | `verified` | `revises-existing` | `rewrite-parent-row` | `defer-contract-change` | This labs packet closes the search projection loop around `search_index -> elastic`, explicitly reuses earlier labs rounds including `labs-004`, and states that the result should later settle into runbook material. It therefore preserves a distinct earlier labs-shaped layer before the later runbook extraction and strengthens the case for a defended labs-specific write-back on `S0A-2A-R03`. |
+
+## Parent-Ledger Rows To Update
+
+- `S0A-2A-R03`: revise the labs-layer row from `bounded-background` only into one explicit direct-evidence review surface, because the early failure-management and search projection lab packets now show durable experimental ownership beyond the broad issue summary alone.
+
+## Contract Changes Deferred Until Parent Write-Back
+
+- `DOC-WORKFLOW-LABS` candidate: if the parent-ledger rewrite is accepted, the labs layer should move from deferred background toward explicit historical review, with any later `historical-backfill` or other release-opening decision made only after the parent packet is accepted.
+
+## Evidence Time Audit
+
+| supplement item id | source observed at | source recorded at | source effective from | source effective until | time precision | timezone note | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-2A-R03-SUP-01` | `2026-02-03` | `unknown` | `2026-02-03` | `unknown` | `day` | `legacy source currently proves only a local execution date, not a defended offset or second-level timestamp` | `labs-004` explicitly records multiple experiment sections as executed on `2026-02-03`, so the earlier labs packet has at least defended day-level timing even though second-level chronology is still absent. |
+| `S0A-2A-R03-SUP-02` | `unknown` | `unknown` | `unknown` | `unknown` | `unknown` | `legacy source currently exposes no defended execution timestamp in the retained packet` | `labs-006` is clearly earlier labs material, but the retained source still needs narrower time reconstruction before any stronger chronology claim is made. |
+
+## Preliminary Reading
+
+- These two labs do not overturn the broad workflow-pipeline reading already owned by `DOC-WORKFLOW-0001`.
+- They do revise the current labs-layer verdict materially enough that `S0A-2A-R03` should no longer read as issue-only bounded background by default.
+- The resulting recommendation for this round was therefore:
+  - keep the broad workflow parent contract unchanged for now
+  - rewrite the parent labs-layer row to acknowledge direct labs evidence
+  - then review whether one `DOC-WORKFLOW-LABS` historical-backfill or other dedicated child-opening packet should follow
+
+## Reader Notes
+
+- `labs-004` is treated here as direct evidence because it explicitly says the experiments should precede later runbook stabilization rather than being read as already-final SOPs.
+- `labs-006` is treated here as direct evidence because it closes the search projection lab loop while still pointing forward to later runbook codification, which keeps the labs-versus-runbook boundary readable.
+- This `002` SUP round now stops after parent-ledger write-back and does not yet write into `DOC-WORKFLOW-LABS`.


### PR DESCRIPTION
## Metadata

- Requested ID: `S0F-7E`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0f-7e`
- Source log: `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
- Labels: `EVOLUTION, s0/knowledge system, drills`
- Development issue: #461

## Summary

- Add stable sequencing and lifecycle-time fields to supplement chronology.
- Fix historical backfill release ordering so later write-backs can be audited consistently.
- Reuse the evidence template for bounded chronology drills instead of ad hoc timing notes.

## Execution Checklist

- [x] `P0-C1-S1`: open `S0F-7E` as the chronology follow-up after `7D`
- [x] `P0-C1-S2`: preserve append-only family numbering by default
- [x] `P0-C1-S3`: distinguish artifact-lifecycle, recorded, and historical-effective chronology up front
- [x] `P1-C1-S1`: define supplement series id plus append-only sequence naming
- [x] `P1-C1-S2`: define minimum lifecycle fields for parent ledgers and supplement ledgers
- [x] `P2-C1-S1`: define minimum contract chronology fields for registry order, recorded order, and historical-effective order
- [x] `P2-C1-S2`: define statement-table chronology range fields when time-bound reading matters
- [x] `P3-C1-S1`: define `historical-backfill` release action and no-renumber handling
- [x] `P3-C1-S2`: define minimum lineage updates for later-recorded earlier states
- [x] `P4-C1-S1`: land the first sequence-bearing `S0A-2A` supplement samples
- [x] `P4-C1-S2`: write back the accepted `002` labs SUP judgment onto parent row `S0A-2A-R03`
- [x] `P5-C1-S1`: define `history-backfilled` clause ordering inside one later current release
- [x] `P5-C1-S2`: widen `DOC-WORKFLOW-LABS-0002` into one local chronology sample with `S0A-2A-R03` history-backfilled clauses and contract time fields
- [x] `P6-C1-S1`: define canonical UTC-second timestamps and legacy precision handling
- [x] `P6-C1-S2`: add time-audit surfaces for parent-ledger rows and supplement-evidence items

## Links

- Log: `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`

Closes #461
