### PR TITLE
S0F-7F/P0-P2+P4: log and roadmap frontmatter minimum time fields

### DIFF
--- a/docs/governance/contracts/workflow/github/projects/DOC-WORKFLOW-GITHUB-PROJECTS-0001-project-views-support-execution-priority.md
+++ b/docs/governance/contracts/workflow/github/projects/DOC-WORKFLOW-GITHUB-PROJECTS-0001-project-views-support-execution-priority.md
@@ -1,0 +1,97 @@
+# DOC-WORKFLOW-GITHUB-PROJECTS-0001 project views support execution priority
+
+```yaml
+contract_record:
+  contract_family: DOC-WORKFLOW-GITHUB-PROJECTS
+  contract_release: 0001
+  contract_id: DOC-WORKFLOW-GITHUB-PROJECTS-0001
+  record_kind: chronology-first-contract
+  status: draft
+  release_action: initial
+  release_change_summary: Establish the first GitHub-Projects workflow release from S0A-1A by isolating Projects views as the execution-time status-board, lookup, sequencing, and bounded reprioritization surface beside, but not replacing, canonical GitHub Issues hierarchy.
+  summary: Use GitHub Projects views as execution-time support for status-board reading, fast lookup, timeline sequencing, and bounded reprioritization while keeping GitHub Issues as the canonical work-breakdown hierarchy.
+  governance_area: workflow GitHub Projects execution-support governance
+  applies_to: GitHub Projects views, execution-time reprioritization, ad hoc or priority insertion support, and operator reading of current queue state during delivery
+  enforcement_surface: manual
+  violation_semantics: warning
+  recorded_at: 2026-04-11
+  reviewed_at: pending
+  effective_from: unknown
+  effective_until: ongoing
+  introduced_by: GitHub issue S0A-1A (issue-only source; no local log exists in workspace)
+  last_changed_by: docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md
+  source_refs:
+    - GitHub issue S0A-1A (issue-only source; no local log exists in workspace)
+    - docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md
+  cumulative_source_refs:
+    - GitHub issue S0A-1A (issue-only source; no local log exists in workspace)
+    - docs/logs/support-only/ledger-S0A-1A-tools-github-issues-projects-and-tags.md
+    - docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md
+  supporting_evidence_refs:
+    - docs/logs/support-only/ledger-S0A-1A-tools-github-issues-projects-and-tags.md
+    - docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md
+  lineage:
+    supersedes: []
+    superseded_by: []
+    split_from:
+      - DOC-WORKFLOW-GITHUB-ISSUES-0001
+    split_into: []
+    absorbed_from: []
+    absorbed_into: []
+    retires: []
+    retired_by: []
+  notes:
+    - This child contract owns GitHub Projects as execution-support surface only; it does not replace the canonical GitHub Issues hierarchy.
+    - Current supporting evidence now directly shows three common operator readings for this surface: status-board columns, fast table lookup, and timeline sequencing.
+    - The local repo currently has no S0A-1A source log, so this draft stays explicit about issue-only sourcing.
+```
+
+## Contract Statement Table
+
+| statement id | statement label | clause status | change action | source basis | first effective release | first effective at | last changed release | last changed at | effective from | effective until | effective status | statement text | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `DOC-WORKFLOW-GITHUB-PROJECTS-0001-ST-01` | `Status-board execution reading` | `active` | `introduced` | `S0A-1A-R02; S0A-1A-R02-SUP-01` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `unknown` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `unknown` | `unknown` | `ongoing` | `in-force` | GitHub Projects views may be used as one visible execution-status surface with operating states such as `Doing`, `Done`, `Backlog`, and `Blocked`. | Screenshot-backed sharpening now makes this concrete reading explicit inside the first release rather than leaving it as only generic execution support prose. |
+| `DOC-WORKFLOW-GITHUB-PROJECTS-0001-ST-02` | `Fast table lookup reading` | `active` | `introduced` | `S0A-1A-R02; S0A-1A-R02-SUP-02` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `unknown` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `unknown` | `unknown` | `ongoing` | `in-force` | GitHub Projects views may be used as one fast lookup surface for issue identity, progress, linked PR context, and assignee context during delivery. | This keeps the operator-facing discovery function visible as part of the contract rather than burying it in supporting prose only. |
+| `DOC-WORKFLOW-GITHUB-PROJECTS-0001-ST-03` | `Timeline sequencing reading` | `active` | `introduced` | `S0A-1A-R02; S0A-1A-R02-SUP-03` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `unknown` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `unknown` | `unknown` | `ongoing` | `in-force` | GitHub Projects views may be used as one timeline and sequence-awareness surface for order, insertion, and interruption reading across the current work stream. | The screenshot-backed Projects evidence now makes the sequencing view explicit as contract-facing meaning. |
+| `DOC-WORKFLOW-GITHUB-PROJECTS-0001-ST-04` | `Bounded reprioritization support` | `active` | `introduced` | `S0A-1A-R02` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `unknown` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `unknown` | `unknown` | `ongoing` | `in-force` | GitHub Projects views may support bounded reprioritization or ad hoc insertion while work is already in flight. | This clause remains directly owned by the issue packet even though the screenshots mainly sharpen the three concrete view classes. |
+| `DOC-WORKFLOW-GITHUB-PROJECTS-0001-ST-05` | `Issues hierarchy remains canonical` | `active` | `introduced` | `S0A-1A-R01; S0A-1A-R02` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `unknown` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `unknown` | `unknown` | `ongoing` | `in-force` | GitHub Projects remains one execution-support surface only; canonical work-breakdown and hierarchy ownership stays with GitHub Issues. | This keeps the Projects child contract structurally tied to the issue hierarchy boundary rather than drifting into hierarchy ownership. |
+
+## Statement Evolution Table
+
+| change id | release id | change action | input statement ids | output statement ids | effective at | recorded at | reason | source basis | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `DOC-WORKFLOW-GITHUB-PROJECTS-0001-CH-01` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `introduced` | `none` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001-ST-01; DOC-WORKFLOW-GITHUB-PROJECTS-0001-ST-02; DOC-WORKFLOW-GITHUB-PROJECTS-0001-ST-03; DOC-WORKFLOW-GITHUB-PROJECTS-0001-ST-04; DOC-WORKFLOW-GITHUB-PROJECTS-0001-ST-05` | `unknown` | `2026-04-11` | The first Projects child release now records the concrete execution-support meanings that selective backfill and the accepted screenshot supplement made readable without transferring hierarchy ownership away from GitHub Issues. | `S0A-1A-R02; S0A-1A-R02-SUP-01; S0A-1A-R02-SUP-02; S0A-1A-R02-SUP-03` | One initial release row is sufficient here because the current file still acts as the first family release rather than as a later amendment to an earlier release id. |
+
+## Release Change
+
+- This release establishes the first Projects-oriented child family extracted from `S0A-1A`.
+- The release isolates the execution-support surface that had previously remained implicit beside the broader issue packet:
+  - Projects views can be used during execution for status-board reading, table-based lookup, and timeline sequencing
+  - Projects views can also support ad hoc reprioritization and priority insertion
+  - that support surface does not replace the canonical GitHub Issues hierarchy
+- This release intentionally does not absorb issue title grammar or issue tag naming; those remain owned by the narrower sibling issue children.
+
+## Contract Statement
+
+- GitHub Projects views may be used as one operator-facing execution support surface during delivery.
+- That execution support now reads in at least three evidenced common view classes:
+  - one status-board reading for visible work state such as `Doing`, `Done`, `Backlog`, and `Blocked`
+  - one table reading for fast lookup across issue identity, progress, linked PRs, and assignee context
+  - one timeline reading for order, insertion, and sequence awareness across the work stream
+- Projects views may also support bounded reprioritization or ad hoc insertion while work is already in flight.
+- That support surface is secondary to the GitHub Issues hierarchy rather than a replacement for it.
+- Canonical work-breakdown and hierarchy ownership remains with GitHub Issues.
+- Projects views should therefore be read as one operator-facing execution support surface, not as the source of truth for decomposition semantics.
+
+## Current Reading
+
+- Read this release when the question is `how should GitHub Projects be used during execution without replacing the canonical issue hierarchy?`
+- It is especially the current reader when the question is about status-board reading, everyday lookup, or timeline sequencing inside the Projects surface.
+- Read the `S0A-1A` parent ledger or `SUP-001` packet when the question is `how did this Projects contract get sharpened and what evidence anchors currently defend those three view classes?`
+- Read `DOC-WORKFLOW-GITHUB-ISSUES-0001` first only when the reader still needs the broader mechanism-introduction boundary.
+
+## Reader Notes
+
+- This draft exists because the source issue explicitly described Projects usage even though the earlier packet did not emit one dedicated Projects contract.
+- The first accepted `SUP` pilot now sharpens this draft with screenshot-backed evidence for status-board, table, and timeline views, but does not change the primary routing boundary.
+- More detailed Projects operating flow may still need later archaeology from non-screenshot evidence if the repo wants one richer later release.

--- a/docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md
+++ b/docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md
@@ -1,0 +1,700 @@
+# log-S0F-7D (Phase 7D: ledger supplement admission and old-log continuation)
+
+---
+
+**id**: `S0F-7D`
+**kind**: `log`
+**title**: `ledger supplement admission and old-log continuation`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Governance, Ledger, Evidence, Migration, epic/s0, sub/7d`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-7C-old-log-decomposition-application-lane.md`
+  **reference_log_1**: `docs/logs/log-S0F-7C-old-log-decomposition-application-lane.md`
+  **reference_log_2**: `docs/logs/_template-support-only-contract-release-ledger.md`
+  **reference_log_3**: `docs/governance/contracts/_template-contract-record.md`
+  **reference_log_4**: `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+**issue_keyword**: `evidence`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/7`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-11`
+**updated**: `2026-04-11`
+**reviewed**: `2026-04-11`
+
+---
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-7D` opens as the bounded follow-up after `S0F-7C` for supplement-ledger admission and future old-log continuation.
+- This lane exists because `7C` has already proved one first application packet, and later work now needs one stricter continuation rule: mixed later evidence must attach to an existing source-owned ledger before it can influence contract meaning.
+
+**Default choices (phase defaults / v1)**:
+
+- Do not let later code, markdown, screenshots, oral recall, or operator validation material write directly into contracts.
+- Admit later evidence only through one bounded supplement ledger that is anchored to an existing parent source-owned ledger.
+- Prefer current logs or new bounded logs for future extraction work; reopen older sources only when an existing ledger lacks enough evidence to defend or revise one already-known slice.
+- Keep `7D` focused on supplement-ledger admission and continuation discipline first; broader provenance, approval, and organizational authority fields remain out of scope for this first scaffold.
+
+## Problem Statement
+
+- `S0F-7C` proved that one old mixed source can be decomposed into ledgers and child contracts, but it also exposed the next missing control surface: later evidence is now likely to arrive from code, old markdown, screenshots, or verified oral explanation rather than from the original source packet alone.
+- If that later evidence writes directly into contracts, the repo loses the defended `source packet -> ledger -> contract` chain that `7B` and `7C` just established.
+- The repo therefore needs one bounded continuation lane that answers three questions before more old-log work continues broadly:
+  - how supplement evidence is admitted without bypassing the parent source-owned ledger
+  - how one supplement ledger can strengthen, sharpen, or reopen an existing routing verdict without inventing arbitrary new contract meaning
+  - when future old-log continuation should prefer current or new bounded logs instead of repeatedly extending the first `7C` packet
+
+## Exported Sections / Outlet Ownership
+
+- This slice starts as one `contract + support-only ledger + log-retained core` governance-design lane.
+- The default expected landing is one supplement-ledger admission model, one first supplement-ledger template or pilot shape, and one explicit continuation rule for future old-log reopening.
+
+**Outlet ownership**:
+
+- `contract`: no-op by default; this lane should first fix supplement-ledger and continuation rules before emitting any family-owned contract
+- `support-only ledger`: expected landing surface for the supplement-ledger template and later pilot instances
+- `view`: no-op by default; reader projection is not the first missing boundary here
+- `index/front-door`: no-op by default; front-door work should wait until supplement-ledger practice stabilizes
+- `disposition/placement`: no-op by default
+- `log-retained core`: expected landing surface for the lane boundary, admission rules, pilot decisions, and evidence
+
+## Definitions (optional)
+
+- `parent ledger`: the existing source-owned support-only ledger that already records source slices and their routing verdicts.
+- `parent ledger row id`: the stable per-slice identifier inside one parent ledger, used as the anchor for later supplement evidence.
+- `supplement ledger`: a bounded evidence-admission ledger that attaches to one parent ledger and may strengthen, sharpen, or reopen one existing routing verdict.
+- `supplement item id`: the stable per-evidence identifier inside one supplement ledger, scoped beneath one parent-ledger row.
+- `attachment or shot id`: the stable per-asset identifier beneath one supplement item, used for screenshots, exports, transcripts, or similar attached evidence.
+- `admitted supplement evidence`: later evidence that is tied to one existing parent-ledger slice and has passed the required verification rule for this lane.
+- `continuation packet`: a later bounded old-log follow-up that reopens a source only because one explicit ledger gap or supplement-evidence need has been identified.
+
+## Constraints
+
+- Do not bind supplement ledgers directly to contracts as the primary owner; they must attach to one parent source-owned ledger first.
+- Do not allow a supplement ledger to introduce entirely new free-floating slices that never appeared in the parent ledger review surface.
+- Do not reopen old logs mechanically; a continuation packet should require one explicit unresolved ledger need.
+- Do not fold broader provenance, approval, or organizational-attestation modeling into this first lane unless the supplement-ledger pilot proves the smaller boundary insufficient.
+
+## Scope
+
+- `P0`: open `S0F-7D`, fix the supplement-ledger continuation boundary, and state why future old-log continuation moves here rather than staying in `7C`
+- `P1`: define the supplement-ledger model, including its naming, minimum header, table shape, and parent-ledger attachment rule
+- `P2`: pilot the first supplement-ledger application on one real packet, expected first on the `S0A-1A` Projects slice
+- `P3`: define the continuation rule for when future old-log work should use current logs, new bounded logs, or explicit supplement-ledger reopening instead of broad historical replay
+- `P4`: reserve any later provenance or approval-interface expansion only if the supplement-ledger pilot proves the current minimal evidence-admission model too weak
+
+## Success Criteria (DoD)
+
+- The repo has one explicit rule that supplement evidence attaches to a parent ledger before it can influence contracts.
+- The repo has one reusable supplement-ledger shape that can admit code, markdown, or other verified later evidence without bypassing source accountability.
+- The repo has one first real pilot showing how a supplement ledger affects an existing parent-ledger verdict.
+- The repo has one explicit continuation rule that keeps future old-log extraction from repeatedly extending `7C` or re-consuming older logs casually.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - `P0-P3` have fixed the supplement-ledger model, first pilot, and continuation boundary;
+  - any broader provenance or approval expansion has either been explicitly deferred or opened as a separate bounded follow-up rather than left implicit here.
+
+## P0 (Lane boundary | v1)
+
+### P0-C1-S1 (Supplement-ledger continuation lane opened after `7C` | v1)
+
+- `S0F-7D` is now the bounded continuation lane after `7C` for supplement-ledger admission and future old-log reopening.
+- Under this rule, `7C` remains the first defended application packet while `7D` owns future continuation discipline.
+
+### P0-C1-S2 (Parent-ledger-first supplement rule fixed | v1)
+
+- Later evidence must now attach to one existing parent source-owned ledger before it can influence contract reading.
+- Under this rule, supplement evidence does not write straight into child contracts or parent contracts.
+
+## P1 (Supplement-ledger model | v1)
+
+### P1-C1-S1 (Supplement-ledger naming and parent-ledger attachment fixed | v1)
+
+- A supplement ledger must now be named as `ledger-SUP-<source-id>-<source-summary>.md`.
+- The `<source-id>` and `<source-summary>` must match the existing parent source-owned ledger rather than inventing one contract-first naming scheme.
+- Under this rule:
+  - one supplement ledger always attaches to one parent ledger
+  - the parent ledger remains the owner of routing verdicts
+  - the supplement ledger may sharpen or reopen a parent-ledger row, but it does not replace the parent ledger as the packet owner
+
+### P1-C1-S2 (Minimum supplement-ledger header and row contract fixed | v1)
+
+- The minimum supplement-ledger header is now fixed as:
+  - `supplement_id`
+  - `supplement_kind`
+  - `status`
+  - `owner_lane`
+  - `parent_ledger_id`
+  - `parent_source_id`
+  - `parent_source_ref`
+  - `supplement_scope`
+  - `target_reading_goal`
+- The minimum evidence row contract is now fixed as:
+  - `parent ledger slice`
+  - `evidence ref`
+  - `evidence type`
+  - `verification status`
+  - `effect on current verdict`
+  - `proposed parent-ledger action`
+  - `contract impact`
+  - `notes`
+- Under this rule, supplement rows record how later evidence should be judged against an already-existing parent-ledger slice rather than redoing the original routing table.
+
+### P1-C1-S3 (Allowed verdict effects and escalation rule fixed | v1)
+
+- Allowed `effect on current verdict` values are now fixed as:
+  - `supports-existing`
+  - `sharpens-existing`
+  - `narrows-existing`
+  - `revises-existing`
+  - `conflicts-needs-review`
+- Allowed `proposed parent-ledger action` values are now fixed as:
+  - `no-change`
+  - `add-supporting-evidence`
+  - `rewrite-parent-row`
+  - `split-parent-row`
+  - `reopen-routing`
+- Under this rule:
+  - supplement evidence may update or reopen a parent-ledger row
+  - supplement evidence may not write directly into contract lineage or release fields first
+  - any contract rewrite must happen only after the parent ledger has absorbed or rejected the supplement verdict
+
+### P1-C2-S1 (Parent-ledger row-id model fixed | v1)
+
+- Parent-ledger rows must now carry one stable `row_id` per routed slice.
+- The naming rule is now fixed as `<source-id>-R<n>`, using zero-padded sequence numbers inside one parent ledger.
+- Under this rule:
+  - `S0A-1A-R01` means the first stable routed slice inside the `S0A-1A` parent ledger
+  - row ids stay ledger-scoped rather than becoming contract ids
+  - wording in `source slice` may later tighten without breaking supplement references, because the stable anchor is the `row_id`
+
+### P1-C2-S2 (Supplement item-id and attachment-id model fixed | v1)
+
+- Supplement evidence items must now carry one stable `supplement_item_id` beneath one parent-ledger row.
+- The naming rule is now fixed as `<parent-row-id>-SUP-<n>`.
+- Attachments or screenshots beneath one supplement item must now carry one stable `attachment_id`, using `ATT` as the generic asset suffix and `SHOT` when the asset is specifically a screenshot.
+- Under this rule:
+  - `S0A-1A-R02-SUP-01` means the first supplement item attached to parent row `S0A-1A-R02`
+  - `S0A-1A-R02-SUP-01-SHOT-01` means the first screenshot asset beneath that supplement item
+  - attachment ids remain evidence-layer identifiers and do not become contract ids
+
+### P1-C2-S3 (ID boundary versus contract boundary fixed | v1)
+
+- `row_id`, `supplement_item_id`, and `attachment_id` are now fixed as ledger-layer and evidence-layer identifiers rather than contract identifiers.
+- Under this rule:
+  - contracts may cite these ids when needed for auditability or reader traceability
+  - contracts should not promote these ids into primary release identity fields
+  - the stable identity split is now: `ledger_id` for the file, `row_id` for the routed slice, `supplement_item_id` for the admitted evidence item, and `attachment_id` for attached assets such as screenshots
+
+### P1-C3-S1 (On-disk supplement naming normalized to `SUP` | v1)
+
+- The on-disk artifact naming for supplement-ledger records is now normalized from `ledger-supplement-...` to `ledger-SUP-...`.
+- Under this rule:
+  - `SUP` is the on-disk abbreviation for supplement-ledger records
+  - the conceptual boundary still remains `supplement ledger`, but filenames and `supplement_id` values now use the shorter `SUP` prefix
+  - existing and future supplement-ledger references should prefer the `ledger-SUP-<source-id>-<source-summary>.md` shape
+
+## Plan (draft)
+
+### P1 (Supplement-ledger model)
+
+- `P1-C1-S1`: define supplement-ledger naming and parent-ledger attachment
+- `P1-C1-S2`: define the minimum supplement-ledger header and evidence row contract
+- `P1-C1-S3`: define allowed verdict effects such as `supports-existing`, `sharpens-existing`, `revises-existing`, and `reopen-routing`
+- `P1-C2-S1`: define stable row ids for parent-ledger slices
+- `P1-C2-S2`: define supplement item ids plus screenshot or attachment ids
+- `P1-C2-S3`: define the boundary between ledger-layer ids and contract-layer ids
+- `P1-C3-S1`: normalize on-disk supplement-ledger naming to the `SUP` prefix
+
+### P2 (First pilot)
+
+- `P2-C1-S1`: pilot the first supplement-ledger against `S0A-1A` Projects evidence
+- `P2-C1-S2`: decide whether the first pilot only sharpens the current Projects child or actually reopens its parent-ledger row
+
+### P2-C1-S2 (First Projects SUP write-back accepted as sharpening-only | v1)
+
+- The first Projects SUP pilot is now accepted as one sharpening-only write-back rather than one routing reversal.
+- Under this rule:
+  - parent row `S0A-1A-R02` should be sharpened through supporting-evidence write-back
+  - `DOC-WORKFLOW-GITHUB-PROJECTS-0001` should be widened to describe the now-evidenced status-board, table, and timeline readings
+  - no reroute or parent-row split is required from the current evidence batch
+
+### P2-C2-S1 (SUP write-back defaults to current-release amendment | v1)
+
+- When one supplement ledger sharpens or revises a parent-ledger row that is already resolved into one current contract release, the default write-back target remains that same current release.
+- Under this rule:
+  - supplement-ledger write-back does not create one new contract release merely because the current release text is being sharpened, widened, narrowed, or otherwise amended from admitted parent-ledger evidence
+  - a new contract release should be opened only when one genuinely new release event is occurring, such as one new bounded extraction from another source issue or log, one lineage-changing reroute, or one contract-family change that can no longer be defended as amendment of the current release text
+  - if the admitted supplement still depends on the same parent release ledger and does not cross that release boundary, the contract should be edited in place while expanding its release change summary, supporting evidence, and reader-visible wording as needed
+
+### P2-C3-S1 (Contract statement-table model fixed without collapsing contract into ledger | v1)
+
+- A contract release may now carry one optional statement table so clause-level identity, replacement, and carry-forward can be tracked without forcing readers to reconstruct meaning from prose diffs alone.
+- Under this rule:
+  - statement ids should be named as `<contract_id>-ST-<nn>`
+  - the statement table should track clause status, change action, source basis, first effective release, last changed release, effective status, statement text, and notes
+  - the statement table does not replace source routing or supplement admission, because the parent ledger still owns routed slices and the supplement ledger still owns later evidence admission
+
+### P2-C3-S2 (LABS-0001 sample now demonstrates contract clause ids and ledger linkage | v1)
+
+- `DOC-WORKFLOW-LABS-001` may now serve as the first concrete sample for contract statement-table management.
+- Under this rule:
+  - the `S0B-1A` parent ledger should expose stable row ids so the labs contract can cite exact source basis anchors
+  - the labs contract may keep one readable prose statement while also exposing one clause-level table that points back to `S0B-1A-R01/R02/R03`
+  - this linkage remains one contract-facing clause registry, not one second routing table embedded inside the contract body
+
+### P2-C4-S1 (Contract statement labels fixed as contract-facing quick labels | v1)
+
+- Contract statement tables may now carry one `statement label` column so readers can see one short contract-facing title for each clause without confusing that title with the source-owned `source slice` field from the ledger.
+- Under this rule:
+  - `statement label` is the short human-readable identifier for the current contract clause
+  - `statement label` should stay contract-facing and concise rather than copying raw source-packet wording wholesale
+  - the full clause meaning still lives in `statement text`, while the ledger continues to own `source slice`
+
+### P2-C4-S2 (Source-basis multiplicity fixed with primary-first stable-anchor rule | v1)
+
+- Contract statement tables may now record more than one `source basis` anchor when one clause truly depends on multiple upstream bases.
+- Under this rule:
+  - `source basis` should use one or more stable ids rather than raw file paths
+  - additional anchors should be limited to directly decisive parent-row, supplement-item, or prior-statement ids rather than general supporting evidence
+  - this multiplicity rule is now superseded by `P2-C5-S1S2`, which separates evidence anchors from statement lineage and no longer treats basis order as the carrier of causal semantics
+
+### P2-C5-S1 (Source basis narrowed to evidence-only anchors | v1)
+
+- `source basis` now records only the directly decisive evidence anchors for one contract clause or clause-change event.
+- Under this rule:
+  - `source basis` may still hold one or more stable ids
+  - `source basis` should not carry primary/supporting causal logic, split history, merge history, or replacement lineage
+  - clause lineage should move to one separate statement-evolution surface instead of being implied through basis formatting
+
+### P2-C5-S2 (Statement-evolution table fixed as the clause-lineage surface | v1)
+
+- A contract release may now carry one optional `Statement Evolution Table` that records split, merge, replacement, retirement, amendment, and carry-forward events between statement ids.
+- Under this rule:
+  - statement evolution should use one stable `change id` named as `<contract_id>-CH-<nn>`
+  - `input statement ids` and `output statement ids` should carry the clause lineage and causal relationship
+  - `source basis` may still appear in the evolution table, but only as the decisive evidence anchors for the change event
+
+### P2-C5-S3 (LABS-0001 sample now demonstrates split handling across two contract tables | v1)
+
+- `DOC-WORKFLOW-LABS-001` may now serve as the first sample where one over-dense cleanup clause is decomposed into two narrower clauses while lineage is retained separately from evidence anchors.
+- Under this rule:
+  - the contract statement table now keeps the narrower current clauses
+  - the statement-evolution table records the split event and its reason
+  - the sample no longer uses `primary/supporting` inside `source basis`
+
+### P2-C6-S1 (Later-release statement ids fixed as release-local rather than reused lineage ids | v1)
+
+- Statement ids in one later release should now be minted under that later release's `contract_id` rather than reusing earlier-release statement ids as the current ids.
+- Under this rule:
+  - a carried-forward or amended clause in `DOC-WORKFLOW-LABS-0002` should now be named as `DOC-WORKFLOW-LABS-0002-ST-<nn>`
+  - earlier ids such as `DOC-WORKFLOW-LABS-001-ST-06` remain historical lineage anchors only
+  - the continuity between releases should be recorded in the statement-evolution table, not by keeping the old statement id as the current id
+
+### P2-C6-S2 (S0B-2A ledger now exposes row ids for LABS-0002 clause anchoring | v1)
+
+- The `S0B-2A` routing ledger may now expose stable row ids so `LABS-0002` can cite exact later-release evidence anchors in its contract statement table.
+- Under this rule:
+  - the labs-only snapshot-policy slice should anchor as `S0B-2A-R03`
+  - unconsumed or deferred slices remain ledger-visible but do not need to appear in the labs contract unless the release actually consumes them
+
+### P2-C6-S3 (LABS-0002 sample now revised to the paired-table clause model | v1)
+
+- `DOC-WORKFLOW-LABS-0002` may now serve as the first later-release sample under the paired contract-clause model.
+- Under this rule:
+  - `LABS-0002` should carry one `Contract Statement Table` for current clause state
+  - `LABS-0002` should carry one `Statement Evolution Table` for carry-forward, amendment, and introduction relationships back to `LABS-0001`
+  - `source basis` in both tables should stay evidence-only and point to stable ledger rows such as `S0B-1A-R01` and `S0B-2A-R03`
+
+### P2-C7-S1 (Contract statement-table ordering fixed by semantic origin first | v1)
+
+- The current `Contract Statement Table` should now be ordered by semantic origin before current-release novelty.
+- Under this rule:
+  - clauses with smaller `first effective release` values should appear earlier
+  - when `first effective release` is the same, `carried-forward` clauses should appear first, `amended` clauses second, and `introduced` clauses third
+  - within the same bucket, one reader-friendly order should be kept rather than forcing pure lexical id order
+
+### P2-C7-S2 (LABS-0002 first-effective and last-changed semantics normalized | v1)
+
+- `LABS-0002` may now normalize clause timing fields so carried-forward and amended clauses preserve their earlier first-effective origin while only later-introduced clauses start at `0002`.
+- Under this rule:
+  - carried-forward clauses from `LABS-0001` should keep `first effective release: DOC-WORKFLOW-LABS-0001`
+  - amended clauses whose meaning first existed in `LABS-0001` should also keep `first effective release: DOC-WORKFLOW-LABS-0001` while updating `last changed release: DOC-WORKFLOW-LABS-0002`
+  - introduced clauses that first appear in the later release should keep both fields at `DOC-WORKFLOW-LABS-0002`
+
+### P2-C8-S1 (S0A-2A selective-backfill ledger now exposes row ids for SUP anchoring | v1)
+
+- The `S0A-2A` selective-backfill ledger may now expose stable row ids so later direct evidence can attach to exact workflow-layer slices instead of relying on mutable prose labels alone.
+- Under this rule:
+  - the runbook layer should now anchor as `S0A-2A-R04`
+  - later SUP rows may now attach to exact `logs`, `labs`, `runbook`, or `ADR` slices without reopening the whole issue-level packet at once
+
+### P2-C8-S2 (S0A-2A runbook-direct-evidence SUP opened from the earliest projection SOPs | v1)
+
+- `ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md` now serves as the first direct-evidence SUP round for the `S0A-2A` runbook layer.
+- Under this rule:
+  - legacy runbooks `run-001-search-projection.md` and `run-003-chronicle-projection.md` now count as direct evidence that the runbook layer was already being extracted from successful projection work, failure-management labs, and long-lived operator verification needs
+  - the current draft SUP judgment is that this evidence revises the earlier `bounded-background` reading for the runbook layer strongly enough to justify parent-row rewrite and later child-promotion review
+  - this round is prioritized because broader roadmap/log skeleton reorganization is still unresolved, while earlier workflow-layer contract extraction can keep advancing through defended direct-evidence packets
+
+### P2-C8-S3 (S0A-2A runbook parent-row verdict rewritten from accepted SUP evidence | v1)
+
+- The `S0A-2A` parent ledger may now write back the accepted runbook SUP reading directly onto parent row `S0A-2A-R04`.
+- Under this rule:
+  - the runbook layer should no longer read as issue-only `bounded-background`; it now enters explicit `DOC-WORKFLOW-RUNBOOK` child-candidate review because the earliest projection SOPs already prove durable operator-facing extraction
+  - the reason for runbook emergence is now recorded at phase level as well: once projection paths existed, the durable next need moved to rebuildability, replay, readiness, observability, runtime failure handling, and operator-safe verification rather than to further labs-only experimentation
+  - actual child-contract opening remains deferred until one defended runbook packet is promoted, so the parent row now records stronger review status without pretending that a runbook contract already exists
+
+### P2-C8-S4 (DOC-WORKFLOW-RUNBOOK-0001 child-opening packet drafted from the accepted runbook packet | v1)
+
+- `DOC-WORKFLOW-RUNBOOK-0001` may now open as the first dedicated runbook-family child draft under the accepted `S0A-2A-R04` review outcome.
+- Under this rule:
+  - the first runbook child should stay narrow to projection operator rebuild, replay, readiness, observability, and failure-recovery governance rather than restating the whole broader workflow pipeline
+  - parent row `S0A-2A-R04` may now resolve to `DOC-WORKFLOW-RUNBOOK-0001`, while `DOC-WORKFLOW-0001` remains unchanged as the broader workflow-layer reader
+  - current sourcing remains explicit about issue-only origin plus later direct runbook evidence from `run-001` and `run-003`, so the child-opening packet does not overclaim broader repo-wide runbook semantics
+
+### P3 (Future continuation discipline)
+
+- `P3-C1-S1`: define when future work should prefer current logs or new bounded logs instead of old-log reopening
+- `P3-C1-S2`: define when an older packet may be reopened only through explicit supplement-ledger need
+
+## Execution Checklist (unchecked)
+
+### P0 (Lane boundary)
+
+- [x] `P0-C1-S1`: open `S0F-7D` as the supplement-ledger continuation lane after `7C`
+- [x] `P0-C1-S2`: fix the parent-ledger-first supplement rule
+
+### P1 (Supplement-ledger model)
+
+- [x] `P1-C1-S1`: define supplement-ledger naming and attachment
+- [x] `P1-C1-S2`: define header and row contract
+- [x] `P1-C1-S3`: define allowed verdict effects
+- [x] `P1-C2-S1`: define stable row ids for parent-ledger slices
+- [x] `P1-C2-S2`: define supplement item ids plus screenshot or attachment ids
+- [x] `P1-C2-S3`: define the boundary between ledger-layer ids and contract-layer ids
+- [x] `P1-C3-S1`: normalize on-disk supplement-ledger naming to the `SUP` prefix
+
+### P2 (First pilot)
+
+- [x] `P2-C1-S1`: pilot the first supplement-ledger on `S0A-1A` Projects evidence
+- [x] `P2-C1-S2`: decide whether the pilot sharpens or reopens the parent-ledger verdict
+- [x] `P2-C2-S1`: fix the release-boundary rule for accepted SUP write-back
+- [x] `P2-C3-S1`: fix the contract statement-table model
+- [x] `P2-C3-S2`: wire `LABS-0001` as the first clause-table sample linked back to its parent ledger
+- [x] `P2-C4-S1`: fix the contract-facing statement-label rule
+- [x] `P2-C4-S2`: fix the multi-anchor source-basis rule
+- [x] `P2-C5-S1`: narrow `source basis` to evidence-only anchors
+- [x] `P2-C5-S2`: fix the statement-evolution table model
+- [x] `P2-C5-S3`: split the LABS cleanup sample across statement-state and statement-evolution tables
+- [x] `P2-C6-S1`: fix later-release statement ids as release-local
+- [x] `P2-C6-S2`: expose `S0B-2A` row ids for later-release clause anchoring
+- [x] `P2-C6-S3`: revise `LABS-0002` to the paired-table clause model
+- [x] `P2-C7-S1`: fix semantic-origin-first statement-table ordering
+- [x] `P2-C7-S2`: normalize `LABS-0002` first-effective and last-changed semantics
+- [x] `P2-C8-S1`: expose `S0A-2A` row ids for later SUP anchoring
+- [x] `P2-C8-S2`: open the first runbook-direct-evidence SUP round for `S0A-2A`
+- [x] `P2-C8-S3`: write back the accepted runbook SUP judgment onto parent row `S0A-2A-R04`
+- [x] `P2-C8-S4`: draft the first `DOC-WORKFLOW-RUNBOOK-0001` child-opening packet from the accepted runbook evidence packet
+
+### P3 (Future continuation discipline)
+
+- [ ] `P3-C1-S1`: define current-log or new-log preference for future work
+- [ ] `P3-C1-S2`: define explicit reopen conditions for older packets
+
+## Current Status
+
+- `S0F-7D` is now opened as the bounded continuation lane after `S0F-7C`.
+- The lane now fixes one immediate baseline: supplement evidence must attach to a parent source-owned ledger before it can affect contract meaning.
+- `P1-C1-S1S2S3` are now complete: supplement-ledger naming, minimum header, evidence row shape, and allowed verdict effects are now fixed, and the first reusable template is now ready for direct pilot work.
+- `P1-C2-S1S2S3` are now complete: stable row ids, supplement item ids, and screenshot or attachment ids are now fixed across the ledger layer, and the contract boundary is now explicit enough for real pilot intake.
+- `P1-C3-S1` is now complete: on-disk supplement-ledger naming now uses the shorter `SUP` prefix, and the reusable template plus first pilot file now follow that same artifact naming model.
+- `P2-C1-S1` is now complete: the first screenshot-backed Projects SUP pilot now exists at a stable repo-local path and reads as one sharpen-the-draft supplement rather than as one routing-reversal packet.
+- `P2-C1-S2` is now complete: the first Projects SUP pilot is accepted as sharpening-only write-back, the parent ledger now sharpens `S0A-1A-R02`, and `PROJECTS-0001` now reflects status-board, table, and timeline readings without changing the underlying routing boundary.
+- `P2-C2-S1` is now complete: accepted SUP write-back is now fixed as amendment of the current resolved release by default, not as one automatic new contract release.
+- `P2-C3-S1` is now complete: the repo now has one explicit contract statement-table model for clause-level identity and carry-forward without collapsing contracts into ledgers.
+- `P2-C3-S2` is now complete: `LABS-0001` now acts as the first clause-table sample, and the `S0B-1A` parent ledger now exposes row ids so the contract can cite exact source-basis anchors.
+- `P2-C4-S1` is now complete: contract statement tables now explicitly distinguish one short `statement label` from the ledger-owned `source slice` field.
+- `P2-C4-S2` is now complete: `source basis` is now fixed as one-or-more stable anchors with a primary-first rule, and `LABS-0001` demonstrates the first multi-anchor sample row.
+- `P2-C5-S1` is now complete: `source basis` is now narrowed back to evidence-only anchors and no longer carries primary/supporting causal semantics.
+- `P2-C5-S2` is now complete: the repo now has one explicit `Statement Evolution Table` model for clause lineage, split, merge, replacement, and carry-forward events.
+- `P2-C5-S3` is now complete: `LABS-0001` now demonstrates the paired-table model by splitting the earlier cleanup sample into two narrower clauses and recording the split in a separate evolution table.
+- `P2-C6-S1` is now complete: later-release statement ids are now fixed as release-local ids, with earlier-release statement ids retained only as lineage anchors.
+- `P2-C6-S2` is now complete: the `S0B-2A` ledger now exposes stable row ids so `LABS-0002` can cite exact later-release evidence anchors.
+- `P2-C6-S3` is now complete: `LABS-0002` now follows the paired-table clause model, with current clause state separated from clause lineage back to `LABS-0001`.
+- `P2-C7-S1` is now complete: current statement tables now sort by smaller `first effective release` first, then by `carried-forward`, `amended`, and `introduced` buckets.
+- `P2-C7-S2` is now complete: `LABS-0002` now preserves `0001` as the first-effective origin for carried-forward and amended clauses while keeping later introductions at `0002`.
+- `P2-C8-S1` is now complete: the `S0A-2A` selective-backfill ledger now exposes stable row ids so the runbook layer can receive later SUP evidence through an exact parent-row anchor.
+- `P2-C8-S2` is now complete: the first `S0A-2A` runbook-direct-evidence SUP round now uses `run-001` and `run-003` to argue that runbooks had already become durable operator-facing extraction rather than only broad issue-level background.
+- `P2-C8-S3` is now complete: parent row `S0A-2A-R04` no longer stays at `bounded-background` only, and the accepted write-back now records one explicit runbook child-candidate review state while still deferring actual `DOC-WORKFLOW-RUNBOOK` contract opening.
+- `P2-C8-S4` is now complete: the repo now has one first `DOC-WORKFLOW-RUNBOOK-0001` child draft, and parent row `S0A-2A-R04` now resolves to that dedicated runbook release rather than stopping at child-candidate review.
+- The next execution step is to reuse this same `7D` lane when earlier packets such as `S0A-2A` need later evidence admitted through one parent-ledger-first SUP write-back.
+
+## Evidence (reserved)
+
+### P0-C1-S1S2 (Supplement-ledger continuation lane scaffolded | 2026-04-11)
+
+- headSha: `54d4f529e`
+- artifacts:
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+- expected:
+  - the repo should gain one new bounded lane after `7C` for supplement-ledger admission and future old-log continuation
+  - the lane should explicitly keep supplement evidence attached to a parent source-owned ledger instead of letting it write directly into contracts
+- observed:
+  - `S0F-7D` now exists as the next bounded follow-up after `7C`
+  - the lane now fixes the parent-ledger-first supplement rule as its opening boundary
+
+### P1-C1-S1S2S3 (Supplement-ledger model fixed and templated | 2026-04-11)
+
+- headSha: `54d4f529e`
+- artifacts:
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+- expected:
+  - the repo should gain one explicit supplement-ledger naming and attachment rule that stays anchored to an existing parent source-owned ledger
+  - the repo should gain one reusable supplement-ledger template with a fixed header and evidence-row contract
+  - the repo should fix the allowed verdict effects and parent-ledger escalation rule before any real pilot starts
+- observed:
+  - supplement-ledger naming is now fixed as `ledger-SUP-<source-id>-<source-summary>.md` with mandatory parent-ledger attachment
+  - one reusable template now exists for supplement-ledger work with explicit header and evidence-row fields
+  - the lane now fixes a narrow verdict set and requires any later contract rewrite to happen only after the parent ledger absorbs or rejects the supplement result
+
+### P1-C2-S1S2S3 (Ledger-layer item and asset ids fixed | 2026-04-11)
+
+- headSha: `5d7c70b84`
+- artifacts:
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/_template-support-only-contract-release-ledger.md`
+  - `docs/logs/_template-support-only-contract-release-ledger-supplement.md`
+  - `docs/logs/support-only/ledger-S0A-1A-tools-github-issues-projects-and-tags.md`
+- expected:
+  - parent ledgers should gain one stable per-row id so supplement evidence can anchor to routed slices without depending on mutable prose labels
+  - supplement items and screenshot or attachment assets should gain stable ids at the evidence layer
+  - the repo should state clearly that these ids remain below the contract layer rather than becoming release identifiers
+- observed:
+  - parent ledger rows now have one stable `row_id` model
+  - supplement items plus screenshot or attachment assets now have one stable id model beneath the parent row
+  - the lane now keeps those ids ledger-scoped and evidence-scoped rather than promoting them into contract identity
+
+### P1-C3-S1 (SUP artifact naming normalized | 2026-04-11)
+
+- headSha: `354e08ec0`
+- artifacts:
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+- expected:
+  - the repo should normalize on-disk supplement-ledger naming to the shorter `SUP` prefix without changing the underlying conceptual boundary
+  - the reusable template and first pilot should use the same naming shape
+- observed:
+  - the on-disk supplement-ledger naming now uses the `ledger-SUP-...` prefix
+  - the reusable template and first pilot now match that same artifact naming rule
+
+### P2-C1-S1 (First screenshot-backed Projects SUP pilot stabilized | 2026-04-11)
+
+- headSha: `354e08ec0`
+- artifacts:
+  - `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+  - `docs/logs/support-only/S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png`
+  - `docs/logs/support-only/S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png`
+  - `docs/logs/support-only/S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png`
+- expected:
+  - the first Projects supplement should move from chat-only placeholder evidence to stable repo-local screenshot-backed evidence
+  - the pilot should remain a sharpening supplement rather than an outright routing reversal
+- observed:
+  - the first Projects SUP pilot now cites stable repo-local screenshot paths and records the three screenshots as verified evidence items
+  - the current reading still keeps `S0A-1A-R02 -> DOC-WORKFLOW-GITHUB-PROJECTS-0001` unchanged while preparing write-back that sharpens the parent row and widens the current Projects draft wording
+
+### P2-C1-S2 (First Projects SUP write-back accepted | 2026-04-11)
+
+- headSha: `e4989e235`
+- artifacts:
+  - `docs/logs/support-only/ledger-S0A-1A-tools-github-issues-projects-and-tags.md`
+  - `docs/governance/contracts/workflow/github/projects/DOC-WORKFLOW-GITHUB-PROJECTS-0001-project-views-support-execution-priority.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+- expected:
+  - the first SUP pilot should either reopen routing or be accepted as a sharpening-only write-back
+  - accepted write-back should sharpen the parent-ledger row and the current Projects draft without inventing a new routing boundary
+- observed:
+  - the current evidence batch is accepted as sharpening-only write-back rather than as a reroute or split
+  - parent row `S0A-1A-R02` now explicitly reads Projects as status-board, lookup, timeline, and bounded reprioritization support
+  - `PROJECTS-0001` now incorporates those three evidenced view classes while keeping GitHub Issues as the canonical hierarchy owner
+
+### P2-C2-S1 (Current-release amendment rule fixed for SUP write-back | 2026-04-11)
+
+- headSha: `e4989e235`
+- artifacts:
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - accepted supplement-ledger write-back should clarify whether current-release text is amended in place or automatically promoted into one new contract release
+  - the lane should state that new release numbering is reserved for genuinely new release events rather than for every supporting-evidence amendment
+- observed:
+  - `7D` now fixes current-release amendment as the default write-back rule when admitted supplement evidence stays within the same parent-ledger and routing boundary
+  - the lane now reserves new contract-release numbering for genuinely new release events such as new bounded extraction, lineage-changing reroute, or family-level contract change
+
+### P2-C3-S1S2 (Contract statement-table model and LABS sample wired in workspace | 2026-04-11)
+
+- headSha: `6b2d8d28f`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0001-tools-labs-and-snapshots.md`
+  - `docs/logs/support-only/ledger-S0B-1A-tools-labs-and-snapshots.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should clarify how one contract can track clause-level identity and source-basis linkage without turning the contract itself into one second ledger
+  - one concrete sample should show how a contract statement table points back to parent-ledger row ids
+- observed:
+  - the contract template now documents one optional statement-table model with stable statement ids and explicit source-basis fields
+  - `LABS-0001` now demonstrates one clause-table registry, while the `S0B-1A` parent ledger now exposes stable row ids that those clauses can cite
+
+### P2-C4-S1S2 (Statement labels and multi-anchor source basis fixed in workspace | 2026-04-11)
+
+- headSha: `6b2d8d28f`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0001-tools-labs-and-snapshots.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should distinguish contract-facing clause labels from ledger-owned source-slice labels
+  - the repo should clarify whether one contract clause may depend on more than one stable source-basis anchor and how that multiplicity should be written
+- observed:
+  - the contract template now recommends `statement label` as the short contract-facing clause title
+  - the template now permits one-or-more stable `source basis` anchors under a primary-first rule, and `LABS-0001` now demonstrates the first multi-anchor basis row
+
+### P2-C5-S1S2S3 (Evidence-only source basis and statement-evolution model fixed in workspace | 2026-04-11)
+
+- headSha: `6b2d8d28f`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0001-tools-labs-and-snapshots.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should keep `source basis` as evidence-only anchors rather than overloading it with clause causality
+  - the repo should publish one second clause-management table for split, merge, replacement, and retirement history
+  - the labs sample should show one clause split handled across the two-table model
+- observed:
+  - the contract template now distinguishes `Contract Statement Table` from `Statement Evolution Table`
+  - `source basis` is now documented as evidence-only, while clause lineage moves to `change id`, `input statement ids`, and `output statement ids`
+  - `LABS-0001` now demonstrates the paired-table model by splitting the cleanup sample into two narrower clauses and recording the split separately
+
+### P2-C6-S1S2S3 (Release-local statement ids and LABS-0002 paired-table model wired in workspace | 2026-04-11)
+
+- headSha: `a910e7a5d`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/logs/support-only/ledger-S0B-2A-tools-scripts-and-snapshots-management.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0002-labs-snapshot-evidence-package-governance.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - later-release statement ids should be clarified as release-local ids rather than reused earlier-release ids
+  - the `S0B-2A` ledger should expose stable row ids for `LABS-0002` clause anchoring
+  - the `LABS-0002` contract should be upgraded to the same paired-table clause model now used by `LABS-0001`
+- observed:
+  - the template now states that later releases mint their own `ST` ids and keep earlier statement ids only as lineage anchors
+  - the `S0B-2A` ledger now exposes stable row ids, including `S0B-2A-R03` for the labs snapshot-policy slice consumed by `LABS-0002`
+  - `LABS-0002` now carries both a `Contract Statement Table` and a `Statement Evolution Table`, with current `0002-ST-*` ids linked back to `001-ST-*` history through explicit evolution rows
+
+### P2-C7-S1S2 (Statement-table ordering and clause timing semantics normalized in workspace | 2026-04-11)
+
+- headSha: `a910e7a5d`
+- artifacts:
+  - `docs/governance/contracts/_template-contract-record.md`
+  - `docs/governance/contracts/workflow/labs/DOC-WORKFLOW-LABS-0002-labs-snapshot-evidence-package-governance.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - current statement tables should read older semantic origins first, then newer release-local introductions
+  - `LABS-0002` should preserve `0001` as the first-effective origin for carried-forward and amended clauses that began earlier
+- observed:
+  - the template now fixes semantic-origin-first ordering with `carried-forward`, `amended`, and `introduced` bucket order inside one release-origin group
+  - `LABS-0002` now orders carried-forward clauses first, amended clauses second, and introduced clauses third, while preserving `0001` as the first-effective origin for earlier clauses
+
+### P2-C8-S1S2 (S0A-2A runbook SUP round opened in workspace | 2026-04-12)
+
+- headSha: `0611fb60b`
+- artifacts:
+  - `docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-2A-001-tools-workflow-log-lab-runbook-adr.md`
+  - `legacy/from_structured_docs/from-runbook/run-001-search-projection.md`
+  - `legacy/from_structured_docs/from-runbook/run-003-chronicle-projection.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the `S0A-2A` parent ledger should gain stable row ids so the runbook slice can receive later direct-evidence SUP rows by exact anchor rather than by mutable prose label
+  - the repo should gain one first `S0A-2A` SUP ledger that tests whether direct runbook evidence is strong enough to revise the current `bounded-background` verdict for the runbook layer
+  - the lane should record why this direct-evidence extraction round is being prioritized ahead of broader roadmap/log skeleton reorganization
+- observed:
+  - the `S0A-2A` parent ledger now exposes row ids, including `S0A-2A-R04` for the runbook layer
+  - one new SUP ledger now attaches `run-001-search-projection.md` and `run-003-chronicle-projection.md` to that exact runbook-layer row as verified direct evidence
+  - the current draft SUP judgment is that the runbook layer should no longer be treated as issue-only bounded background by default, and this extraction round is now prioritized while broader roadmap/log restructuring remains unsettled
+
+### P2-C8-S3 (S0A-2A runbook parent-row write-back accepted | 2026-04-12)
+
+- headSha: `b0ad217cd`
+- artifacts:
+  - `docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md`
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - parent row `S0A-2A-R04` should stop reading as issue-only `bounded-background` once the accepted SUP evidence proves durable runbook extraction from the earliest projection SOPs
+  - the lane should record the runbook-emergence reason explicitly at phase level, not only inside the support-only SUP ledger
+  - the write-back should strengthen the runbook verdict without falsely claiming that a `DOC-WORKFLOW-RUNBOOK` contract has already been opened
+- observed:
+  - `S0A-2A-R04` now reads as explicit `DOC-WORKFLOW-RUNBOOK` child-candidate review while still keeping actual release opening deferred
+  - `S0F-7D` now records that runbooks emerged because durable operator needs shifted toward rebuildability, replay, readiness, observability, runtime failure handling, and operator-safe verification after projection paths had succeeded
+  - the parent-ledger write-back now sharpens the verdict materially without inventing a non-existent runbook contract
+
+### P2-C8-S4 (DOC-WORKFLOW-RUNBOOK-0001 child-opening packet drafted | 2026-04-12)
+
+- headSha: `42987ad37`
+- artifacts:
+  - `docs/governance/contracts/workflow/runbook/DOC-WORKFLOW-RUNBOOK-0001-projection-operator-rebuild-replay-and-failure-recovery.md`
+  - `docs/logs/support-only/ledger-S0A-2A-tools-workflow-log-lab-runbook-adr.md`
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/log-S0F-docs-management-v6.md`
+- expected:
+  - the repo should gain one first dedicated runbook-family child draft from the accepted `S0A-2A-R04` packet instead of stopping at child-candidate review only
+  - the draft should stay narrow to the earliest projection SOP pattern: rebuildability, replay, runtime verification, observability, and failure recovery
+  - parent row `S0A-2A-R04` should resolve to the new child draft without widening logs, labs, or ADR ownership from the same broad issue source
+- observed:
+  - `DOC-WORKFLOW-RUNBOOK-0001` now exists as the first dedicated runbook-family draft sourced from the accepted `S0A-2A` runbook packet plus the two earliest projection SOPs
+  - `S0A-2A-R04` now resolves to `DOC-WORKFLOW-RUNBOOK-0001` with full consumed scope while keeping the rest of the mixed `S0A-2A` packet unchanged
+  - `S0F-7D` now carries the child-opening step explicitly so this runbook extraction remains visible in the same supplement-ledger continuation lane
+
+## Numbering
+
+- `S<n>`: Step.
+- `C<n>`: Cycle.
+
+**Commit / PR naming**:
+
+- `S0F-7D/P<phase>-C<cycle>-S<steps>: <summary>`, where `<steps>` can be a single step (`1`, meaning `...-S1`) or multiple consecutive steps grouped within the same phase / cycle.
+
+**Branch convention**:
+
+- `S0F-7D` work should continue on the top-level `S0F-docs-management-v6` branch unless the lane later opens one narrower bounded follow-up that warrants its own child branch.
+
+**Commit discipline (recommended)**:
+
+- Keep scaffold, template, and first pilot commits separated so supplement-ledger model changes do not get buried inside one larger old-log continuation packet.

--- a/docs/logs/log-S0F-7F-log-and-roadmap-frontmatter-minimum-time-fields.md
+++ b/docs/logs/log-S0F-7F-log-and-roadmap-frontmatter-minimum-time-fields.md
@@ -1,0 +1,248 @@
+# log-S0F-7F (Phase 7F: log and roadmap frontmatter minimum time fields)
+
+---
+
+**id**: `S0F-7F`
+**kind**: `log`
+**title**: `log and roadmap frontmatter minimum time fields`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Governance, Records, Roadmap, epic/s0, sub/7f`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
+  **reference_log_1**: `docs/logs/log-S0F-7E-supplement-sequencing-time-fields-and-historical-backfill-release-chronology.md`
+  **reference_log_2**: `docs/logs/_template-log-phase-drills-evidence.md`
+  **reference_log_3**: `docs/roadmap/road-template-main-roadmap.md`
+  **reference_log_4**: `docs/roadmap/road-template-branch-roadmap.md`
+  **reference_log_5**: `docs/roadmap/road-template-structured-roadmap.md`
+**issue_keyword**: `records`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/7`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-13`
+**updated**: `2026-04-13`
+
+---
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-7F` opens as the bounded follow-up after `S0F-7E` for one narrower documentation-management problem: most governance logs and roadmap documents still carry `created` and `updated`, but the repo does not yet define one minimum frontmatter lifecycle-time contract aligned with the newer UTC-aware ledger and supplement model.
+- This lane will fix only the minimum shared frontmatter contract for logs and roadmaps first; it will not widen immediately into contract chronology or evidence-audit fields that already belong to `S0F-7E` and the contract templates.
+
+**Default choices (phase defaults / v1)**:
+
+- Treat log and roadmap frontmatter time as `artifact-lifecycle` time only, not as historical-effective rule time.
+- Keep the minimum shared contract narrow: `created`, `updated`, and later `reviewed` only where the document class actually needs review-state tracking.
+- Prefer canonical UTC-second timestamps for new writes in those existing fields when exact lifecycle audit matters, while allowing day-only values when only day-level history is defended.
+- Do not force every log or roadmap file to gain row-level or evidence-level time-audit tables; that stays reserved for ledgers, supplements, and other evidence-heavy packets.
+- Start with a minimum sample set before any wider migration rule is declared.
+
+## Minimum Frontmatter Lifecycle-Time Rule
+
+- Ordinary `log` and `roadmap` frontmatter should now use `created`, `updated`, and optional `reviewed` as the minimum artifact-lifecycle fields.
+- New writes should prefer canonical UTC-second timestamps such as `2026-04-13T08:15:30Z` in those existing fields when exact lifecycle audit matters.
+- Legacy day-only values such as `2026-04-13` remain valid when second-level precision is unnecessary or unavailable.
+- `reviewed` is optional and should appear only when a log or roadmap is reviewed as one bounded governance packet rather than as an ordinary iterative draft.
+- Evidence-time audit and historical-effective time remain out of scope for ordinary log and roadmap frontmatter.
+
+## Problem Statement
+
+- The repo now has a stronger chronology model for support-only ledgers, supplement ledgers, and contract templates, but the ordinary `log` and `roadmap` frontmatter still uses older `created` and `updated` fields without one repo-wide minimum lifecycle-time rule.
+- Without a bounded follow-up, later docs-management work will keep mixing at least three things:
+  - older compatibility fields such as `created` and `updated`
+  - newer UTC-aware lifecycle fields such as `created_at` and `reviewed_at`
+  - evidence or historical-effective time that does not belong in ordinary log and roadmap frontmatter at all
+- The repo therefore needs one narrow lane that answers three questions before broader migration starts:
+  - what the minimum shared frontmatter lifecycle-time fields should be for logs and roadmaps
+  - how those fields should relate to older compatibility fields already present in templates and live files
+  - which smallest sample set is sufficient to test the contract before any repo-wide rewrite
+
+## Exported Sections / Outlet Ownership
+
+- This slice starts as one `log-template + roadmap-template + log-retained core` field-governance lane.
+- The expected landing is one minimum frontmatter lifecycle-time rule for ordinary logs and roadmap files plus one compatibility policy for older day-only fields.
+
+**Outlet ownership**:
+
+- `contract`: no-op by default; this lane should not widen into contract chronology because that surface is already owned elsewhere
+- `runbook`: no-op by default
+- `view`: no-op by default
+- `index/front-door`: no-op by default
+- `disposition/placement`: the log and roadmap templates are the first mutable landing surfaces; later live-file migration should remain sample-first
+- `log-retained core`: the lane boundary, field contract, compatibility rule, and sample verdicts remain here
+
+## Definitions (optional)
+
+- `artifact-lifecycle time`: the repo-side time when a document was created, updated, reviewed, or accepted.
+- `minimum frontmatter lifecycle-time contract`: the smallest shared field set that ordinary logs and roadmaps must carry before any document-class-specific timing extensions are considered.
+- `compatibility field`: one older field shape, such as `created` or `updated`, that may remain temporarily while the repo transitions toward one newer standard.
+- `local-time mirror field`: one optional display-only local timestamp derived from a canonical UTC timestamp; it is not the primary stored time value.
+
+## Constraints
+
+- Do not widen ordinary logs or roadmaps into evidence-audit packets by default.
+- Do not require ordinary log frontmatter to carry historical-effective fields that belong to contracts.
+- Do not break existing template compatibility before the minimum replacement rule is tested on a small sample set.
+- Do not attempt a repo-wide timestamp rewrite before the migration rule is proven on a few controlled files.
+
+## Scope
+
+- `P0`: open `S0F-7F`, bound the problem to ordinary log and roadmap frontmatter lifecycle-time fields, and separate it from `S0F-7E` evidence/chronology work
+- `P1`: define the minimum shared lifecycle-time frontmatter rule for logs and roadmaps plus compatibility handling for older `created` and `updated` fields
+- `P2`: test the rule on one minimum sample set consisting of the log template, the main-roadmap template, and the branch-roadmap template
+- `P3`: if the sample passes, decide whether one first live log sample and one first live roadmap sample should be migrated next
+- `P4`: apply the fixed timing rule to one existing ledger plus one existing supplement-ledger sample, including one first screenshot-time audit and one first sequence-bearing SUP rename
+
+## Success Criteria (DoD)
+
+- The repo has one explicit minimum frontmatter lifecycle-time rule for ordinary logs and roadmaps.
+- The repo has one compatibility rule that explains how older `created` and `updated` fields relate to any newer lifecycle-time fields.
+- The repo has one small proved sample set before any broader migration guidance is declared.
+- The lane stays separate from evidence-time audit and contract chronology, so document classes do not collapse back into one mixed time model.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - the minimum frontmatter lifecycle-time contract is explicitly written
+  - the minimum sample set has been updated and reviewed
+  - the lane records whether the next step is a bounded live-file migration or direct retention
+- `stable` does not require repo-wide migration in the same lane; one accepted sample-first rule is sufficient.
+
+## P0 (Lane boundary | v1)
+
+### P0-C1-S1 (Open `S0F-7F` as the log/roadmap frontmatter timing follow-up)
+
+- Open one bounded follow-up lane after `S0F-7E` for ordinary log and roadmap lifecycle-time fields.
+
+### P0-C1-S2 (Fix the minimum sample set before wider migration)
+
+- The first bounded sample set is:
+  - `docs/logs/_template-log-phase-drills-evidence.md`
+  - `docs/roadmap/road-template-main-roadmap.md`
+  - `docs/roadmap/road-template-branch-roadmap.md`
+
+## Plan (draft)
+
+### P1 (Minimum frontmatter rule)
+
+- `P1-C1-S1`: define the minimum shared lifecycle-time field set for logs and roadmaps
+- `P1-C1-S2`: define compatibility with existing `created` and `updated` fields
+
+### P2 (Template samples)
+
+- `P2-C1-S1`: update the log template sample
+- `P2-C1-S2`: update the main-roadmap and branch-roadmap template samples
+
+### P3 (First live-file migration decision)
+
+- `P3-C1-S1`: decide whether one live log sample should migrate next
+- `P3-C1-S2`: decide whether one live roadmap sample should migrate next
+
+### P4 (Ledger and SUP timing samples)
+
+- `P4-C1-S1`: add lifecycle fields to `ledger-S0A-1A` and normalize the first Projects SUP file as sequence `001`
+- `P4-C1-S2`: add screenshot-backed time audit for the three `2026-02-12` Projects screenshots without overclaiming second-level precision
+- `P4-C1-S3`: align `ledger-S0A-1A` and `PROJECTS-0001` to the more complete chronology-first structure already demonstrated by the `S0A-2A` plus `LABS-0002` sample set
+
+## Execution Checklist (unchecked)
+
+### P0 (Lane boundary)
+
+- [x] `P0-C1-S1`: open `S0F-7F` as the log/roadmap frontmatter timing follow-up
+- [x] `P0-C1-S2`: fix the minimum sample set before wider migration
+
+### P1 (Minimum frontmatter rule)
+
+- [x] `P1-C1-S1`: define the minimum shared lifecycle-time field set for logs and roadmaps
+- [x] `P1-C1-S2`: define compatibility with existing `created` and `updated` fields
+
+### P2 (Template samples)
+
+- [x] `P2-C1-S1`: update the log template sample
+- [x] `P2-C1-S2`: update the main-roadmap and branch-roadmap template samples
+
+### P4 (Ledger and SUP timing samples)
+
+- [x] `P4-C1-S1`: add lifecycle fields to `ledger-S0A-1A` and normalize the first Projects SUP file as sequence `001`
+- [x] `P4-C1-S2`: add screenshot-backed time audit for the three `2026-02-12` Projects screenshots without overclaiming second-level precision
+- [x] `P4-C1-S3`: align `ledger-S0A-1A` and `PROJECTS-0001` to the more complete chronology-first structure already demonstrated by the `S0A-2A` plus `LABS-0002` sample set
+
+## Current Status (recommended)
+
+- `S0F-7F` is now opened as the bounded follow-up after `S0F-7E` for ordinary log and roadmap frontmatter lifecycle-time fields.
+- The minimum sample set is fixed as the log template plus the main-roadmap and branch-roadmap templates.
+- `P1-C1-S1` is now complete: the lane now defines `created`, `updated`, and optional `reviewed` as the minimum lifecycle-time fields for ordinary logs and roadmaps.
+- `P1-C1-S2` is now complete: the lane now allows future UTC-second writes in those existing fields instead of introducing a second pair of `*_at` field names.
+- `P2-C1-S1` is now complete: the phase-drills-evidence log template now uses the revised `created/updated/reviewed` contract.
+- `P2-C1-S2` is now complete: the main-roadmap and branch-roadmap templates now use the same revised `created/updated/reviewed` contract.
+- `P3-C1-S1` is now complete: `log-S0F-7D` now carries one first live-log sample of the revised `created/updated/reviewed` contract.
+- `P3-C1-S2` is now complete: `road-001` now carries one first live-roadmap sample of the revised `created/updated/reviewed` contract.
+- `P4-C1-S1` is now complete: `ledger-S0A-1A` now carries explicit lifecycle fields, and the first Projects supplement sample now uses the sequence-bearing `SUP-001` filename plus the full supplement lifecycle header.
+- `P4-C1-S2` is now complete: the three Projects screenshots now carry one explicit day-precision evidence-time audit fixed at `2026-02-12` without inventing second-level timestamps.
+- `P4-C1-S3` is now complete: `ledger-S0A-1A` now also exposes one row-level chronology audit for `R02`, and `PROJECTS-0001` now carries the minimum chronology-first contract structure that was still missing relative to the more complete `LABS-0002` sample.
+- The next step is to review whether this revised log/roadmap contract together with the first ledger/SUP timing sample is sufficient before any broader live-file migration continues.
+
+## Evidence (reserved)
+
+- Artifacts are the source of truth for evidence; this log records the head SHA, key parameters, and artifact paths when the lane starts mutating templates.
+- This section stays empty until the first template-sample patch is actually landed.
+
+### P1-C1-S1S2 + P2-C1-S1S2 + P3-C1-S1S2 (Revised `created/updated/reviewed` contract and first live samples fixed | 2026-04-13)
+
+- headSha: `dc7a027f6`
+
+- artifacts:
+  - `docs/logs/_template-log-phase-drills-evidence.md`
+  - `docs/roadmap/road-template-main-roadmap.md`
+  - `docs/roadmap/road-template-branch-roadmap.md`
+  - `docs/logs/log-S0F-7F-log-and-roadmap-frontmatter-minimum-time-fields.md`
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/roadmap/road-001-systems-platform-ops-roadmap.md`
+- expected:
+  - ordinary logs and roadmap templates should keep the existing `created` and `updated` field names, gain one optional `reviewed` field, and avoid a duplicated `*_at` naming layer
+  - future writes should still be allowed to use UTC-second values inside those existing fields when finer lifecycle audit is needed
+  - the first live samples should prove that one existing log and one existing roadmap can adopt `reviewed` without any wider chronology surface change
+- observed:
+  - the log, main-roadmap, and branch-roadmap templates now expose `created`, `updated`, and optional `reviewed` only, while still allowing UTC-second or day-level values in those fields
+  - `log-S0F-7D` now uses `reviewed: 2026-04-11`, aligned to its current `updated` value as the first live-log sample
+  - `road-001` now uses `reviewed: 2026-03-29`, aligned to its current `updated` value as the first live-roadmap sample
+
+### P4-C1-S1S2S3 (First live ledger/SUP timing sample and Projects-0001 structure alignment fixed | 2026-04-13)
+
+- headSha: `6b4eaf13e`
+
+- artifacts:
+  - `docs/logs/support-only/ledger-S0A-1A-tools-github-issues-projects-and-tags.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+  - `docs/governance/contracts/workflow/github/projects/DOC-WORKFLOW-GITHUB-PROJECTS-0001-project-views-support-execution-priority.md`
+  - `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  - `docs/logs/log-S0F-7F-log-and-roadmap-frontmatter-minimum-time-fields.md`
+- expected:
+  - the first existing ledger/SUP sample should expose lifecycle fields without confusing them with row-level or evidence-level historical time
+  - the first older unsequenced Projects SUP file should be normalized to one explicit `001` round under the newer append-only supplement naming rule
+  - the three Projects screenshots should record the defended day-level capture date `2026-02-12` without claiming second-level timestamps that the archive does not preserve
+  - the Projects trio should also close the structure gap against the more complete `S0A-2A` plus `LABS-0002` sample by adding one parent-row chronology audit and one minimum chronology-first contract statement/evolution surface
+- observed:
+  - `ledger-S0A-1A` now exposes `created_at`, `reviewed_at`, and `accepted_at`, while the Projects supplement sample now exposes sequence-bearing identity plus the full supplement lifecycle header
+  - the Projects SUP file now reads as `ledger-SUP-S0A-1A-001-...`, and all supporting references now point to the sequence-bearing filename
+  - the three screenshot evidence items now share one explicit day-precision time audit anchored at `2026-02-12`, with observation and recording both limited to defended day-level capture timing
+  - `ledger-S0A-1A` now also exposes one optional row chronology audit for `S0A-1A-R02`, and `PROJECTS-0001` now carries `recorded_at/reviewed_at/effective_from/effective_until` plus one minimum contract statement table and one statement evolution table so the Projects trio now reads much closer to the `S0A-2A` plus `LABS-0002` structure level

--- a/docs/logs/support-only/ledger-S0A-1A-tools-github-issues-projects-and-tags.md
+++ b/docs/logs/support-only/ledger-S0A-1A-tools-github-issues-projects-and-tags.md
@@ -1,0 +1,61 @@
+# ledger-S0A-1A-tools-github-issues-projects-and-tags
+
+```yaml
+support_only_contract_release_ledger:
+  ledger_id: ledger-S0A-1A-tools-github-issues-projects-and-tags
+  ledger_kind: support-only-contract-release-ledger
+  status: active
+  owner_lane: S0F-7C
+  created_at: 2026-04-11
+  reviewed_at: 2026-04-11
+  accepted_at: 2026-04-11
+  source_id: S0A-1A
+  source_ref: GitHub issue S0A-1A (#23) (issue-only source; no local log exists in workspace)
+  source_scope: mixed issue-only source covering GitHub Issues as canonical work breakdown, GitHub Projects as execution-time support, issue title grammar, and issue tag naming
+  target_reading_goal: show whether the earlier issue-only S0A-1A packet already has sufficient routing recorded through existing contracts or now needs explicit selective ledger backfill for its mixed source boundaries
+```
+
+## Decision Frame
+
+- This ledger is a selective-backfill scaffold, not yet a full re-adjudication.
+- The current draft default is:
+  - keep GitHub Issues mechanism introduction aligned to `DOC-WORKFLOW-GITHUB-ISSUES-0001`
+  - keep title grammar aligned to `DOC-WORKFLOW-GITHUB-ISSUES-TITLE-0001`
+  - keep tag naming aligned to `DOC-WORKFLOW-GITHUB-ISSUES-TAGS-0001`
+  - promote GitHub Projects into one first dedicated child contract rather than leaving it implicit beside the issue packet
+- The purpose of this scaffold is to make the mixed-source question reviewable rather than assumed solved because contracts already exist.
+
+## Routing And Consumption Table
+
+| row id | source slice | meaning owned here | target family | target release action | contract lineage impact | retained-only action | resolution status | resolved by contract id | consumed scope | resolution notes | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R01` | `GitHub Issues as canonical breakdown` in issue `S0A-1A (#23)` | introduce GitHub Issues as the canonical work-breakdown surface for timeline queue work | `DOC-WORKFLOW-GITHUB-ISSUES` | `existing-family-review` | `none-source-only` | `keep-in-issue` | `applied` | `DOC-WORKFLOW-GITHUB-ISSUES-0001` | `full` | consumed by the existing issue-mechanism parent contract, which now serves as the explicit `ISSUES-0001` surface for this packet | This slice already maps cleanly to the existing parent contract; the backfill now makes that ownership explicit. |
+| `S0A-1A-R02` | `GitHub Projects as execution-time view support` in issue `S0A-1A (#23)` | use Projects views as one operator-facing execution support surface for status-board reading, fast table lookup, timeline sequencing, and bounded reprioritization without replacing issue hierarchy | `DOC-WORKFLOW-GITHUB-PROJECTS` | `new-family` | `none-source-only` | `keep-in-issue` | `applied` | `DOC-WORKFLOW-GITHUB-PROJECTS-0001` | `full` | consumed by a dedicated Projects child contract and now sharpened further by `ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`, which evidences status-board, table, and timeline usage without changing the existing routing boundary | This slice was implicit in the older packet and is now made explicit through selective backfill plus screenshot-backed sharpening evidence. |
+| `S0A-1A-R03` | `Title name` in issue `S0A-1A (#23)` | issue title key exposes level and category directly in the title itself | `DOC-WORKFLOW-GITHUB-ISSUES-TITLE` | `existing-family-review` | `none-source-only` | `keep-in-issue` | `applied` | `DOC-WORKFLOW-GITHUB-ISSUES-TITLE-0001` | `full` | consumed by the title child contract, whose frontmatter is now aligned to the release-style template | This slice remains the clearest direct match to the title child contract. |
+| `S0A-1A-R04` | `Tag name` in issue `S0A-1A (#23)` | classify issue tags by naming role across top-level, hierarchy, and module/business labels | `DOC-WORKFLOW-GITHUB-ISSUES-TAGS` | `existing-family-review` | `none-source-only` | `keep-in-issue` | `applied` | `DOC-WORKFLOW-GITHUB-ISSUES-TAGS-0001` | `full` | consumed by the tag child contract, whose frontmatter is now aligned to the release-style template | This slice remains the clearest direct match to the tag child contract. |
+
+## Row Id Map
+
+- `S0A-1A-R01`: GitHub Issues as canonical breakdown
+- `S0A-1A-R02`: GitHub Projects as execution-time view support
+- `S0A-1A-R03`: Title name
+- `S0A-1A-R04`: Tag name
+
+## New Releases Expected
+
+- `DOC-WORKFLOW-GITHUB-PROJECTS-0001`
+
+## Deferred Slices
+
+- whether later non-screenshot evidence should extend `DOC-WORKFLOW-GITHUB-PROJECTS-0001` beyond the now-evidenced status-board, table, and timeline views into a richer later operating-flow release
+
+## Row Chronology Audit
+
+| row id | source observed at | source recorded at | source effective from | source effective until | time precision | timezone note | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02` | `2026-02-12` | `2026-02-12` | `unknown` | `unknown` | `day` | `current Projects evidence preserves only one defended screenshot-capture date` | The parent row now has one defended screenshot-backed chronology anchor through `SUP-001`, but the current evidence still proves only day-level observation and recording rather than a longer historical-effective range. |
+
+## Reader Notes
+
+- This ledger now confirms that the earlier `S0A-1A` packet needed one explicit Projects child and explicit completed routing state, but not one workflow-level reroute.
+- The `S0A-1A-R02` row is now also sharpened by the accepted `SUP-001` pilot, which adds stable screenshot-backed evidence without changing the existing routing outcome.

--- a/docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md
+++ b/docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md
@@ -1,0 +1,120 @@
+# ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags
+
+```yaml
+support_only_contract_release_ledger_supplement:
+  supplement_series_id: ledger-SUP-S0A-1A
+  supplement_sequence: 001
+  supplement_id: ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags
+  supplement_kind: support-only-contract-release-ledger-supplement
+  status: completed
+  owner_lane: S0F-7D
+  created_at: 2026-04-11
+  reviewed_at: 2026-04-11
+  accepted_at: 2026-04-11
+  writeback_started_at: 2026-04-11
+  writeback_completed_at: 2026-04-11
+  parent_ledger_id: ledger-S0A-1A-tools-github-issues-projects-and-tags
+  parent_source_id: S0A-1A
+  parent_source_ref: GitHub issue S0A-1A (#23) (issue-only source; no local log exists in workspace)
+  supplement_scope: first screenshot-backed SUP for the Projects slice under S0A-1A, covering status-board usage, table lookup usage, and timeline-sequence usage
+  target_reading_goal: show whether later screenshot evidence sharpens the existing Projects routing verdict enough to justify richer wording in the current Projects child draft without reopening the parent-ledger routing boundary
+```
+
+## Decision Frame
+
+- This SUP ledger is attached only to parent row `S0A-1A-R02`.
+- The current draft judgment is that the three screenshots do not challenge the existing routing of the Projects slice into `DOC-WORKFLOW-GITHUB-PROJECTS-0001`.
+- The current review question is narrower:
+  - do these screenshots merely support the current Projects child
+  - or do they sharpen the current draft enough that the child contract should describe concrete common views rather than only generic execution-time support
+
+## Evidence Table
+
+| supplement item id | parent row id | evidence ref | evidence type | attachment ids | verification status | effect on current verdict | proposed parent-ledger action | contract impact | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02-SUP-01` | `S0A-1A-R02` | `docs/logs/support-only/S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png` | `screenshot` | `S0A-1A-R02-SUP-01-SHOT-01` | `verified` | `sharpens-existing` | `add-supporting-evidence` | `rewrite-current-draft` | The screenshot shows four explicit operating states under Projects usage: `Doing` with a visible WIP guard, `Done` as the recent-deliverable landing, `Backlog` as temporary defer-without-overloading current work, and `Blocked` as active stop-or-reroute handling. This sharpens the existing Projects reading from generic reprioritization support into one operator-facing execution-status surface. |
+| `S0A-1A-R02-SUP-02` | `S0A-1A-R02` | `docs/logs/support-only/S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png` | `screenshot` | `S0A-1A-R02-SUP-02-SHOT-01` | `verified` | `sharpens-existing` | `add-supporting-evidence` | `rewrite-current-draft` | The screenshot shows one high-utility lookup view where operators can find items quickly by title, id, labels, completion state, linked PR, and assignee information. This sharpens the current Projects reading by showing that Projects is not only for reprioritization but also for everyday discovery and current-state scanning. |
+| `S0A-1A-R02-SUP-03` | `S0A-1A-R02` | `docs/logs/support-only/S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png` | `screenshot` | `S0A-1A-R02-SUP-03-SHOT-01` | `verified` | `sharpens-existing` | `add-supporting-evidence` | `rewrite-current-draft` | The screenshot shows one timeline-oriented reading used to understand delivery ordering and visible insertion into the current work stream. This sharpens the current Projects reading by adding sequence and interruption-awareness to the existing execution-support boundary, while still staying below canonical issue-hierarchy ownership. |
+
+## Attachment Inventory
+
+| attachment id | supplement item id | asset type | asset ref or description | key text transcription | proving claim | anchor ref | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02-SUP-01-SHOT-01` | `S0A-1A-R02-SUP-01` | `screenshot` | `[open asset](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)` | `Doing`, `WIP <= 5`, `Done`, `most recent deliverables!`, `Backlog`, `This item has been backlogged`, `Blocked`, `This item has been blocked` | Projects is used as one active execution-status surface with concrete operating columns rather than only one abstract prioritization aid | `S0A-1A-R02` | Stable repo-local screenshot path now exists and is directly reviewable from this packet. |
+| `S0A-1A-R02-SUP-02-SHOT-01` | `S0A-1A-R02-SUP-02` | `screenshot` | `[open asset](./S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png)` | `Title`, `Sub-issues progress`, `Status`, `Linked pull req...`, `Assignees` | Projects is used as one fast lookup and daily reading surface for issue identity, completion state, PR linkage, and assignment context | `S0A-1A-R02` | Stable repo-local screenshot path now exists and is directly reviewable from this packet. |
+| `S0A-1A-R02-SUP-03-SHOT-01` | `S0A-1A-R02-SUP-03` | `screenshot` | `[open asset](./S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png)` | `Timeline`, `March 2026`, `April 2026`, item rows arranged against dates | Projects is used as one sequence and insertion-order reading surface, helping operators understand completion ordering and interruption timing | `S0A-1A-R02` | Stable repo-local screenshot path now exists and is directly reviewable from this packet. |
+
+## Attachment Review Table
+
+| attachment id | supplement item id | click-through asset ref | review status | approval basis | review note |
+| --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02-SUP-01-SHOT-01` | `S0A-1A-R02-SUP-01` | `[open asset](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)` | `accepted-for-packet` | The visible column layout and captured labels are sufficient to defend the claim that Projects is serving as one operator-facing execution-status board. | Review checked the screenshot for explicit state-column wording plus the visible WIP constraint, and no contradiction to the current `sharpens-existing` verdict was found. |
+| `S0A-1A-R02-SUP-02-SHOT-01` | `S0A-1A-R02-SUP-02` | `[open asset](./S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png)` | `accepted-for-packet` | The visible table headers are sufficient to defend the claim that Projects is serving as one quick lookup surface for delivery-state reading. | Review checked the screenshot for issue-title, progress, status, PR-link, and assignee columns, and the captured UI is strong enough for the current packet claim without needing a broader governance inference. |
+| `S0A-1A-R02-SUP-03-SHOT-01` | `S0A-1A-R02-SUP-03` | `[open asset](./S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png)` | `accepted-for-packet` | The visible date-grid layout is sufficient to defend the claim that Projects is being used as one sequencing and interruption-reading surface. | Review checked the screenshot for the dated timeline layout and item placement across time, and the image is sufficient for the current sequence-awareness reading while still staying below canonical issue-hierarchy ownership. |
+
+## Actor and Provenance Review Table
+
+| supplement item id | submitted by | evidence owner | verified by | verification method | approved by | approval state | approval basis | provenance note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02-SUP-01` | `unknown` | `role:packet-maintainer` | `role:packet-reviewer` | `direct-screenshot-inspection` | `role:packet-reviewer` | `accepted-for-packet` | The current packet preserves enough screenshot evidence and review notes to defend the status-board claim at packet level. | The screenshot is preserved in-repo and the packet review chain is explicit, but the original named submitter is not defended by the surviving issue-only source history. |
+| `S0A-1A-R02-SUP-02` | `unknown` | `role:packet-maintainer` | `role:packet-reviewer` | `direct-screenshot-inspection` | `role:packet-reviewer` | `accepted-for-packet` | The current packet preserves enough screenshot evidence and review notes to defend the quick-lookup claim at packet level. | The screenshot is preserved in-repo and the packet review chain is explicit, but the original named submitter is not defended by the surviving issue-only source history. |
+| `S0A-1A-R02-SUP-03` | `unknown` | `role:packet-maintainer` | `role:packet-reviewer` | `direct-screenshot-inspection` | `role:packet-reviewer` | `accepted-for-packet` | The current packet preserves enough screenshot evidence and review notes to defend the sequence-awareness claim at packet level. | The screenshot is preserved in-repo and the packet review chain is explicit, but the original named submitter is not defended by the surviving issue-only source history. |
+
+## Attachment Quick Review
+
+### S0A-1A-R02-SUP-01-SHOT-01
+
+- Attachment: [S0A-1A-R02-SUP-01-SHOT-01](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)
+- Review focus: confirm that the screenshot visibly supports the execution-status reading through explicit state columns and the WIP guard.
+
+![S0A-1A-R02-SUP-01-SHOT-01 preview](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)
+
+### S0A-1A-R02-SUP-02-SHOT-01
+
+- Attachment: [S0A-1A-R02-SUP-02-SHOT-01](./S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png)
+- Review focus: confirm that the screenshot visibly supports the quick-lookup reading through title, progress, status, PR-link, and assignee columns.
+
+![S0A-1A-R02-SUP-02-SHOT-01 preview](./S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png)
+
+### S0A-1A-R02-SUP-03-SHOT-01
+
+- Attachment: [S0A-1A-R02-SUP-03-SHOT-01](./S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png)
+- Review focus: confirm that the screenshot visibly supports the sequence-awareness reading through the dated timeline layout and item placement across time.
+
+![S0A-1A-R02-SUP-03-SHOT-01 preview](./S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png)
+
+## Evidence Time Audit
+
+| supplement item id | source observed at | source recorded at | source effective from | source effective until | time precision | timezone note | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02-SUP-01` | `2026-02-12` | `2026-02-12` | `unknown` | `unknown` | `day` | `screenshot archive currently preserves one day-level capture date only` | The status-board screenshot was captured on `2026-02-12`; that day currently acts as both the defended observation day and the screenshot recording day, but no second-level timestamp is retained. |
+| `S0A-1A-R02-SUP-02` | `2026-02-12` | `2026-02-12` | `unknown` | `unknown` | `day` | `screenshot archive currently preserves one day-level capture date only` | The table-view screenshot was captured on `2026-02-12`; that day currently acts as both the defended observation day and the screenshot recording day, but no second-level timestamp is retained. |
+| `S0A-1A-R02-SUP-03` | `2026-02-12` | `2026-02-12` | `unknown` | `unknown` | `day` | `screenshot archive currently preserves one day-level capture date only` | The timeline-view screenshot was captured on `2026-02-12`; that day currently acts as both the defended observation day and the screenshot recording day, but no second-level timestamp is retained. |
+
+## Parent-Ledger Rows To Update
+
+- `S0A-1A-R02`: add screenshot-backed supporting evidence and sharpen the row notes so the Projects slice reads as concrete multi-view execution support rather than only generic reprioritization support.
+
+## Contract Changes Deferred Until Parent Write-Back
+
+- `DOC-WORKFLOW-GITHUB-PROJECTS-0001`: if this SUP ledger is accepted, the current draft should be widened to mention at least three common view classes now evidenced directly:
+  - status-board usage
+  - table lookup usage
+  - timeline sequence usage
+
+## Preliminary Reading
+
+- The current three screenshots do not overturn the existing `S0A-1A-R02 -> DOC-WORKFLOW-GITHUB-PROJECTS-0001` routing.
+- They do sharpen the meaning of the Projects child materially enough that the current draft contract likely needs richer wording.
+- The current draft recommendation is therefore:
+  - keep the parent-ledger routing unchanged
+  - add the screenshots as supporting evidence
+  - then rewrite `PROJECTS-0001` after the parent-ledger write-back is accepted
+
+## Reader Notes
+
+- This SUP-001 ledger is now anchored to stable repo-local screenshot paths under the same directory as the ledger file.
+- The attachment inventory and attachment review table now let reviewers open each screenshot directly from the packet and record one bounded approval-facing verdict without turning the main evidence table into an image gallery.
+- The `Attachment Quick Review` section now provides one table-external place to click and visually inspect each screenshot when table-cell link rendering is not sufficient in the active reader surface.
+- The `Actor and Provenance Review Table` now records one minimum packet-level accountability chain for each supplement item without inventing named actors that the surviving historical source cannot defend.
+- If later code, markdown, or process notes show that these views were treated as stable workflow surfaces rather than one temporary board arrangement, a later SUP item may escalate the contract impact further.

--- a/docs/roadmap/road-001-systems-platform-ops-roadmap.md
+++ b/docs/roadmap/road-001-systems-platform-ops-roadmap.md
@@ -14,6 +14,7 @@
   **reference_log_1**: `docs/roadmap/road-template-main-roadmap.md`
 **created**: `2026-03-21`
 **updated**: `2026-03-29`
+**reviewed**: `2026-03-29`
 
 ---
 

--- a/docs/roadmap/road-template-branch-roadmap.md
+++ b/docs/roadmap/road-template-branch-roadmap.md
@@ -14,10 +14,18 @@
   **reference_log_1**: `docs/logs/_template-log-parent-epic-spine.md`
   **reference_log_2**: `docs/logs/_template-log-phase-drills-evidence.md`
   **reference_log_3**: `docs/roadmap/road-template-main-roadmap.md`
-**created**: `2026-03-29`
-**updated**: `2026-03-29`
+**created**: `YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown`
+**updated**: `YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown`
+**reviewed**: `YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|pending`
 
 ---
+
+## Frontmatter Lifecycle-Time Rule
+
+- `created`, `updated`, and optional `reviewed` are the minimum artifact-lifecycle fields for roadmap frontmatter.
+- Prefer canonical UTC-second timestamps such as `2026-04-13T08:15:30Z` when exact repo-side lifecycle audit matters.
+- Legacy day-only values may remain when branch-road maintenance does not yet require second-level precision.
+- `reviewed` should be used only when a branch roadmap enters bounded review rather than ordinary iterative editing.
 
 ## Positioning
 

--- a/docs/roadmap/road-template-main-roadmap.md
+++ b/docs/roadmap/road-template-main-roadmap.md
@@ -13,10 +13,18 @@
   **reference_log_1**: `docs/logs/_template-log-parent-epic-spine.md`
   **reference_log_2**: `docs/logs/_template-log-phase-drills-evidence.md`
   **reference_log_3**: `docs/roadmap/road-template-branch-roadmap.md`
-**created**: `2026-03-29`
-**updated**: `2026-03-29`
+**created**: `YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown`
+**updated**: `YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown`
+**reviewed**: `YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|pending`
 
 ---
+
+## Frontmatter Lifecycle-Time Rule
+
+- `created`, `updated`, and optional `reviewed` are the minimum artifact-lifecycle fields for roadmap frontmatter.
+- Prefer canonical UTC-second timestamps such as `2026-04-13T08:15:30Z` when exact repo-side lifecycle audit matters.
+- Legacy day-only values may remain when roadmap maintenance does not yet require second-level precision.
+- `reviewed` should be used only when a roadmap enters bounded review rather than ordinary iterative editing.
 
 ## Positioning
 


### PR DESCRIPTION
## Metadata

- Requested ID: `S0F-7F`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0f-7f`
- Source log: `docs/logs/log-S0F-7F-log-and-roadmap-frontmatter-minimum-time-fields.md`
- Labels: `EVOLUTION, s0/knowledge system, drills`
- Development issue: #462

## Summary

- Define the minimum frontmatter lifecycle-time fields for logs and roadmap artifacts.
- Land UTC-second and reviewed-state samples where chronology audit actually needs them.
- Keep the time contract minimal enough for routine docs work while still supporting governance replay.

## Execution Checklist

- [x] `P0-C1-S1`: open `S0F-7F` as the log/roadmap frontmatter timing follow-up
- [x] `P0-C1-S2`: fix the minimum sample set before wider migration
- [x] `P1-C1-S1`: define the minimum shared lifecycle-time field set for logs and roadmaps
- [x] `P1-C1-S2`: define compatibility with existing `created` and `updated` fields
- [x] `P2-C1-S1`: update the log template sample
- [x] `P2-C1-S2`: update the main-roadmap and branch-roadmap template samples
- [x] `P4-C1-S1`: add lifecycle fields to `ledger-S0A-1A` and normalize the first Projects SUP file as sequence `001`
- [x] `P4-C1-S2`: add screenshot-backed time audit for the three `2026-02-12` Projects screenshots without overclaiming second-level precision
- [x] `P4-C1-S3`: align `ledger-S0A-1A` and `PROJECTS-0001` to the more complete chronology-first structure already demonstrated by the `S0A-2A` plus `LABS-0002` sample set

## Links

- Log: `docs/logs/log-S0F-7F-log-and-roadmap-frontmatter-minimum-time-fields.md`

Closes #462
