### PR TITLE
S0F-7G/P0-P3: approval-facing screenshot evidence review and attachment protocol

### DIFF
--- a/docs/logs/_template-support-only-contract-release-ledger-SUP.md
+++ b/docs/logs/_template-support-only-contract-release-ledger-SUP.md
@@ -1,0 +1,175 @@
+# support-only-contract-release-ledger-SUP-template
+
+## Purpose
+
+- Use this ledger when later evidence needs to strengthen, sharpen, narrow, revise, or reopen one routing verdict that already lives in an existing source-owned support-only contract-release ledger.
+- This SUP ledger owns `evidence admission, verdict refinement, and parent-ledger write-back recommendation`.
+- Do not use this SUP ledger to bypass the parent ledger and write directly into contracts; the parent ledger remains the owner of source-slice routing.
+
+## Naming Rule
+
+- Name SUP ledgers as `ledger-SUP-<source-id>-<sequence>-<source-summary>.md`.
+- The `<source-id>` must match the attached parent ledger.
+- The `<source-summary>` should summarize the supplement round itself and does not need to duplicate the parent-ledger summary when a narrower evidence packet name is clearer.
+- The `<sequence>` must be one append-only three-digit supplement round such as `001`, `002`, or `003` inside one stable supplement series.
+- Preferred example shapes:
+  - `ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+  - `ledger-SUP-S0B-2A-002-tools-scripts-and-snapshots-management.md`
+
+- The stable parent binding is carried by `supplement_series_id` plus `parent_ledger_id`; readers should not rely on the filename summary alone to infer attachment.
+
+## Minimal Header
+
+```yaml
+support_only_contract_release_ledger_supplement:
+  supplement_series_id: <ledger-SUP-S0A-1A>
+  supplement_sequence: <001>
+  supplement_id: <ledger-SUP-S0A-1A-001-source-summary>
+  supplement_kind: support-only-contract-release-ledger-supplement
+  status: <draft|active|completed>
+  owner_lane: <S0F-7D>
+  created_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  reviewed_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  accepted_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  writeback_started_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  writeback_completed_at: <YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown|pending>
+  parent_ledger_id: <ledger-S0A-1A-source-summary>
+  parent_source_id: <S0A-1A>
+  parent_source_ref: <issue/log/support-only source already owned by the parent ledger>
+  supplement_scope: <what later evidence this supplement is admitting>
+  target_reading_goal: <what later reader should understand after this supplement is applied>
+```
+
+## Lifecycle Field Rule
+
+- `supplement_series_id` is the stable sequence family for repeated supplement rounds attached to one parent source.
+- `supplement_sequence` is the append-only round number inside that series; do not reuse or renumber older rounds once admitted.
+- New writes should use canonical UTC second timestamps such as `2026-04-12T15:18:05Z` for supplement-lifecycle fields.
+- Legacy day-only values may remain when older rounds do not yet have defended second-level audit timestamps.
+- Local-time display belongs in an optional mirror field or prose note only; the canonical stored timestamp should remain UTC when second-level precision is available.
+- `created_at` records when this supplement file was first created in the repo.
+- `reviewed_at` records when this supplement round first reached defended review state.
+- `accepted_at` records when the row-level verdicts are accepted for parent-ledger write-back.
+- `writeback_started_at` records when the accepted parent-ledger or contract write-back begins.
+- `writeback_completed_at` records when that write-back is complete in the repo.
+- These fields are artifact-lifecycle timestamps only; historical-effective rule timing belongs in contract chronology fields, not here.
+
+## Asset and Item Id Rule
+
+- Every SUP row must carry one `supplement_item_id`.
+- Name it as `<parent-row-id>-SUP-<n>`.
+- Every attachment beneath one SUP row must carry one stable `attachment_id`.
+- Use `<supplement-item-id>-ATT-<n>` for generic assets and `<supplement-item-id>-SHOT-<n>` when the asset is specifically a screenshot.
+- When a stable repo-local file exists, the attachment reference should be rendered as one clickable markdown link rather than as bare path prose only.
+
+## Evidence Table Shape
+
+| supplement item id | parent row id | evidence ref | evidence type | attachment ids | verification status | effect on current verdict | proposed parent-ledger action | contract impact | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `<S0A-1A-R02-SUP-01>` | `<S0A-1A-R02>` | `<code path|md path|issue|oral note|other evidence anchor>` | `<code|md|issue|log|oral|screenshot|other>` | `<S0A-1A-R02-SUP-01-SHOT-01>` | `<pending|verified|rejected>` | `<supports-existing|sharpens-existing|narrows-existing|revises-existing|conflicts-needs-review>` | `<no-change|add-supporting-evidence|rewrite-parent-row|split-parent-row|reopen-routing>` | `<none|rewrite-current-draft|open-new-release|defer-contract-change>` | `<why this evidence should or should not change the parent-ledger reading>` |
+
+## Approval-Facing Attachment Review Rule
+
+- Keep the main `Evidence Table` focused on routing and verdict semantics; do not turn it into an image gallery.
+- When screenshot or other attached-file evidence materially supports the SUP verdict, add one `Attachment Review Table`.
+- The attachment ref in that review table should be one clickable markdown link whenever a stable repo-local asset exists.
+- If table-cell rendering is too weak for the active review surface, add one table-external `Attachment Quick Review` block with standalone links and optional inline previews.
+- `review status` records whether the attachment is merely listed, accepted as sufficient for this packet, still too weak, or rejected.
+- `approval basis` should stay short and claim-facing: it explains why the visible attachment is good enough to support the packet judgment.
+- `review note` should stay compact and reviewer-facing: record what was checked, what was visible, or why the evidence is still insufficient.
+
+## Actor and Provenance Field Rule
+
+- When packet-level evidence accountability matters, add one `Actor and Provenance Review Table` beneath the attachment-review surfaces.
+- Keep this field set minimal: `submitted by`, `evidence owner`, `verified by`, `verification method`, `approved by`, `approval state`, and `approval basis`.
+- These fields describe packet-level accountability only; they do not replace the routing verdict, the attachment review record, or any later permissions model.
+- Historical packets may use defended partial values such as `unknown`, `pending`, role-based labels, or delegated labels instead of inventing named actors.
+- Prefer one concise `provenance note` when the actor chain is incomplete but still bounded enough for the packet to remain useful.
+
+## Incomplete-History Representation Rule
+
+- Use `unknown` when the packet cannot currently defend the actor identity.
+- Use `pending` when the actor or state is expected to be filled later but is not yet resolved.
+- Use `role:<role-name>` when the packet can defend the responsible role but not the named person.
+- Use `delegated:<role-name>` when the packet can defend that authority was delegated to one role boundary without yet naming the final actor.
+- Do not fabricate named individuals or over-precise authority chains merely to fill the table.
+- A packet may remain partially specified when the evidence remains useful and the missing actor detail is stated explicitly in `provenance note`.
+
+## Actor and Provenance Review Table
+
+Use this when the packet needs explicit accountability for submission, verification, and approval.
+
+| supplement item id | submitted by | evidence owner | verified by | verification method | approved by | approval state | approval basis | provenance note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `<S0A-1A-R02-SUP-01>` | `<unknown|pending|role:operator|delegated:review-lead|name>` | `<unknown|pending|role:workflow-owner|name>` | `<unknown|pending|role:reviewer|name>` | `<direct-screenshot-inspection|source-path-check|manual-replay|transcript-comparison|other>` | `<unknown|pending|role:approver|delegated:records-lead|name>` | `<pending|accepted-for-packet|needs-better-evidence|rejected>` | `<why this approval state is currently defended>` | `<why any actor fields remain partial or how the current provenance chain is bounded>` |
+
+## Attachment Review Table
+
+Use this when screenshot or other file-backed evidence needs direct reviewer access from the packet.
+
+| attachment id | supplement item id | click-through asset ref | review status | approval basis | review note |
+| --- | --- | --- | --- | --- | --- |
+| `<S0A-1A-R02-SUP-01-SHOT-01>` | `<S0A-1A-R02-SUP-01>` | `[open asset](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)` | `<pending|accepted-for-packet|needs-better-evidence|rejected>` | `<why this attachment is good enough, or not good enough, for the current packet>` | `<what the reviewer checked or what remains missing>` |
+
+## Optional Attachment Quick Review
+
+Use this when reviewers need one table-external place to open or visually inspect attachments directly.
+
+- `Attachment`: `[S0A-1A-R02-SUP-01-SHOT-01](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)`
+- `Preview`:
+
+  ![S0A-1A-R02-SUP-01-SHOT-01 preview](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)
+
+- `Review focus`: `<what the reviewer should confirm from this attachment>`
+
+- Use this block only when direct human review readability matters enough to justify the extra vertical space.
+- Keep the main packet verdict in `Evidence Table` and `Attachment Review Table`; this block is a review aid, not the canonical routing surface.
+
+## Optional Evidence Time Audit
+
+Use this when one supplement row needs explicit audit of source execution time, source recording time, or historical-effective range.
+
+| supplement item id | source observed at | source recorded at | source effective from | source effective until | time precision | timezone note | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `<S0A-1A-R02-SUP-01>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|unknown>` | `<YYYY-MM-DDTHH:MM:SSZ|YYYY-MM-DD|ongoing|unknown>` | `<second|day|month|year|unknown>` | `<optional source-local zone or offset note>` | `<why this evidence time audit matters>` |
+
+- `source observed at` is the best known time the evidence event, experiment, or source snapshot was executed or observed.
+- `source recorded at` is the best known time the evidence document itself was written or admitted.
+- `source effective from` and `source effective until` describe the best known historical-effective range for the rule signal carried by that evidence row.
+- `time precision` must remain evidence-bound; if the source proves only a day, keep `day` rather than inventing seconds.
+
+## Required Rules
+
+- Every SUP row must point to one existing `parent row id`; a SUP ledger may not invent free-floating new slices.
+- `supplement_item_id` is required for every admitted evidence item.
+- `attachment ids` should stay empty when no attached asset is needed; when assets exist, each asset should receive one stable id rather than being referenced only by prose.
+- Screenshot-backed verdicts should prefer one `Attachment Review Table` row per attachment whenever direct reviewer click-through matters.
+- When table-cell links are not sufficiently reviewable in the active editor or preview surface, prefer adding one `Attachment Quick Review` section rather than overloading the main evidence tables.
+- When actor/provenance accountability matters, prefer one `Actor and Provenance Review Table` row per supplement item rather than scattering those fields across prose notes.
+- `verification status` records whether the evidence is merely proposed, verified enough for judgment, or rejected for this SUP round.
+- `effect on current verdict` states how the admitted evidence relates to the current parent-ledger judgment.
+- `proposed parent-ledger action` states what the parent ledger should do if that effect is accepted.
+- `contract impact` is downstream-only guidance; it may not be applied before the parent ledger is updated or explicitly left unchanged.
+
+## Escalation Rule
+
+- When the effect is `supports-existing` or `sharpens-existing`, prefer `add-supporting-evidence` or another minimal parent-ledger write-back.
+- When the effect is `narrows-existing` or `revises-existing`, prefer `rewrite-parent-row` or `split-parent-row` before any contract rewrite.
+- When the effect is `conflicts-needs-review`, prefer `reopen-routing`; do not write directly into contract release fields.
+- If a SUP row cannot be tied to one existing parent row id, open a new bounded source or continuation packet instead of forcing the evidence into this SUP ledger.
+
+## Completion Rule
+
+- A SUP ledger may be marked `completed` only when every admitted evidence row has one explicit `verification status` and one explicit proposed parent-ledger action.
+- A SUP ledger is not complete merely because evidence has been collected; the row verdicts must be explicit.
+
+## Optional Rollup
+
+- `parent-ledger rows to update`:
+  - list the exact parent row ids that should be rewritten or supplemented
+- `attachment inventory`:
+  - list screenshot, transcript, export, or similar asset ids admitted in this round
+- `contract changes deferred until parent write-back`:
+  - list any contract records that may need change only after the parent ledger is updated
+- `rejected evidence`:
+  - list proposed evidence rows that were intentionally not admitted in this round

--- a/docs/logs/log-S0F-7G-approval-facing-screenshot-evidence-review-and-attachment-protocol.md
+++ b/docs/logs/log-S0F-7G-approval-facing-screenshot-evidence-review-and-attachment-protocol.md
@@ -1,0 +1,227 @@
+# log-S0F-7G (Phase 7G: approval-facing screenshot evidence review and attachment protocol)
+
+---
+
+**id**: `S0F-7G`
+**kind**: `log`
+**title**: `approval-facing screenshot evidence review and attachment protocol`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Governance, Evidence, Records, epic/s0, sub/7g`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-7F-log-and-roadmap-frontmatter-minimum-time-fields.md`
+  **reference_log_1**: `docs/logs/log-S0F-7F-log-and-roadmap-frontmatter-minimum-time-fields.md`
+  **reference_log_2**: `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  **reference_log_3**: `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  **reference_log_4**: `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+**issue_keyword**: `evidence`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/7`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-13`
+**updated**: `2026-04-13`
+
+---
+
+## Frontmatter Lifecycle-Time Rule
+
+- `created`, `updated`, and optional `reviewed` are the minimum artifact-lifecycle fields for this log.
+- Day-level values remain acceptable for this scaffold because the lane is being opened as one bounded governance design packet rather than one second-precision operational run.
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-7G` opens as the bounded follow-up after `S0F-7F` for one narrower evidence-governance problem: screenshot-backed supplement packets are now structurally traceable, but approval and review still remain awkward when the reviewer cannot directly open, inspect, and judge the attached evidence from the packet itself.
+- This lane will first define one approval-facing attachment and screenshot review protocol for supplement-ledger packets; it will not yet widen into a repo-wide actor/authority/provenance control plane.
+
+**Default choices (phase defaults / v1)**:
+
+- Keep the first landing surface inside supplement-ledger packets rather than trying to retrofit every log, roadmap, and contract immediately.
+- Prefer stable attachment ids plus clickable repo-local asset refs over embedding full screenshots directly into the main evidence tables.
+- Add review-facing structure only where it materially improves packet readability: attachment access, concise reviewer notes, approval state, and defended basis for acceptance or rejection.
+- Keep asset review separate from historical-effective time: screenshot visibility solves evidence readability, not chronology semantics.
+- Defer actor-rich provenance fields such as `submitted_by`, `verified_by`, and `approved_by` unless the attachment-review pilot proves that review usability alone is still insufficient.
+
+## Minimum Quick Review Contract
+
+- When one SUP packet contains screenshot-backed evidence that must be reviewed directly by a human, keep the routing verdict in `Evidence Table` and keep approval-facing judgment in `Attachment Review Table`.
+- Stable repo-local assets should be exposed as clickable markdown links, not as bare path prose only.
+- When the active reader surface makes table-cell links or markdown rendering too weak for practical review, the SUP packet may add one table-external `Attachment Quick Review` section with standalone attachment links and optional inline previews.
+- `Attachment Quick Review` is one review aid only; it does not replace `Evidence Table`, `Attachment Review Table`, or parent-ledger routing semantics.
+- This lane does not require actor-rich provenance fields; those belong to a later bounded follow-up if reviewability alone proves insufficient.
+
+## Problem Statement
+
+- `S0F-7D` and `S0F-7F` now let the repo admit screenshot evidence through one parent-ledger plus SUP chain, but the current packet shape still assumes that attachment ids and file paths alone are enough for approval-facing review.
+- In practice, that leaves one missing governance surface:
+  - reviewers need one consistent way to open the image evidence quickly from the packet
+  - reviewers need one bounded place to record what was actually checked or why one screenshot was accepted, rejected, or left pending
+  - the repo still needs to avoid bloating the main evidence tables into image galleries or mixing screenshot review with broader provenance-actor governance too early
+- The repo therefore needs one narrow follow-up lane that answers three questions before any broader approval model is attempted:
+  - what minimum supplement-ledger structure makes screenshot evidence directly reviewable
+  - how attachment ids and repo-local asset refs should be rendered so reviewers can click through without ambiguity
+  - which smallest live packet should prove the protocol before any repo-wide adoption rule is declared
+
+## Exported Sections / Outlet Ownership
+
+- This slice starts as one `support-only ledger + template + log-retained core` governance-design lane.
+- The expected first landing is one supplement-ledger review protocol and one sample packet update that proves approval-facing readability without changing contract ownership.
+
+**Outlet ownership**:
+
+- `contract`: the minimum quick-review contract remains written here in `S0F-7G`; do not emit a separate contract file from this lane yet
+- `runbook`: no-op by default
+- `view`: no-op by default; a future reviewer-facing evidence index may emerge later, but it is not assumed here
+- `index/front-door`: no-op by default
+- `disposition/placement`: supplement-ledger template and pilot packets are the first mutable landing surfaces
+- `log-retained core`: lane boundary, review protocol, pilot verdicts, and any deferred provenance expansion stay here
+
+## Definitions (optional)
+
+- `approval-facing screenshot review`: the minimum structure that lets a reviewer open an image asset, understand what claim it is supposed to prove, and record a bounded judgment.
+- `click-through attachment ref`: one repo-local asset path or equivalent stable ref presented so the reviewer can open the evidence directly from the packet.
+- `attachment review note`: one compact reviewer-facing note that records what was checked, what was visible, or why the evidence was accepted, rejected, or deferred.
+- `approval basis`: the concise rationale connecting the visible attachment evidence to the packet verdict.
+
+## Constraints
+
+- Do not embed full screenshots directly into the main supplement evidence table by default.
+- Do not reopen the chronology model; this lane is about reviewability of attachments, not new time semantics.
+- Do not widen immediately into full actor / authority / organization provenance fields unless the first attachment-review pilot proves that narrower review structure is insufficient.
+- Do not break existing supplement naming, attachment-id, or parent-ledger binding rules.
+
+## Scope
+
+- `P0`: open `S0F-7G` and bound the problem to approval-facing screenshot evidence review inside supplement-ledger packets
+- `P1`: define the minimum attachment review protocol, including clickable asset refs, review-note shape, and approval-state semantics
+- `P2`: apply the protocol to one first live sample, expected first on `ledger-SUP-S0A-1A-001`
+- `P3`: decide whether reviewer/approver actor fields are truly needed next or should remain deferred to a later provenance-governance lane
+
+## Success Criteria (DoD)
+
+- The repo has one explicit minimum rule for making screenshot evidence directly reviewable from a supplement packet.
+- The repo has one explicit rule for how attachment refs should appear so reviewers can click through to the source asset without ambiguity.
+- The repo has one bounded reviewer-facing note or approval-basis surface that records what was actually checked without turning supplement packets into image galleries.
+- The repo proves the protocol on one live packet before declaring wider adoption.
+- Any broader actor/provenance governance expansion is either explicitly deferred or opened as a separate bounded lane.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - the minimum attachment-review protocol is explicitly written
+  - one live supplement packet demonstrates the protocol cleanly
+  - the lane records whether actor-rich provenance or approval-role fields are still needed next or should remain deferred
+- `stable` does not require repo-wide migration; one accepted sample-first protocol is sufficient.
+
+## P0 (Lane boundary | v1)
+
+### P0-C1-S1 (Open `S0F-7G` as the screenshot-review follow-up)
+
+- Open one bounded follow-up lane after `S0F-7F` for approval-facing screenshot evidence review and attachment readability.
+
+### P0-C1-S2 (Fix the first landing surface before wider governance expansion)
+
+- The first mutable landing surface is the supplement-ledger template plus one first live packet rather than a repo-wide frontmatter rewrite.
+
+## Plan (draft)
+
+### P1 (Minimum attachment review protocol)
+
+- `P1-C1-S1`: define how attachment refs should be rendered for click-through review
+- `P1-C1-S2`: define one minimum review-note and approval-basis surface for screenshot evidence rows
+
+### P2 (First live packet pilot)
+
+- `P2-C1-S1`: patch the supplement-ledger template with the approved review protocol
+- `P2-C1-S2`: apply the protocol to `ledger-SUP-S0A-1A-001` as the first live screenshot-review sample
+
+### P3 (Deferred provenance decision)
+
+- `P3-C1-S1`: decide whether actor-rich provenance or approval-role fields are actually required next
+
+## Execution Checklist (unchecked)
+
+### P0 (Lane boundary)
+
+- [x] `P0-C1-S1`: open `S0F-7G` as the screenshot-review follow-up
+- [x] `P0-C1-S2`: fix the first landing surface before wider governance expansion
+
+### P1 (Minimum attachment review protocol)
+
+- [x] `P1-C1-S1`: define how attachment refs should be rendered for click-through review
+- [x] `P1-C1-S2`: define one minimum review-note and approval-basis surface for screenshot evidence rows
+
+### P2 (First live packet pilot)
+
+- [x] `P2-C1-S1`: patch the supplement-ledger template with the approved review protocol
+- [x] `P2-C1-S2`: apply the protocol to `ledger-SUP-S0A-1A-001` as the first live screenshot-review sample
+
+### P3 (Deferred provenance decision)
+
+- [x] `P3-C1-S1`: decide whether actor-rich provenance or approval-role fields are actually required next
+
+## Current Status (recommended)
+
+- `S0F-7G` is now opened as the bounded follow-up after `S0F-7F` for approval-facing screenshot evidence review and attachment click-through structure.
+- The lane is intentionally scoped to supplement-ledger readability first; it does not yet commit the repo to a broader provenance / actor / authority model.
+- `P1-C1-S1` is now complete: the SUP protocol now requires click-through markdown links for stable repo-local assets instead of relying on bare path prose only.
+- `P1-C1-S2` is now complete: the SUP protocol now defines one minimum `Attachment Review Table` with `review status`, `approval basis`, and `review note` as the approval-facing review surface.
+- `P2-C1-S1` is now complete: the SUP template now exposes the attachment-review protocol without disturbing the existing routing-focused evidence table.
+- `P2-C1-S2` is now complete: `ledger-SUP-S0A-1A-001` now proves the protocol on three live screenshot rows, each with one direct click-through link and one bounded approval-facing review record.
+- `P3-C1-S1` is now complete: actor-rich reviewer / approver provenance fields remain deferred because the narrower reviewability problem is now handled by the attachment-review protocol plus one table-external quick-review surface.
+- The next step is to judge whether this narrower screenshot-review protocol is now stable enough to retain as-is or whether a later separate lane should open specifically for provenance / authority actors.
+
+## Evidence (reserved)
+
+- Artifacts are the source of truth for evidence; this log records the head SHA, key parameters, and artifact paths when the lane starts mutating templates or live supplement packets.
+- This section stays empty until the first template or pilot patch is actually landed.
+
+### P1-C1-S1S2 + P2-C1-S1S2 (Minimum screenshot-review protocol and first live packet pilot fixed | 2026-04-13)
+
+- headSha: `e4671f222`
+
+- artifacts:
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+  - `docs/logs/log-S0F-7G-approval-facing-screenshot-evidence-review-and-attachment-protocol.md`
+- expected:
+  - screenshot-backed SUP packets should expose one direct click-through path to stable repo-local image assets instead of forcing reviewers to copy bare file paths manually
+  - approval-facing review should stay compact and packet-local, using one bounded review surface rather than turning the main evidence table into an embedded image gallery
+  - the first live packet should prove that screenshot evidence can carry `review status`, `approval basis`, and `review note` without reopening broader actor or provenance modeling
+- observed:
+  - the SUP template now requires clickable markdown links for stable repo-local attachments and defines one dedicated `Attachment Review Table` for approval-facing review
+  - `ledger-SUP-S0A-1A-001` now exposes direct click-through links for all three screenshot assets and records one bounded review row for each attachment
+  - the live pilot proves that packet-level screenshot review can be made directly readable without changing the chronology model or introducing actor-rich provenance fields yet
+
+### P3-C1-S1 (Actor-rich provenance decision deferred; quick-review surface added | 2026-04-13)
+
+- headSha: `f02c1c3eb`
+
+- artifacts:
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+  - `docs/logs/log-S0F-7G-approval-facing-screenshot-evidence-review-and-attachment-protocol.md`
+- expected:
+  - the lane should decide whether actor-rich provenance fields are truly needed now or whether the narrower reviewability problem is already solved by better attachment access and review ergonomics
+  - if table-cell link rendering proves too weak, the packet should expose one table-external review surface rather than forcing a bigger provenance-field expansion
+- observed:
+  - the current attachment-review protocol is sufficient for the bounded screenshot-review problem, so actor-rich provenance fields remain deferred for now
+  - the SUP template and live pilot now also expose one `Attachment Quick Review` section with standalone links and inline previews, making the screenshots directly visible and easier to open from the packet outside the tables

--- a/docs/logs/log-S0F-7H-actor-and-provenance-fields-for-evidence-review-governance.md
+++ b/docs/logs/log-S0F-7H-actor-and-provenance-fields-for-evidence-review-governance.md
@@ -1,0 +1,229 @@
+# log-S0F-7H (Phase 7H: actor and provenance fields for evidence review governance)
+
+---
+
+**id**: `S0F-7H`
+**kind**: `log`
+**title**: `actor and provenance fields for evidence review governance`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Governance, Evidence, Records, epic/s0, sub/7h`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-7G-approval-facing-screenshot-evidence-review-and-attachment-protocol.md`
+  **reference_log_1**: `docs/logs/log-S0F-7G-approval-facing-screenshot-evidence-review-and-attachment-protocol.md`
+  **reference_log_2**: `docs/logs/log-S0F-7D-ledger-supplement-admission-and-old-log-continuation.md`
+  **reference_log_3**: `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  **reference_log_4**: `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+**issue_keyword**: `records`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/7`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M5`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-13`
+**updated**: `2026-04-13`
+
+---
+
+## Frontmatter Lifecycle-Time Rule
+
+- `created`, `updated`, and optional `reviewed` are the minimum artifact-lifecycle fields for this log.
+- Day-level values remain acceptable for this scaffold because the lane is being opened as one bounded governance design packet rather than one second-precision operational run.
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-7H` opens as the bounded follow-up after `S0F-7G` for one narrower governance problem: once screenshot and attachment review is readable, the next missing boundary is who submitted evidence, who verified it, who approved it, and what provenance chain currently defends that judgment.
+- This lane will define a minimum actor/provenance field set for evidence-review packets first; it will not widen into a full org-role or permissions model yet.
+
+**Default choices (phase defaults / v1)**:
+
+- Keep the first landing surface inside supplement-ledger packets rather than retrofitting every document class at once.
+- Separate review ergonomics from authority/provenance semantics: `7G` already solved readable attachment review, while `7H` should solve actor and provenance accountability.
+- Prefer a minimum field set first, such as `submitted_by`, `evidence_owner`, `verified_by`, `verification_method`, `approved_by`, `approval_state`, and `approval_basis`, before considering wider org-interface fields.
+- Avoid guessing real-world actors when the historical packet cannot yet defend them; `unknown`, `pending`, or bounded notes remain valid.
+- Keep role/authority escalation explicit and deferred until the minimum field set proves insufficient.
+
+## Minimum Actor / Provenance Contract
+
+- Supplement-ledger evidence review may add one minimal accountability surface using `submitted by`, `evidence owner`, `verified by`, `verification method`, `approved by`, `approval state`, and `approval basis`.
+- These fields describe packet-level submission, verification, and approval only; they do not by themselves establish a full permissions or org-authority model.
+- The packet may add one short `provenance note` when the current accountability chain is only partially defended.
+- This lane treats role-based or delegated values as valid intermediate states when the historical packet cannot yet defend one named actor.
+
+## Problem Statement
+
+- `S0F-7G` solved the narrower screenshot-reviewability problem, but it intentionally deferred one next governance question: approval-facing packets still need a consistent way to name who submitted evidence, who verified it, how it was verified, who approved it, and what provenance chain currently supports that approval state.
+- Without one minimum actor/provenance protocol, the repo still risks mixing several different concerns:
+  - evidence readability
+  - evidence accountability
+  - approval authority
+  - provenance traceability
+- The repo therefore needs one bounded lane that answers three questions before broader governance expansion:
+  - what the minimum actor/provenance field set should be for supplement-ledger evidence review
+  - how those fields should be recorded when historical packets cannot fully defend named actors yet
+  - which smallest live packet should prove the protocol before any wider rollout is declared
+
+## Exported Sections / Outlet Ownership
+
+- This slice starts as one `support-only ledger + template + log-retained core` governance-design lane.
+- The expected first landing is one minimum actor/provenance field contract for evidence-review packets plus one live pilot.
+
+**Outlet ownership**:
+
+- `contract`: the minimum actor/provenance field contract remains written here in `S0F-7H` until the repo actually needs a separate evidence-governance contract surface
+- `runbook`: no-op by default
+- `view`: no-op by default
+- `index/front-door`: no-op by default
+- `disposition/placement`: supplement-ledger template and pilot packets are the first mutable landing surfaces
+- `log-retained core`: lane boundary, field contract, pilot verdicts, and deferred authority questions stay here
+
+## Definitions (optional)
+
+- `submitted_by`: the actor or source channel that first supplied the evidence into the review packet.
+- `evidence_owner`: the actor or role currently accountable for the evidence item being maintained or defended.
+- `verified_by`: the actor or role that checked the evidence closely enough for packet-level judgment.
+- `verification_method`: the bounded method used for verification, such as direct screenshot inspection, source-path check, transcript comparison, or manual replay.
+- `approved_by`: the actor or role that accepted the evidence for packet-level use.
+- `approval_state`: the current packet-level judgment state for the evidence row.
+- `approval_basis`: the concise rationale that explains why the approval state is currently defended.
+
+## Constraints
+
+- Do not collapse actor/provenance fields back into attachment ergonomics; `7G` already owns the narrower screenshot-review surface.
+- Do not invent named people or authority chains when the packet cannot defend them.
+- Do not widen immediately into permissions, org charts, or enterprise approval workflow modeling.
+- Do not break existing supplement naming, attachment-id, or parent-ledger binding rules.
+
+## Scope
+
+- `P0`: open `S0F-7H` and bound the problem to minimum actor/provenance fields for evidence-review packets
+- `P1`: define the minimum actor/provenance field set and its semantics for supplement-ledger packets
+- `P2`: decide how unknown, pending, delegated, or role-based values should be represented when evidence history is incomplete
+- `P3`: apply the protocol to one first live sample, expected first on `ledger-SUP-S0A-1A-001`
+
+## Success Criteria (DoD)
+
+- The repo has one explicit minimum actor/provenance field contract for evidence-review packets.
+- The repo has one explicit representation rule for incomplete or historically under-defended actor/provenance data.
+- The repo proves the protocol on one bounded live packet before wider rollout.
+- Broader authority or permissions modeling remains explicitly deferred unless the minimum field set proves insufficient.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - the minimum actor/provenance field contract is explicitly written
+  - one live packet demonstrates the protocol cleanly
+  - the lane records whether broader authority modeling is still needed next or remains deferred
+- `stable` does not require repo-wide rollout; one accepted sample-first protocol is sufficient.
+
+## P0 (Lane boundary | v1)
+
+### P0-C1-S1 (Open `S0F-7H` as the actor/provenance follow-up)
+
+- Open one bounded follow-up lane after `S0F-7G` for actor/provenance fields around evidence submission, verification, and approval.
+
+### P0-C1-S2 (Keep the first landing surface inside SUP packets)
+
+- The first mutable landing surface remains the supplement-ledger template plus one live packet rather than a repo-wide frontmatter rewrite.
+
+## Plan (draft)
+
+### P1 (Minimum actor/provenance field contract)
+
+- `P1-C1-S1`: define the minimum actor/provenance field set for evidence-review packets
+- `P1-C1-S2`: define the semantics for each field without assuming a full org-role model
+
+### P2 (Incomplete-history representation rule)
+
+- `P2-C1-S1`: define how `unknown`, `pending`, role-based, or delegated values should be represented
+- `P2-C1-S2`: define when the packet may stay partial rather than fabricating actor certainty
+
+### P3 (First live packet pilot)
+
+- `P3-C1-S1`: patch the supplement-ledger template with the approved actor/provenance protocol
+- `P3-C1-S2`: apply the protocol to `ledger-SUP-S0A-1A-001` as the first live sample
+
+## Execution Checklist (unchecked)
+
+### P0 (Lane boundary)
+
+- [x] `P0-C1-S1`: open `S0F-7H` as the actor/provenance follow-up
+- [x] `P0-C1-S2`: keep the first landing surface inside SUP packets
+
+### P1 (Minimum actor/provenance field contract)
+
+- [x] `P1-C1-S1`: define the minimum actor/provenance field set for evidence-review packets
+- [x] `P1-C1-S2`: define the semantics for each field without assuming a full org-role model
+
+### P2 (Incomplete-history representation rule)
+
+- [x] `P2-C1-S1`: define how `unknown`, `pending`, role-based, or delegated values should be represented
+- [x] `P2-C1-S2`: define when the packet may stay partial rather than fabricating actor certainty
+
+### P3 (First live packet pilot)
+
+- [x] `P3-C1-S1`: patch the supplement-ledger template with the approved actor/provenance protocol
+- [x] `P3-C1-S2`: apply the protocol to `ledger-SUP-S0A-1A-001` as the first live sample
+
+## Current Status (recommended)
+
+- `S0F-7H` is now opened as the bounded follow-up after `S0F-7G` for actor/provenance fields around evidence submission, verification, and approval.
+- The lane is intentionally scoped to supplement-ledger accountability first; it does not yet commit the repo to a broader org-role or permissions model.
+- `P1-C1-S1` is now complete: the lane now defines the minimum actor/provenance field set for evidence-review packets as `submitted by`, `evidence owner`, `verified by`, `verification method`, `approved by`, `approval state`, and `approval basis`.
+- `P1-C1-S2` is now complete: the lane now states that these fields record packet-level accountability only and do not yet establish a full permissions or org-authority model.
+- `P2-C1-S1` is now complete: the lane now defines `unknown`, `pending`, `role:<role-name>`, and `delegated:<role-name>` as the bounded representation grammar for incomplete actor history.
+- `P2-C1-S2` is now complete: the lane now permits partial actor/provenance rows when the packet stays useful and the missing detail is stated explicitly in one `provenance note`.
+- `P3-C1-S1` is now complete in workspace: the SUP template now exposes the actor/provenance protocol as one dedicated accountability surface separate from attachment-review ergonomics.
+- `P3-C1-S2` is now complete in workspace: `ledger-SUP-S0A-1A-001` now proves the protocol on three live supplement items using defended partial actor values rather than invented named submitters.
+- The next step is to review whether this minimum packet-level accountability chain is already sufficient or whether a later lane should widen into stronger authority-role or org-level provenance modeling.
+
+## Evidence (reserved)
+
+- Artifacts are the source of truth for evidence; this log records the head SHA, key parameters, and artifact paths when the lane starts mutating templates or live supplement packets.
+- This section stays empty until the first template or pilot patch is actually landed.
+
+### P1-C1-S1S2 + P2-C1-S1S2 (Minimum actor/provenance contract and incomplete-history rule fixed in workspace | 2026-04-13)
+
+- headSha: `92c223458`
+
+- artifacts:
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  - `docs/logs/log-S0F-7H-actor-and-provenance-fields-for-evidence-review-governance.md`
+- expected:
+  - the repo should define one minimum actor/provenance field set for evidence-review packets without dragging in a full permissions or org-model rewrite
+  - the protocol should state how to represent incomplete actor history using explicit bounded values instead of fabricated named actors
+- observed:
+  - the SUP template now defines one `Actor and Provenance Review Table` with the minimum packet-level accountability fields
+  - the lane now records `unknown`, `pending`, `role:<role-name>`, and `delegated:<role-name>` as the approved grammar for incomplete actor history, plus one `provenance note` when the chain remains partial but still usable
+
+### P3-C1-S1S2 (First live actor/provenance pilot fixed in workspace | 2026-04-13)
+
+- headSha: `aa4bf42d8`
+
+- artifacts:
+  - `docs/logs/_template-support-only-contract-release-ledger-SUP.md`
+  - `docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md`
+  - `docs/logs/log-S0F-7H-actor-and-provenance-fields-for-evidence-review-governance.md`
+- expected:
+  - the live pilot should prove that the minimum actor/provenance protocol can be applied without inventing named actors the historical packet cannot actually defend
+  - the sample should show one bounded accountability chain per supplement item while staying separate from the narrower screenshot-review ergonomics already solved in `7G`
+- observed:
+  - `ledger-SUP-S0A-1A-001` now exposes one `Actor and Provenance Review Table` for all three supplement items
+  - the pilot uses defended partial values such as `unknown` and `role:packet-reviewer` rather than fabricating historical named submitters, while still recording one explicit packet-level approval state and provenance note for each item

--- a/docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md
+++ b/docs/logs/support-only/ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags.md
@@ -1,0 +1,120 @@
+# ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags
+
+```yaml
+support_only_contract_release_ledger_supplement:
+  supplement_series_id: ledger-SUP-S0A-1A
+  supplement_sequence: 001
+  supplement_id: ledger-SUP-S0A-1A-001-tools-github-issues-projects-and-tags
+  supplement_kind: support-only-contract-release-ledger-supplement
+  status: completed
+  owner_lane: S0F-7D
+  created_at: 2026-04-11
+  reviewed_at: 2026-04-11
+  accepted_at: 2026-04-11
+  writeback_started_at: 2026-04-11
+  writeback_completed_at: 2026-04-11
+  parent_ledger_id: ledger-S0A-1A-tools-github-issues-projects-and-tags
+  parent_source_id: S0A-1A
+  parent_source_ref: GitHub issue S0A-1A (#23) (issue-only source; no local log exists in workspace)
+  supplement_scope: first screenshot-backed SUP for the Projects slice under S0A-1A, covering status-board usage, table lookup usage, and timeline-sequence usage
+  target_reading_goal: show whether later screenshot evidence sharpens the existing Projects routing verdict enough to justify richer wording in the current Projects child draft without reopening the parent-ledger routing boundary
+```
+
+## Decision Frame
+
+- This SUP ledger is attached only to parent row `S0A-1A-R02`.
+- The current draft judgment is that the three screenshots do not challenge the existing routing of the Projects slice into `DOC-WORKFLOW-GITHUB-PROJECTS-0001`.
+- The current review question is narrower:
+  - do these screenshots merely support the current Projects child
+  - or do they sharpen the current draft enough that the child contract should describe concrete common views rather than only generic execution-time support
+
+## Evidence Table
+
+| supplement item id | parent row id | evidence ref | evidence type | attachment ids | verification status | effect on current verdict | proposed parent-ledger action | contract impact | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02-SUP-01` | `S0A-1A-R02` | `docs/logs/support-only/S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png` | `screenshot` | `S0A-1A-R02-SUP-01-SHOT-01` | `verified` | `sharpens-existing` | `add-supporting-evidence` | `rewrite-current-draft` | The screenshot shows four explicit operating states under Projects usage: `Doing` with a visible WIP guard, `Done` as the recent-deliverable landing, `Backlog` as temporary defer-without-overloading current work, and `Blocked` as active stop-or-reroute handling. This sharpens the existing Projects reading from generic reprioritization support into one operator-facing execution-status surface. |
+| `S0A-1A-R02-SUP-02` | `S0A-1A-R02` | `docs/logs/support-only/S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png` | `screenshot` | `S0A-1A-R02-SUP-02-SHOT-01` | `verified` | `sharpens-existing` | `add-supporting-evidence` | `rewrite-current-draft` | The screenshot shows one high-utility lookup view where operators can find items quickly by title, id, labels, completion state, linked PR, and assignee information. This sharpens the current Projects reading by showing that Projects is not only for reprioritization but also for everyday discovery and current-state scanning. |
+| `S0A-1A-R02-SUP-03` | `S0A-1A-R02` | `docs/logs/support-only/S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png` | `screenshot` | `S0A-1A-R02-SUP-03-SHOT-01` | `verified` | `sharpens-existing` | `add-supporting-evidence` | `rewrite-current-draft` | The screenshot shows one timeline-oriented reading used to understand delivery ordering and visible insertion into the current work stream. This sharpens the current Projects reading by adding sequence and interruption-awareness to the existing execution-support boundary, while still staying below canonical issue-hierarchy ownership. |
+
+## Attachment Inventory
+
+| attachment id | supplement item id | asset type | asset ref or description | key text transcription | proving claim | anchor ref | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02-SUP-01-SHOT-01` | `S0A-1A-R02-SUP-01` | `screenshot` | `[open asset](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)` | `Doing`, `WIP <= 5`, `Done`, `most recent deliverables!`, `Backlog`, `This item has been backlogged`, `Blocked`, `This item has been blocked` | Projects is used as one active execution-status surface with concrete operating columns rather than only one abstract prioritization aid | `S0A-1A-R02` | Stable repo-local screenshot path now exists and is directly reviewable from this packet. |
+| `S0A-1A-R02-SUP-02-SHOT-01` | `S0A-1A-R02-SUP-02` | `screenshot` | `[open asset](./S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png)` | `Title`, `Sub-issues progress`, `Status`, `Linked pull req...`, `Assignees` | Projects is used as one fast lookup and daily reading surface for issue identity, completion state, PR linkage, and assignment context | `S0A-1A-R02` | Stable repo-local screenshot path now exists and is directly reviewable from this packet. |
+| `S0A-1A-R02-SUP-03-SHOT-01` | `S0A-1A-R02-SUP-03` | `screenshot` | `[open asset](./S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png)` | `Timeline`, `March 2026`, `April 2026`, item rows arranged against dates | Projects is used as one sequence and insertion-order reading surface, helping operators understand completion ordering and interruption timing | `S0A-1A-R02` | Stable repo-local screenshot path now exists and is directly reviewable from this packet. |
+
+## Attachment Review Table
+
+| attachment id | supplement item id | click-through asset ref | review status | approval basis | review note |
+| --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02-SUP-01-SHOT-01` | `S0A-1A-R02-SUP-01` | `[open asset](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)` | `accepted-for-packet` | The visible column layout and captured labels are sufficient to defend the claim that Projects is serving as one operator-facing execution-status board. | Review checked the screenshot for explicit state-column wording plus the visible WIP constraint, and no contradiction to the current `sharpens-existing` verdict was found. |
+| `S0A-1A-R02-SUP-02-SHOT-01` | `S0A-1A-R02-SUP-02` | `[open asset](./S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png)` | `accepted-for-packet` | The visible table headers are sufficient to defend the claim that Projects is serving as one quick lookup surface for delivery-state reading. | Review checked the screenshot for issue-title, progress, status, PR-link, and assignee columns, and the captured UI is strong enough for the current packet claim without needing a broader governance inference. |
+| `S0A-1A-R02-SUP-03-SHOT-01` | `S0A-1A-R02-SUP-03` | `[open asset](./S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png)` | `accepted-for-packet` | The visible date-grid layout is sufficient to defend the claim that Projects is being used as one sequencing and interruption-reading surface. | Review checked the screenshot for the dated timeline layout and item placement across time, and the image is sufficient for the current sequence-awareness reading while still staying below canonical issue-hierarchy ownership. |
+
+## Actor and Provenance Review Table
+
+| supplement item id | submitted by | evidence owner | verified by | verification method | approved by | approval state | approval basis | provenance note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02-SUP-01` | `unknown` | `role:packet-maintainer` | `role:packet-reviewer` | `direct-screenshot-inspection` | `role:packet-reviewer` | `accepted-for-packet` | The current packet preserves enough screenshot evidence and review notes to defend the status-board claim at packet level. | The screenshot is preserved in-repo and the packet review chain is explicit, but the original named submitter is not defended by the surviving issue-only source history. |
+| `S0A-1A-R02-SUP-02` | `unknown` | `role:packet-maintainer` | `role:packet-reviewer` | `direct-screenshot-inspection` | `role:packet-reviewer` | `accepted-for-packet` | The current packet preserves enough screenshot evidence and review notes to defend the quick-lookup claim at packet level. | The screenshot is preserved in-repo and the packet review chain is explicit, but the original named submitter is not defended by the surviving issue-only source history. |
+| `S0A-1A-R02-SUP-03` | `unknown` | `role:packet-maintainer` | `role:packet-reviewer` | `direct-screenshot-inspection` | `role:packet-reviewer` | `accepted-for-packet` | The current packet preserves enough screenshot evidence and review notes to defend the sequence-awareness claim at packet level. | The screenshot is preserved in-repo and the packet review chain is explicit, but the original named submitter is not defended by the surviving issue-only source history. |
+
+## Attachment Quick Review
+
+### S0A-1A-R02-SUP-01-SHOT-01
+
+- Attachment: [S0A-1A-R02-SUP-01-SHOT-01](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)
+- Review focus: confirm that the screenshot visibly supports the execution-status reading through explicit state columns and the WIP guard.
+
+![S0A-1A-R02-SUP-01-SHOT-01 preview](./S0A-1A-R02-SUP-01-SHOT-01-projects-status-board.png)
+
+### S0A-1A-R02-SUP-02-SHOT-01
+
+- Attachment: [S0A-1A-R02-SUP-02-SHOT-01](./S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png)
+- Review focus: confirm that the screenshot visibly supports the quick-lookup reading through title, progress, status, PR-link, and assignee columns.
+
+![S0A-1A-R02-SUP-02-SHOT-01 preview](./S0A-1A-R02-SUP-02-SHOT-01-projects-table-view.png)
+
+### S0A-1A-R02-SUP-03-SHOT-01
+
+- Attachment: [S0A-1A-R02-SUP-03-SHOT-01](./S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png)
+- Review focus: confirm that the screenshot visibly supports the sequence-awareness reading through the dated timeline layout and item placement across time.
+
+![S0A-1A-R02-SUP-03-SHOT-01 preview](./S0A-1A-R02-SUP-03-SHOT-01-projects-timeline-view.png)
+
+## Evidence Time Audit
+
+| supplement item id | source observed at | source recorded at | source effective from | source effective until | time precision | timezone note | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S0A-1A-R02-SUP-01` | `2026-02-12` | `2026-02-12` | `unknown` | `unknown` | `day` | `screenshot archive currently preserves one day-level capture date only` | The status-board screenshot was captured on `2026-02-12`; that day currently acts as both the defended observation day and the screenshot recording day, but no second-level timestamp is retained. |
+| `S0A-1A-R02-SUP-02` | `2026-02-12` | `2026-02-12` | `unknown` | `unknown` | `day` | `screenshot archive currently preserves one day-level capture date only` | The table-view screenshot was captured on `2026-02-12`; that day currently acts as both the defended observation day and the screenshot recording day, but no second-level timestamp is retained. |
+| `S0A-1A-R02-SUP-03` | `2026-02-12` | `2026-02-12` | `unknown` | `unknown` | `day` | `screenshot archive currently preserves one day-level capture date only` | The timeline-view screenshot was captured on `2026-02-12`; that day currently acts as both the defended observation day and the screenshot recording day, but no second-level timestamp is retained. |
+
+## Parent-Ledger Rows To Update
+
+- `S0A-1A-R02`: add screenshot-backed supporting evidence and sharpen the row notes so the Projects slice reads as concrete multi-view execution support rather than only generic reprioritization support.
+
+## Contract Changes Deferred Until Parent Write-Back
+
+- `DOC-WORKFLOW-GITHUB-PROJECTS-0001`: if this SUP ledger is accepted, the current draft should be widened to mention at least three common view classes now evidenced directly:
+  - status-board usage
+  - table lookup usage
+  - timeline sequence usage
+
+## Preliminary Reading
+
+- The current three screenshots do not overturn the existing `S0A-1A-R02 -> DOC-WORKFLOW-GITHUB-PROJECTS-0001` routing.
+- They do sharpen the meaning of the Projects child materially enough that the current draft contract likely needs richer wording.
+- The current draft recommendation is therefore:
+  - keep the parent-ledger routing unchanged
+  - add the screenshots as supporting evidence
+  - then rewrite `PROJECTS-0001` after the parent-ledger write-back is accepted
+
+## Reader Notes
+
+- This SUP-001 ledger is now anchored to stable repo-local screenshot paths under the same directory as the ledger file.
+- The attachment inventory and attachment review table now let reviewers open each screenshot directly from the packet and record one bounded approval-facing verdict without turning the main evidence table into an image gallery.
+- The `Attachment Quick Review` section now provides one table-external place to click and visually inspect each screenshot when table-cell link rendering is not sufficient in the active reader surface.
+- The `Actor and Provenance Review Table` now records one minimum packet-level accountability chain for each supplement item without inventing named actors that the surviving historical source cannot defend.
+- If later code, markdown, or process notes show that these views were treated as stable workflow surfaces rather than one temporary board arrangement, a later SUP item may escalate the contract impact further.


### PR DESCRIPTION
## Metadata

- Requested ID: `S0F-7G`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0f-7g`
- Source log: `docs/logs/log-S0F-7G-approval-facing-screenshot-evidence-review-and-attachment-protocol.md`
- Labels: `EVOLUTION, s0/knowledge system, drills`
- Development issue: #463

## Summary

- Define how screenshot evidence should be reviewed, attached, and retained for approval-facing packets.
- Separate approval-facing evidence packaging from raw operator-side capture.
- Connect screenshot attachment rules back to supplement-ledger review governance.

## Execution Checklist

- [x] `P0-C1-S1`: open `S0F-7G` as the screenshot-review follow-up
- [x] `P0-C1-S2`: fix the first landing surface before wider governance expansion
- [x] `P1-C1-S1`: define how attachment refs should be rendered for click-through review
- [x] `P1-C1-S2`: define one minimum review-note and approval-basis surface for screenshot evidence rows
- [x] `P2-C1-S1`: patch the supplement-ledger template with the approved review protocol
- [x] `P2-C1-S2`: apply the protocol to `ledger-SUP-S0A-1A-001` as the first live screenshot-review sample
- [x] `P3-C1-S1`: decide whether actor-rich provenance or approval-role fields are actually required next

## Links

- Log: `docs/logs/log-S0F-7G-approval-facing-screenshot-evidence-review-and-attachment-protocol.md`

Closes #463
