### PR TITLE
S0F-10C/P0-P3: payment-event to subscription-state and entitlement trigger packet boundary v1

### DIFF
--- a/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
+++ b/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
@@ -5,7 +5,7 @@
 **id**: `S0F-10C`
 **kind**: `log`
 **title**: `payment-event to subscription-state and entitlement trigger packet boundary v1`
-**status**: `draft`
+**status**: `stable`
 **scope**: `S0`
 **tags**: `EVOLUTION, Access, Billing, Entitlement, Policy, Drills, Evidence, epic/s0, sub/10c`
 **links**: ``
@@ -349,6 +349,41 @@
 - `P3-C1-S1`: decide whether real provider-style detail is still unnecessary after the first trigger drills
 - `P3-C1-S2`: decide whether checkout, invoice, and tax surfaces belong in separate later packets rather than inside `S0F-10C`
 
+### P3 Provider Handoff Decision (v1)
+
+- `P3` is now fixed as a close-out boundary decision rather than as the start of an embedded provider integration stream.
+- `S0F-10C` now explicitly concludes that provider-style realism is not required to make the first trigger packet coherent or replayable.
+- The minimum closure delivered by `P0-P2` is now sufficient to stand on its own because:
+  - the trigger-chain vocabulary for `payment_event`, `subscription_state`, and `entitlement_snapshot` is explicit
+  - the first representative trigger matrix and state-to-entitlement mapping are explicit
+  - the first replayable trigger drills already prove lifecycle-driven entitlement change and role-integrity boundaries without provider callbacks or checkout realism
+- Provider-shaped work is now explicitly split to a later packet under the following rule:
+  - a later packet may model provider webhooks, checkout completion, invoice issue, or tax-bearing payment events only if it needs to explain how one trusted trigger input is produced or verified
+  - that later packet must treat provider realism as the source of a bounded `payment_event`, not as a replacement for `subscription_state` or `entitlement_snapshot`
+  - that later packet must not redefine the role baseline from `S0F-10A`, the entitlement boundary from `S0F-10B`, or the trigger-chain semantics fixed in `S0F-10C`
+- The `P3` success rule in this packet is:
+  - one reader should be able to explain why `10C` can close without implementing provider callbacks, checkout, invoice, or tax flows
+  - one reader should be able to explain what future provider work is still allowed to do
+  - later realism should have to open a new bounded packet instead of silently attaching itself to this lane
+
+#### P3 Keep-vs-Split Decision Table (v1)
+
+| topic | decision in `S0F-10C` | reason |
+| --- | --- | --- |
+| `payment_event` vocabulary | `keep-in-lane` | This packet needs explicit trigger-input semantics to explain the lifecycle chain. |
+| `subscription_state` transition model | `keep-in-lane` | This packet needs lifecycle standing semantics to explain entitlement change over time. |
+| `entitlement_snapshot` outcome mapping | `keep-in-lane` | This packet needs effective capability outcome semantics to close the trigger chain. |
+| provider webhook or API realism | `split-to-later-packet` | Provider transport is not required to prove the first trigger boundary or replay the current drills. |
+| checkout, invoice, and tax detail | `split-to-later-packet` | Those surfaces belong to later external-system packets, not to the minimum trigger closure. |
+
+#### P3 Later-Packet Entry Conditions (v1)
+
+- A later provider-shaped packet may open only when at least one of these conditions becomes concrete:
+  - one replay requires proving how a provider callback or checkout success becomes a trusted `payment_event`
+  - one downstream implementation packet needs a bounded source-of-truth rule for invoice, refund, or tax-bearing trigger generation
+  - one integration packet needs a concrete `provider event -> payment_event -> subscription_state -> entitlement_snapshot` chain rather than the abstract trigger model fixed here
+- Until one of those conditions is real, later work should treat `S0F-10C` as the stable trigger-chain baseline and should not reopen this lane just to host speculative provider detail.
+
 ## Execution Checklist (unchecked)
 
 ### P0 (Contract)
@@ -369,8 +404,8 @@
 
 ### P3 (Provider realism defer decision)
 
-- [ ] `P3-C1-S1`: decide whether real provider-style detail is still unnecessary after the first trigger drills
-- [ ] `P3-C1-S2`: decide whether checkout, invoice, and tax surfaces belong in separate later packets
+- [x] `P3-C1-S1`: decide whether real provider-style detail is still unnecessary after the first trigger drills
+- [x] `P3-C1-S2`: decide whether checkout, invoice, and tax surfaces belong in separate later packets
 
 ## Current Status (recommended)
 
@@ -378,9 +413,10 @@
 - `P0` is now complete: the lane now fixes one minimum vocabulary for `payment_event`, `subscription_state`, and `entitlement_snapshot`, plus one explicit allowed-transition boundary that keeps role and entitlement baselines outside the trigger chain.
 - `P1` is now complete: the lane now fixes one first trigger-to-state matrix, one state-to-entitlement matrix, and one transition mapping that keeps role and entitlement boundaries stable while explaining lifecycle-driven capability change.
 - `P2` is now complete: the lane now carries one replayable trigger drill where lifecycle standing changes effective entitlement outcome, plus one integrity drill that proves role and `system_admin` semantics remain unchanged through cancellation, expiry, and correction paths.
-- The lane is still `draft`: it now has concrete contract, transition-mapping, and replay-drill packets, but it does not yet decide whether provider realism should stay deferred after those drills.
+- `P3` is now complete: the lane now explicitly splits provider callback, checkout, invoice, and tax realism into later dedicated packets instead of embedding them into the minimum trigger-chain closure.
+- `S0F-10C` now stands as the stable minimum trigger-chain baseline after `S0F-10B`: later work may widen from it, but should not reopen it just to host provider integration detail.
 - `roadmap_milestone` is already fixed to `M4`, but `roadmap_phase` remains blank on purpose because the current `road-002` `M4-P0..P3` bridge is already occupied by `S0F-10A` and `S0F-10C` should not guess a new roadmap slot before that follow-up widening is made explicit.
-- Automation should still read this log as an opening source scaffold rather than as a stable policy artifact.
+- Automation may now read this log as the stable minimum trigger-chain source packet and treat provider-shaped follow-up as separate later work.
 
 ## Evidence (reserved)
 
@@ -429,6 +465,20 @@
   - the lane now fixes one integrity drill showing that cancellation, expiry, and administrative correction change lifecycle or entitlement results without rewriting ordinary collaboration roles or platform override behavior
   - the trigger packet can now answer both state-driven capability change and role-integrity questions without introducing provider implementation detail
 
+### P3-C1-S1S2 (Provider realism split beyond the minimum trigger-chain closure | 2026-04-15)
+
+- headSha: `working-tree-uncommitted`
+- artifacts:
+  - `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`
+- expected:
+  - the lane should stop leaving provider realism as an unresolved ambiguity after the trigger chain is already explicit and replayable
+  - the packet should decide whether provider-style detail belongs inside `S0F-10C` or in a later dedicated packet
+  - the result should preserve the `10A` role baseline, the `10B` entitlement boundary, and the `10C` trigger-chain semantics
+- observed:
+  - `S0F-10C` now explicitly concludes that provider realism is not required for the first trigger-chain closure
+  - the lane now splits webhook, checkout, invoice, and tax-bearing integration detail to later dedicated packets
+  - the first trigger packet can now be treated as a stable minimum closure rather than as a partially finished provider-and-trigger hybrid
+
 ## Recent changes (for traceability, optional)
 
 - 2026-04-15: opened `S0F-10C` as the next intended `M4` trigger packet so payment and lifecycle triggers can be modeled separately from the already-stable entitlement boundary in `S0F-10B`.
@@ -436,3 +486,4 @@
 - 2026-04-15: completed `P0-C1-S1S2S3` by fixing the minimum trigger-chain vocabulary, the allowed transition boundary from external input to lifecycle standing to entitlement outcome, and the explicit defer rule for provider realism.
 - 2026-04-15: completed `P1-C1-S1S2` by fixing the first representative trigger matrix, the first state-to-entitlement outcome mapping, and the first transition notes that preserve the `10A/10B` baselines.
 - 2026-04-15: completed `P2-C1-S1S2` by fixing one replayable trigger drill for lifecycle-driven entitlement change and one integrity drill that preserves role and `system_admin` semantics.
+- 2026-04-15: completed `P3-C1-S1S2` by explicitly splitting provider callback, checkout, invoice, and tax realism to later dedicated packets and marking `S0F-10C` as the stable minimum trigger-chain closure.

--- a/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
+++ b/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
@@ -291,7 +291,7 @@
 
 ### P0-C1-S1S2S3 (Minimum trigger-chain vocabulary and allowed transition boundary fixed | 2026-04-15)
 
-- headSha: `working-tree-uncommitted`
+- headSha: `cebd89c52`
 - artifacts:
   - `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`
 - expected:

--- a/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
+++ b/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
@@ -367,7 +367,7 @@
 
 ### P1-C1-S1S2 (Minimum trigger matrix and entitlement outcome mapping fixed | 2026-04-15)
 
-- headSha: `working-tree-uncommitted`
+- headSha: `5b48cbec7`
 - artifacts:
   - `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`
 - expected:

--- a/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
+++ b/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
@@ -309,6 +309,41 @@
 - `P2-C1-S1`: prove one replay where a bounded trigger changes `subscription_state` and therefore changes effective entitlement outcome
 - `P2-C1-S2`: prove one replay where the same trigger does not mutate role standing or platform override semantics
 
+### P2 Drill Decision (v1)
+
+- `P2` now stays on the same trigger packet and proves one replayable state-transition chain instead of widening into provider realism.
+- The first trigger drill is now fixed as:
+  - one bounded external trigger arrives
+  - `subscription_state` changes according to the transition table
+  - the resulting `entitlement_snapshot` changes accordingly
+  - the observed outcome is explained as lifecycle-driven capability change rather than as role mutation
+- The first integrity drill is now fixed as:
+  - one lifecycle degradation or correction occurs
+  - the effective entitlement bundle changes or is repaired
+  - `viewer / editor / owner / system_admin` semantics remain unchanged throughout the replay
+- The `P2` success rule in this packet is:
+  - one reader should be able to replay one full `payment_event -> subscription_state -> entitlement_snapshot` chain without guessing hidden billing logic
+  - one reader should be able to explain that lifecycle change constrains entitlement-shaped capabilities but does not rewrite role or override semantics
+  - the lane should still avoid provider webhook, checkout, invoice, or tax realism
+
+#### P2 Replay Drill A (Upgrade and renewal failure change entitlement through lifecycle standing)
+
+| drill step | actor or trigger source | precondition | intended transition or action | expected result | why it matters |
+| --- | --- | --- | --- | --- | --- |
+| `A1` | bounded external trigger `upgrade_success` | one user currently holds valid ordinary standing and the subscription is `trialing` | apply `upgrade_success` | `trialing -> active` and `activate-current-plan-bundle` | The lane must show that successful upgrade changes lifecycle standing first and entitlement outcome second. |
+| `A2` | same user after activation | same role standing unchanged | attempt one entitlement-shaped capability such as `copy_block_cross_book` or `export_book` under the now-active plan bundle | `allow` according to the active bundle | The lane must show that the newly effective entitlement bundle widens capability without changing role semantics. |
+| `A3` | bounded external trigger `renewal_failed` | subscription currently `active` | apply `renewal_failed` | `active -> past_due` and `suspend-current-plan-bundle` or `narrow-current-plan-bundle` | The lane must show that failure degrades entitlement through lifecycle standing rather than through direct role mutation. |
+| `A4` | same user after degradation | same role standing unchanged | attempt the same entitlement-shaped capability again | `deny-via-entitlement` or narrower result | The lane must show that capability contraction follows lifecycle impairment while ordinary collaboration standing remains intact. |
+
+#### P2 Replay Drill B (Cancellation, expiry, and correction do not mutate role or override semantics)
+
+| drill step | actor or trigger source | precondition | intended transition or action | expected result | why it matters |
+| --- | --- | --- | --- | --- | --- |
+| `B1` | bounded external trigger `cancellation_requested` | subscription currently `active`; user still has valid ordinary standing on one book | apply `cancellation_requested` | `active -> canceled` and narrowed pending-expiry entitlement bundle | The lane must show that cancellation affects lifecycle and entitlement but not collaboration role assignment. |
+| `B2` | end-of-term lapse | subscription currently `canceled` or `past_due` | move to `expired` | `expire-current-plan-bundle` | The lane must show the clean terminal state for entitlement without rewriting owner/editor/viewer semantics. |
+| `B3` | bounded `admin_correction` | lifecycle state was recorded incorrectly | repair to the corrected lifecycle state and repair the bundle | `repair-current-plan-bundle` | Administrative correction should restore consistency rather than bypass the model. |
+| `B4` | `system_admin` override path | same lifecycle scenarios as above | inspect or recover book access through override path | `allow-via-override` with no paid-plan dependency | The lane must show that platform override remains outside lifecycle-trigger semantics. |
+
 ### P3 (Provider realism defer decision)
 
 - `P3-C1-S1`: decide whether real provider-style detail is still unnecessary after the first trigger drills
@@ -329,8 +364,8 @@
 
 ### P2 (Drill / Replay)
 
-- [ ] `P2-C1-S1`: prove one replay where a trigger changes entitlement outcome through `subscription_state`
-- [ ] `P2-C1-S2`: prove one replay where the same trigger leaves role and override semantics unchanged
+- [x] `P2-C1-S1`: prove one replay where a trigger changes entitlement outcome through `subscription_state`
+- [x] `P2-C1-S2`: prove one replay where the same trigger leaves role and override semantics unchanged
 
 ### P3 (Provider realism defer decision)
 
@@ -342,7 +377,8 @@
 - `S0F-10C` is now scaffolded as the intended next `M4` trigger packet after the stable entitlement-boundary closure in `S0F-10B`.
 - `P0` is now complete: the lane now fixes one minimum vocabulary for `payment_event`, `subscription_state`, and `entitlement_snapshot`, plus one explicit allowed-transition boundary that keeps role and entitlement baselines outside the trigger chain.
 - `P1` is now complete: the lane now fixes one first trigger-to-state matrix, one state-to-entitlement matrix, and one transition mapping that keeps role and entitlement boundaries stable while explaining lifecycle-driven capability change.
-- The lane is still `draft`: it now has concrete contract and transition-mapping packets, but it does not yet prove the first replayable trigger drill.
+- `P2` is now complete: the lane now carries one replayable trigger drill where lifecycle standing changes effective entitlement outcome, plus one integrity drill that proves role and `system_admin` semantics remain unchanged through cancellation, expiry, and correction paths.
+- The lane is still `draft`: it now has concrete contract, transition-mapping, and replay-drill packets, but it does not yet decide whether provider realism should stay deferred after those drills.
 - `roadmap_milestone` is already fixed to `M4`, but `roadmap_phase` remains blank on purpose because the current `road-002` `M4-P0..P3` bridge is already occupied by `S0F-10A` and `S0F-10C` should not guess a new roadmap slot before that follow-up widening is made explicit.
 - Automation should still read this log as an opening source scaffold rather than as a stable policy artifact.
 
@@ -379,9 +415,24 @@
   - the lane now fixes one resulting state-to-entitlement mapping that distinguishes activation, narrowing, suspension, expiry, and repair of the current plan bundle
   - the transition notes now state explicitly that lifecycle-driven capability change constrains the entitlement-shaped capabilities from `S0F-10B` without mutating role standing or `system_admin` override semantics
 
+### P2-C1-S1S2 (Replayable trigger drills fixed without mutating role or override semantics | 2026-04-15)
+
+- headSha: `working-tree-uncommitted`
+- artifacts:
+  - `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`
+- expected:
+  - the lane should prove one replay where a trigger changes lifecycle standing and therefore changes effective entitlement outcome
+  - the lane should prove one replay where lifecycle degradation, expiry, or correction do not rewrite `viewer / editor / owner / system_admin` semantics
+  - the drills should remain independent from provider, checkout, invoice, or tax realism
+- observed:
+  - `S0F-10C` now fixes one replay where `upgrade_success` activates the current plan bundle and `renewal_failed` later narrows or suspends that same bundle through `subscription_state` change
+  - the lane now fixes one integrity drill showing that cancellation, expiry, and administrative correction change lifecycle or entitlement results without rewriting ordinary collaboration roles or platform override behavior
+  - the trigger packet can now answer both state-driven capability change and role-integrity questions without introducing provider implementation detail
+
 ## Recent changes (for traceability, optional)
 
 - 2026-04-15: opened `S0F-10C` as the next intended `M4` trigger packet so payment and lifecycle triggers can be modeled separately from the already-stable entitlement boundary in `S0F-10B`.
 - 2026-04-15: fixed the opening default that `S0F-10A` remains the role baseline and `S0F-10B` remains the entitlement baseline while `S0F-10C` handles only trigger-chain semantics for later entitlement-state change.
 - 2026-04-15: completed `P0-C1-S1S2S3` by fixing the minimum trigger-chain vocabulary, the allowed transition boundary from external input to lifecycle standing to entitlement outcome, and the explicit defer rule for provider realism.
 - 2026-04-15: completed `P1-C1-S1S2` by fixing the first representative trigger matrix, the first state-to-entitlement outcome mapping, and the first transition notes that preserve the `10A/10B` baselines.
+- 2026-04-15: completed `P2-C1-S1S2` by fixing one replayable trigger drill for lifecycle-driven entitlement change and one integrity drill that preserves role and `system_admin` semantics.

--- a/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
+++ b/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
@@ -467,7 +467,7 @@
 
 ### P3-C1-S1S2 (Provider realism split beyond the minimum trigger-chain closure | 2026-04-15)
 
-- headSha: `working-tree-uncommitted`
+- headSha: `d62ec6e4a`
 - artifacts:
   - `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`
 - expected:

--- a/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
+++ b/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
@@ -243,6 +243,67 @@
 - `P1-C1-S1`: fix one minimum trigger matrix that maps representative `payment_event` values to resulting `subscription_state` transitions
 - `P1-C1-S2`: map those transitions to entitlement activation, narrowing, suspension, or expiry without rewriting role or entitlement boundaries
 
+### P1 Minimum Trigger-Matrix Decision (v1)
+
+- `P1` is now fixed as one minimum transition-mapping packet rather than as one full billing engine design.
+- The stable vocabulary from `P0` remains authoritative for trigger input, lifecycle standing, and entitlement outcome.
+- The first representative trigger set is now fixed as:
+  - `upgrade_success`
+  - `renewal_failed`
+  - `cancellation_requested`
+  - `refund_applied`
+  - `admin_correction`
+- The first entitlement outcome set is now fixed as:
+  - `activate-current-plan-bundle`
+  - `narrow-current-plan-bundle`
+  - `suspend-current-plan-bundle`
+  - `expire-current-plan-bundle`
+  - `repair-current-plan-bundle`
+- The `P1` success rule in this packet is:
+  - one reader should be able to answer which lifecycle transition each representative trigger is allowed to request
+  - one reader should be able to answer how the resulting entitlement snapshot changes after that transition
+  - the packet should keep `S0F-10A` and `S0F-10B` semantics stable while widening only the state-transition model
+
+#### P1 Trigger-to-State Matrix (v1)
+
+| trigger input | from state | to state | transition standing | notes |
+| --- | --- | --- | --- | --- |
+| `upgrade_success` | `trialing` | `active` | `allow` | Successful upgrade or activation moves the subscription into the normal active lifecycle. |
+| `renewal_failed` | `active` | `past_due` | `allow` | Failed renewal degrades lifecycle standing without changing role semantics. |
+| `cancellation_requested` | `active` | `canceled` | `allow` | Cancellation records intent to end the commercial relationship. |
+| `refund_applied` | `active` | `canceled` | `allow-bounded` | Refund-backed reversal may end active standing through a bounded corrective path. |
+| `admin_correction` | any incorrect state | corrected state | `allow-bounded` | Administrative correction exists only to restore consistency with intended lifecycle reality. |
+| end-of-term lapse | `past_due` or `canceled` | `expired` | `allow` | Expiry closes the lifecycle after non-recovery or cancellation reaches its end point. |
+
+#### P1 State-to-Entitlement Matrix (v1)
+
+| resulting `subscription_state` | resulting entitlement effect | notes |
+| --- | --- | --- |
+| `trialing` | `narrow-current-plan-bundle` | Trialing keeps the package on a deliberately narrower effective bundle. |
+| `active` | `activate-current-plan-bundle` | Active standing enables the normal effective bundle for the current plan. |
+| `past_due` | `suspend-current-plan-bundle` or `narrow-current-plan-bundle` | Past-due standing impairs capability outcome without mutating role semantics. |
+| `canceled` | `narrow-current-plan-bundle` pending expiry | Cancellation narrows or preserves bounded access until end-of-term handling completes. |
+| `expired` | `expire-current-plan-bundle` | Expired standing closes effective entitlement outcome for the current plan bundle. |
+| corrected state via `admin_correction` | `repair-current-plan-bundle` | Correction restores the effective bundle that should have been active for the corrected lifecycle standing. |
+
+#### P1 Transition Mapping Notes (v1)
+
+- The trigger chain now maps as follows:
+  - trigger inputs change lifecycle standing
+  - lifecycle standing changes effective entitlement outcome
+  - entitlement outcome then constrains the entitlement-shaped capabilities already defined in `S0F-10B`
+- The minimum mapping back to `S0F-10B` is now fixed as:
+  - `activate-current-plan-bundle` means the plan's normal capability bundle becomes effective again
+  - `narrow-current-plan-bundle` means the plan's entitlement-shaped capabilities contract to the narrower allowed set
+  - `suspend-current-plan-bundle` means entitlement-shaped capabilities are temporarily unavailable even though ordinary collaboration standing still exists
+  - `expire-current-plan-bundle` means the entitlement-shaped capability bundle is no longer effective until a later reactivation trigger occurs
+  - `repair-current-plan-bundle` means the bundle is corrected to match the lifecycle state that should have been in force
+- This packet still does not decide provider transport or webhook trust detail.
+- This packet still does not mutate:
+  - `viewer / editor / owner` standing from `S0F-10A`
+  - the role-only vs entitlement-shaped action split from `S0F-10B`
+  - `system_admin` override semantics
+
 ### P2 (Drill / Replay)
 
 - `P2-C1-S1`: prove one replay where a bounded trigger changes `subscription_state` and therefore changes effective entitlement outcome
@@ -263,8 +324,8 @@
 
 ### P1 (Transition mapping and trigger matrix)
 
-- [ ] `P1-C1-S1`: fix one minimum trigger matrix for representative payment or lifecycle events
-- [ ] `P1-C1-S2`: map those transitions to entitlement outcomes without mutating role standing
+- [x] `P1-C1-S1`: fix one minimum trigger matrix for representative payment or lifecycle events
+- [x] `P1-C1-S2`: map those transitions to entitlement outcomes without mutating role standing
 
 ### P2 (Drill / Replay)
 
@@ -280,7 +341,8 @@
 
 - `S0F-10C` is now scaffolded as the intended next `M4` trigger packet after the stable entitlement-boundary closure in `S0F-10B`.
 - `P0` is now complete: the lane now fixes one minimum vocabulary for `payment_event`, `subscription_state`, and `entitlement_snapshot`, plus one explicit allowed-transition boundary that keeps role and entitlement baselines outside the trigger chain.
-- The lane is still `draft`: it now has a concrete trigger-chain contract packet, but it does not yet define the first full transition matrix or replay drill.
+- `P1` is now complete: the lane now fixes one first trigger-to-state matrix, one state-to-entitlement matrix, and one transition mapping that keeps role and entitlement boundaries stable while explaining lifecycle-driven capability change.
+- The lane is still `draft`: it now has concrete contract and transition-mapping packets, but it does not yet prove the first replayable trigger drill.
 - `roadmap_milestone` is already fixed to `M4`, but `roadmap_phase` remains blank on purpose because the current `road-002` `M4-P0..P3` bridge is already occupied by `S0F-10A` and `S0F-10C` should not guess a new roadmap slot before that follow-up widening is made explicit.
 - Automation should still read this log as an opening source scaffold rather than as a stable policy artifact.
 
@@ -303,8 +365,23 @@
   - the lane now fixes one allowed transition boundary where trigger inputs may change lifecycle standing and lifecycle standing may change effective entitlement outcome without mutating role or override semantics
   - the lane now explicitly defers provider realism while allowing later provider-shaped work only as a source of trusted trigger inputs rather than as a replacement for trigger-chain semantics
 
+### P1-C1-S1S2 (Minimum trigger matrix and entitlement outcome mapping fixed | 2026-04-15)
+
+- headSha: `working-tree-uncommitted`
+- artifacts:
+  - `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`
+- expected:
+  - the lane should stop leaving the first trigger-to-state and state-to-entitlement mapping implicit after `P0`
+  - the packet should name one bounded representative trigger matrix without reopening role or entitlement boundaries
+  - the packet should explain how lifecycle transitions affect effective entitlement outcomes while preserving `S0F-10A` and `S0F-10B`
+- observed:
+  - `S0F-10C` now fixes one representative trigger matrix for upgrade, renewal failure, cancellation, refund-backed correction, admin correction, and end-of-term lapse
+  - the lane now fixes one resulting state-to-entitlement mapping that distinguishes activation, narrowing, suspension, expiry, and repair of the current plan bundle
+  - the transition notes now state explicitly that lifecycle-driven capability change constrains the entitlement-shaped capabilities from `S0F-10B` without mutating role standing or `system_admin` override semantics
+
 ## Recent changes (for traceability, optional)
 
 - 2026-04-15: opened `S0F-10C` as the next intended `M4` trigger packet so payment and lifecycle triggers can be modeled separately from the already-stable entitlement boundary in `S0F-10B`.
 - 2026-04-15: fixed the opening default that `S0F-10A` remains the role baseline and `S0F-10B` remains the entitlement baseline while `S0F-10C` handles only trigger-chain semantics for later entitlement-state change.
 - 2026-04-15: completed `P0-C1-S1S2S3` by fixing the minimum trigger-chain vocabulary, the allowed transition boundary from external input to lifecycle standing to entitlement outcome, and the explicit defer rule for provider realism.
+- 2026-04-15: completed `P1-C1-S1S2` by fixing the first representative trigger matrix, the first state-to-entitlement outcome mapping, and the first transition notes that preserve the `10A/10B` baselines.

--- a/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
+++ b/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
@@ -417,7 +417,7 @@
 
 ### P2-C1-S1S2 (Replayable trigger drills fixed without mutating role or override semantics | 2026-04-15)
 
-- headSha: `working-tree-uncommitted`
+- headSha: `e68ced29b`
 - artifacts:
   - `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`
 - expected:

--- a/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
+++ b/docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md
@@ -1,0 +1,310 @@
+# log-S0F-10C (Phase 10C: Payment-event to subscription-state entitlement trigger packet)
+
+---
+
+**id**: `S0F-10C`
+**kind**: `log`
+**title**: `payment-event to subscription-state and entitlement trigger packet boundary v1`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Access, Billing, Entitlement, Policy, Drills, Evidence, epic/s0, sub/10c`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: ``
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0F-docs-management-v6.md`
+  **previous_log**: `docs/logs/log-S0F-10B-plan-and-entitlement-minimum-widening.md`
+  **reference_log_1**: `docs/logs/log-S0F-10B-plan-and-entitlement-minimum-widening.md`
+  **reference_log_2**: `docs/roadmap/_draft/road-S2-.md`
+**issue_keyword**: `policy`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/10c`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: `M4`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-15`
+**updated**: `2026-04-15`
+**reviewed**: `pending`
+
+---
+
+## Frontmatter Lifecycle-Time Rule
+
+- `created`, `updated`, and optional `reviewed` are the minimum artifact-lifecycle fields for this lane.
+- Day-level precision is acceptable while this trigger packet is still a policy-and-boundary scaffold.
+- `reviewed` should remain `pending` until this lane is accepted as the next bounded `M4` child packet after the stable entitlement boundary in `S0F-10B`.
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0F-10C` opens the next `M4` child lane as a bounded trigger packet for `payment_event -> subscription_state -> entitlement` after `S0F-10B` has already fixed the minimum entitlement boundary.
+- The purpose of this lane is not to redefine role standing or re-open the entitlement boundary; it is to explain how external commerce or lifecycle triggers may change `subscription_state`, and how those state changes may later activate, suspend, narrow, or expire entitlement outcomes.
+- The opening packet should still avoid real provider integration, invoice realism, tax handling, or checkout orchestration; it should stay on the trigger semantics needed to explain state change clearly.
+
+**Default choices (phase defaults / v1)**:
+
+- `S0F-10A` remains the stable role baseline.
+- `S0F-10B` remains the stable entitlement-boundary baseline.
+- `S0F-10C` may explain how `subscription_state` changes over time, but it must not redefine what `plan`, `entitlement`, `viewer`, `editor`, `owner`, or `system_admin` already mean.
+- `payment_event` is treated as an external trigger input, not as a replacement for `subscription_state` or `entitlement`.
+- If a later state transition can be explained without real payment-provider detail, prefer the simpler trigger model and defer provider realism again.
+
+## PR Summary Inputs (optional)
+
+- Use this block because `S0F-10C` is intended to become the next bounded `M4` trigger packet after `S0F-10B`.
+
+**PR summary bullets**:
+
+- Open the next `M4` child lane for the bounded `payment_event -> subscription_state -> entitlement` trigger chain after the minimum entitlement boundary is already stable.
+- Fix the difference between external trigger inputs, subscription lifecycle state, and entitlement outcomes without rewriting the `10A/10B` baselines.
+- Keep provider realism, tax, and invoice detail out of the opening packet unless later phases prove they are required.
+
+**PR checklist source**:
+
+- Default source: reuse this log's execution checklist for the generated PR checklist block.
+
+**PR links**:
+
+- Log: `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`
+- Previous log: `docs/logs/log-S0F-10B-plan-and-entitlement-minimum-widening.md`
+
+## Exported Sections / Outlet Ownership
+
+- This slice starts as one `log-retained core + trigger-chain contract-first` lane.
+- The expected first landing is one stable contract that answers how `payment_event`, `subscription_state`, and entitlement changes relate without reopening role or entitlement semantics that are already stable elsewhere.
+
+**Outlet ownership**:
+
+- `contract`: define the trigger-chain vocabulary and the allowed transition rule between `payment_event`, `subscription_state`, and entitlement change
+- `runbook`: no-op at packet open; operator procedure should wait until the first replayable trigger drill exists
+- `view`: no-op at packet open; reader-facing subscription trigger summaries should wait until one stable transition table exists
+- `index/front-door`: no-op at packet open
+- `disposition/placement`: no-op at packet open
+- `log-retained core`: lane boundary, trigger rules, phase plan, execution checklist, and later evidence ledger remain here
+
+## Definitions
+
+- `payment_event`: one external trigger input such as upgrade success, renewal failure, cancellation, refund, or manual administrative correction.
+- `subscription_state`: one lifecycle state such as `trialing`, `active`, `past_due`, `canceled`, or `expired`.
+- `entitlement_snapshot`: one effective capability bundle derived from current plan plus current subscription state.
+- `trigger chain`: one bounded sequence where an external event changes lifecycle standing and therefore changes effective entitlement outcomes.
+- `state transition`: one allowed change from one `subscription_state` to another under one bounded trigger.
+- `external trigger packet`: one lane that explains how state changes happen without redefining the access or entitlement baseline.
+
+## Constraints
+
+- Do not rewrite the role baseline already fixed in `S0F-10A`.
+- Do not rewrite the entitlement boundary already fixed in `S0F-10B`.
+- Do not require real payment-provider integration in this opening packet.
+- Do not mix checkout UX, invoice rendering, tax logic, and trigger semantics into one lane.
+- Do not allow `payment_event` to directly grant owner/editor/system-admin authority.
+
+## Scope
+
+- `P0`: contract
+- `P1`: transition mapping and trigger matrix
+- `P2`: drill and replay
+- `P3`: provider realism defer decision
+
+## Success Criteria (DoD)
+
+- The lane fixes one minimum vocabulary for `payment_event`, `subscription_state`, and `entitlement_snapshot` without collapsing them into one object.
+- The lane explains one allowed trigger chain from external event to lifecycle state to entitlement outcome.
+- The lane proves that state-triggered capability change does not rewrite `S0F-10A` role semantics or `S0F-10B` entitlement boundaries.
+- The lane keeps provider integration, tax, invoice, and checkout detail explicitly separate unless a replay drill proves they are necessary.
+- The lane leaves one reader able to explain how entitlement state changes happen over time, not just what entitlement means in the abstract.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - the trigger-chain vocabulary and transition rules are explicit
+  - at least one allowed `payment_event -> subscription_state -> entitlement` mapping is explicit
+  - at least one replayable trigger drill exists without requiring real provider integration
+  - the Evidence section includes traceable `headSha` values plus artifact paths
+- `stable` for this trigger packet does not require real billing integration; it requires a bounded and replayable explanation of state-triggered entitlement change.
+
+## P0 (Contract | v1)
+
+### P0-C1-S1 (Trigger-chain vocabulary)
+
+- Fix one minimum vocabulary for `payment_event`, `subscription_state`, and `entitlement_snapshot`.
+- Keep external trigger, lifecycle standing, and effective capability outcome as distinct concepts.
+
+### P0 Minimum Trigger Vocabulary Decision (v1)
+
+- `P0` is now fixed as one vocabulary-and-boundary packet for the external trigger chain that follows the already-stable role and entitlement baselines.
+- The minimum terms in this packet are now fixed as:
+  - `payment_event`
+  - `subscription_state`
+  - `entitlement_snapshot`
+- The semantic boundary for those terms is now fixed as follows:
+  - `payment_event` means one external trigger input that may request or justify lifecycle change; it does not directly grant role authority or capability by itself
+  - `subscription_state` means one lifecycle standing that records whether the commercial relationship is trialing, active, impaired, canceled, or expired
+  - `entitlement_snapshot` means one effective capability bundle derived from stable plan semantics plus current lifecycle standing
+- The minimum illustrative values in this packet are now fixed as:
+  - `payment_event`: `upgrade_success`, `renewal_failed`, `cancellation_requested`, `refund_applied`, `admin_correction`
+  - `subscription_state`: `trialing`, `active`, `past_due`, `canceled`, `expired`
+- The `P0-C1-S1` success rule in this packet is:
+  - one reader should be able to distinguish trigger input, lifecycle standing, and effective capability outcome without treating them as aliases
+  - one reader should be able to explain why role semantics still belong to `S0F-10A` and entitlement boundary semantics still belong to `S0F-10B`
+  - later billing or provider realism should have to plug into this vocabulary rather than replace it
+
+#### P0 Trigger Vocabulary Table (v1)
+
+| term | fixed meaning in `S0F-10C` | not allowed to mean |
+| --- | --- | --- |
+| `payment_event` | one external trigger input that may justify lifecycle transition | direct owner/editor/system-admin authority or the entitlement bundle itself |
+| `subscription_state` | one lifecycle standing that can activate, narrow, suspend, or expire effective capability | role standing, plan identity, or provider callback history as a whole |
+| `entitlement_snapshot` | one effective capability bundle derived from plan plus current lifecycle standing | the raw trigger event or a replacement for the stable entitlement boundary |
+
+### P0-C1-S2 (Allowed transition boundary)
+
+- Fix the rule that `payment_event` may change `subscription_state`, and `subscription_state` may change effective entitlement outcomes.
+- Keep role standing and bounded platform override outside this trigger chain.
+
+### P0 Allowed Transition Boundary Decision (v1)
+
+- `S0F-10C` now fixes the following trigger order for this lane:
+  - first receive one bounded `payment_event` or lifecycle trigger input
+  - then determine whether that trigger allows one `subscription_state` transition
+  - then derive one resulting `entitlement_snapshot` outcome from the stable plan plus the resulting lifecycle standing
+- The first allowed transition boundary in this packet is now fixed as:
+  - `payment_event` may request a change in lifecycle standing
+  - `subscription_state` may activate, narrow, suspend, or expire effective entitlement outcomes
+  - role standing from `S0F-10A` and entitlement meaning from `S0F-10B` must remain unchanged by this trigger chain
+- The minimum representative trigger chain in this packet is now fixed as:
+  - `upgrade_success` may move `trialing -> active`
+  - `renewal_failed` may move `active -> past_due`
+  - `cancellation_requested` may move `active -> canceled`
+  - lapse or end-of-term handling may move `past_due -> expired` or `canceled -> expired`
+  - `admin_correction` may repair incorrect lifecycle standing only through explicit bounded correction logic
+- The `P0-C1-S2` success rule in this packet is:
+  - one reader should be able to explain which part of the chain changes lifecycle standing and which part changes effective entitlement outcome
+  - one reader should be able to explain that the trigger chain does not upgrade viewers into editors or editors into owners
+  - one reader should be able to explain that `system_admin` override remains outside paid lifecycle semantics
+
+#### P0 Allowed Transition Table (v1)
+
+| trigger input | allowed lifecycle transition | entitlement effect | boundary reason |
+| --- | --- | --- | --- |
+| `upgrade_success` | `trialing -> active` | activate broader entitlement snapshot for the current plan | Successful upgrade or activation should widen capability only through lifecycle standing. |
+| `renewal_failed` | `active -> past_due` | narrow or suspend entitlement snapshot according to later policy | Failure affects effective capability state, not collaboration role semantics. |
+| `cancellation_requested` | `active -> canceled` | keep or narrow entitlement snapshot until later expiry according to later policy | Cancellation changes lifecycle standing first, not role assignment. |
+| end-of-term lapse | `past_due -> expired` or `canceled -> expired` | expire entitlement snapshot | Expiry closes capability standing through lifecycle state rather than through direct trigger-to-role mutation. |
+| `admin_correction` | bounded corrective transition | repair entitlement snapshot to match corrected state | Administrative correction is allowed only to restore consistency, not to bypass the model. |
+
+### P0-C1-S3 (Deferred provider realism | v1)
+
+- Real provider integration, checkout orchestration, invoice detail, and tax logic remain deferred at packet open.
+- The opening trigger packet should stay coherent even if those external systems are left unmodeled.
+
+### P0 Provider Defer Decision (v1)
+
+- Real provider integration remains deferred after `P0` and does not enter this contract packet as an implementation obligation.
+- The following surfaces are explicitly out of scope in this packet:
+  - payment provider APIs or webhook realism
+  - checkout orchestration or UI flow
+  - invoice rendering or tax logic
+  - settlement, accounting, or ledger reconciliation detail
+- A later provider-shaped packet is allowed only under the following rule:
+  - it may explain how one external trigger is produced or verified
+  - it may not redefine the lifecycle vocabulary or entitlement boundary already fixed here and in `S0F-10B`
+  - it should act as a source of trusted trigger inputs rather than as a replacement for `subscription_state`
+- The `P0-C1-S3` success rule in this packet is:
+  - one reader should be able to explain why this lane can define trigger semantics without implementing provider callbacks
+  - one reader should be able to explain what later provider work is still allowed to do
+  - later realism should have to open a new bounded packet instead of silently attaching itself to this trigger-chain lane
+
+## Numbering
+
+- `S<n>`: Step.
+- `C<n>`: Cycle.
+
+**Commit / PR naming**:
+
+- `S0F-10C/P<phase>-C<cycle>-S<steps>: <summary>`
+
+## Plan (draft)
+
+### P1 (Transition mapping and trigger matrix)
+
+- `P1-C1-S1`: fix one minimum trigger matrix that maps representative `payment_event` values to resulting `subscription_state` transitions
+- `P1-C1-S2`: map those transitions to entitlement activation, narrowing, suspension, or expiry without rewriting role or entitlement boundaries
+
+### P2 (Drill / Replay)
+
+- `P2-C1-S1`: prove one replay where a bounded trigger changes `subscription_state` and therefore changes effective entitlement outcome
+- `P2-C1-S2`: prove one replay where the same trigger does not mutate role standing or platform override semantics
+
+### P3 (Provider realism defer decision)
+
+- `P3-C1-S1`: decide whether real provider-style detail is still unnecessary after the first trigger drills
+- `P3-C1-S2`: decide whether checkout, invoice, and tax surfaces belong in separate later packets rather than inside `S0F-10C`
+
+## Execution Checklist (unchecked)
+
+### P0 (Contract)
+
+- [x] `P0-C1-S1`: fix one minimum vocabulary for `payment_event`, `subscription_state`, and `entitlement_snapshot`
+- [x] `P0-C1-S2`: fix the allowed transition boundary from external trigger to lifecycle state to entitlement outcome
+- [x] `P0-C1-S3`: keep provider realism explicitly deferred at packet open
+
+### P1 (Transition mapping and trigger matrix)
+
+- [ ] `P1-C1-S1`: fix one minimum trigger matrix for representative payment or lifecycle events
+- [ ] `P1-C1-S2`: map those transitions to entitlement outcomes without mutating role standing
+
+### P2 (Drill / Replay)
+
+- [ ] `P2-C1-S1`: prove one replay where a trigger changes entitlement outcome through `subscription_state`
+- [ ] `P2-C1-S2`: prove one replay where the same trigger leaves role and override semantics unchanged
+
+### P3 (Provider realism defer decision)
+
+- [ ] `P3-C1-S1`: decide whether real provider-style detail is still unnecessary after the first trigger drills
+- [ ] `P3-C1-S2`: decide whether checkout, invoice, and tax surfaces belong in separate later packets
+
+## Current Status (recommended)
+
+- `S0F-10C` is now scaffolded as the intended next `M4` trigger packet after the stable entitlement-boundary closure in `S0F-10B`.
+- `P0` is now complete: the lane now fixes one minimum vocabulary for `payment_event`, `subscription_state`, and `entitlement_snapshot`, plus one explicit allowed-transition boundary that keeps role and entitlement baselines outside the trigger chain.
+- The lane is still `draft`: it now has a concrete trigger-chain contract packet, but it does not yet define the first full transition matrix or replay drill.
+- `roadmap_milestone` is already fixed to `M4`, but `roadmap_phase` remains blank on purpose because the current `road-002` `M4-P0..P3` bridge is already occupied by `S0F-10A` and `S0F-10C` should not guess a new roadmap slot before that follow-up widening is made explicit.
+- Automation should still read this log as an opening source scaffold rather than as a stable policy artifact.
+
+## Evidence (reserved)
+
+- Artifacts are the source of truth for evidence; this log records the head SHA, key parameters, and artifact paths when the lane begins making real bounded changes.
+- This section now begins with `P0` because the trigger-chain vocabulary and boundary contract are complete, even though transition drills are still open.
+
+### P0-C1-S1S2S3 (Minimum trigger-chain vocabulary and allowed transition boundary fixed | 2026-04-15)
+
+- headSha: `working-tree-uncommitted`
+- artifacts:
+  - `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`
+- expected:
+  - the lane should stop using `payment_event`, `subscription_state`, and `entitlement_snapshot` as loose placeholders and should fix one minimum trigger-chain contract vocabulary
+  - the lane should state clearly how external trigger input may change lifecycle standing and how lifecycle standing may change effective entitlement outcome
+  - the lane should keep provider realism deferred while still explaining what later provider-shaped work is allowed to do
+- observed:
+  - `S0F-10C` now fixes one minimum vocabulary where `payment_event` is external trigger input, `subscription_state` is lifecycle standing, and `entitlement_snapshot` is the resulting effective capability bundle
+  - the lane now fixes one allowed transition boundary where trigger inputs may change lifecycle standing and lifecycle standing may change effective entitlement outcome without mutating role or override semantics
+  - the lane now explicitly defers provider realism while allowing later provider-shaped work only as a source of trusted trigger inputs rather than as a replacement for trigger-chain semantics
+
+## Recent changes (for traceability, optional)
+
+- 2026-04-15: opened `S0F-10C` as the next intended `M4` trigger packet so payment and lifecycle triggers can be modeled separately from the already-stable entitlement boundary in `S0F-10B`.
+- 2026-04-15: fixed the opening default that `S0F-10A` remains the role baseline and `S0F-10B` remains the entitlement baseline while `S0F-10C` handles only trigger-chain semantics for later entitlement-state change.
+- 2026-04-15: completed `P0-C1-S1S2S3` by fixing the minimum trigger-chain vocabulary, the allowed transition boundary from external input to lifecycle standing to entitlement outcome, and the explicit defer rule for provider realism.


### PR DESCRIPTION
## Metadata

- Requested ID: `S0F-10C`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s0f-10c`
- Source log: `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`
- Labels: `EVOLUTION, s0/knowledge system, drills`
- Development issue: #489

## Summary

- Open the next `M4` child lane for the bounded `payment_event -> subscription_state -> entitlement` trigger chain after the minimum entitlement boundary is already stable.
- Fix the difference between external trigger inputs, subscription lifecycle state, and entitlement outcomes without rewriting the `10A/10B` baselines.
- Keep provider realism, tax, and invoice detail out of the opening packet unless later phases prove they are required.

## Execution Checklist

- [x] `P0-C1-S1`: fix one minimum vocabulary for `payment_event`, `subscription_state`, and `entitlement_snapshot`
- [x] `P0-C1-S2`: fix the allowed transition boundary from external trigger to lifecycle state to entitlement outcome
- [x] `P0-C1-S3`: keep provider realism explicitly deferred at packet open
- [x] `P1-C1-S1`: fix one minimum trigger matrix for representative payment or lifecycle events
- [x] `P1-C1-S2`: map those transitions to entitlement outcomes without mutating role standing
- [x] `P2-C1-S1`: prove one replay where a trigger changes entitlement outcome through `subscription_state`
- [x] `P2-C1-S2`: prove one replay where the same trigger leaves role and override semantics unchanged
- [x] `P3-C1-S1`: decide whether real provider-style detail is still unnecessary after the first trigger drills
- [x] `P3-C1-S2`: decide whether checkout, invoice, and tax surfaces belong in separate later packets

## Links

- Log: `docs/logs/log-S0F-10C-payment-event-subscription-state-entitlement-trigger-packet.md`

Closes #489
