### PR TITLE
S4F-1A/P0-P3: backend-only access / subscription deployable cut (S4D workflow reuse, access-aware verify, and drills/evidence) v1

### DIFF
--- a/docs/labs/scenarios/catalog.yml
+++ b/docs/labs/scenarios/catalog.yml
@@ -153,6 +153,26 @@ scenarios:
       - runtime:db_only
       - s2c:s2c2a
 
+  - id: verify/access_subscription/deployable_cut
+    aliases:
+      - s4f1a_access_subscription_deployable_cut
+    cli: >-
+      python scripts/drills/s4f1a_p2c1s1_access_subscription_runner.py
+      --env-file "$ENV_FILE"
+      --run-id "$RUN_ID"
+      --outdir "docs/labs/_snapshot/auto/S4F-1A/access_subscription_deployable_cut/$RUN_ID"
+    requires:
+      db: true
+      es: false
+      jaeger: false
+      worker: false
+    defaults: {}
+    tags:
+      - intent:verify
+      - pipeline:access_subscription
+      - runtime:db_api
+      - s4f:s4f1a
+
   - id: verify/chronicle/rebuild_entries_smoke
     aliases:
       - s2c3a_rebuild_chronicle_entries_smoke

--- a/docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md
+++ b/docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md
@@ -83,11 +83,11 @@
 
 - Log: `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
 - Runbook: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
-- Evidence artifact: ``
+- Evidence artifact: `artifacts/_tmp_s4f1a_p2_run_24652525475/labs-evidence-verify_access_subscription_deployable_cut-24652525475-1-verify_access_subscription_deployable_cut/summary.json`
 
 **Evidence Footer Source**:
 
-- `P1-C1-S1S2` | artifact: ``
+- `P2-C1-S1S2` | artifact: `artifacts/_tmp_s4f1a_p2_run_24652525475/labs-evidence-verify_access_subscription_deployable_cut-24652525475-1-verify_access_subscription_deployable_cut/summary.json`
 
 ## Definitions (optional)
 
@@ -318,8 +318,8 @@ curl -sS "$API_BASE_URL/admin/subscriptions/$VERIFY_LIBRARY_ID/history" \
 
 ### P2 (Drill / Verify)
 
-- [ ] `P2-C1-S1`: deployed member read proved
-- [ ] `P2-C1-S2`: deployed admin read + lifecycle re-read proved
+- [x] `P2-C1-S1`: deployed member read proved
+- [x] `P2-C1-S2`: deployed admin read + lifecycle re-read proved
 
 ### P3 (Close-out / next-lane decision)
 
@@ -327,14 +327,25 @@ curl -sS "$API_BASE_URL/admin/subscriptions/$VERIFY_LIBRARY_ID/history" \
 
 ## Current Status (recommended)
 
-- `S4F-1A/P1` is now fixed at the contract level: the packet reuses the stable `S4D` workflow and now carries one explicit deployed verify tuple plus three concrete feature probes.
-- The next step is `P2`: run the deployed member read, admin read, and lifecycle re-read against one real `VERIFY_LIBRARY_ID`, then write the resulting evidence bundle back into this log.
+- `S4F-1A/P2` now has one executable access/subscription drill runner plus one green runtime evidence sample on GitHub-hosted CI: member read, admin read, lifecycle mutation, and deterministic re-read all passed against the same real API + Postgres slice.
+- The packet still reuses the `S4D` deploy contract for operator-facing cloud release, but the first runnable probe harness is now fixed and proven independently from the local Windows/WSL Docker surface.
 
 ## Evidence (reserved)
 
-- Artifacts are the source of truth for evidence; this log records the head SHA, deploy parameters, and deployed member/admin verify artifacts once they exist.
+- Artifacts are the source of truth for evidence; this log records the head SHA, runtime parameters, and the member/admin/lifecycle probe results for the first runnable `S4F-1A` sample.
+- 2026-04-20 | GitHub Actions `drill-labs-scenario` | run id `24652525475`
+  - workflow scenario: `verify/access_subscription/deployable_cut`
+  - head SHA: `1ad8dc57cdb343a5014c0d5dd1d2e211d8601b7b`
+  - runtime shape: GitHub-hosted Ubuntu runner + migrated `wordloom_test` Postgres on `localhost:5435` + API on `http://127.0.0.1:30011`
+  - evidence artifact: `artifacts/_tmp_s4f1a_p2_run_24652525475/labs-evidence-verify_access_subscription_deployable_cut-24652525475-1-verify_access_subscription_deployable_cut/summary.json`
+  - probe target library: `66b766de-6c54-432c-9d75-634360712b47`
+  - member read: `200`, roles=`member`, plan=`trial`, state=`trialing`, entitlements include `read_library`
+  - admin read: `200`, library_id matched, plan=`trial`, state=`trialing`, entitlements include `read_library`
+  - lifecycle mutation: `upgrade_success` returned `200` and promoted `subscription_state` to `active`
+  - deterministic re-read/history: re-read returned `active`; history returned one `upgrade_success` item
 
 ## Recent changes (for traceability, optional)
 
 - 2026-04-20: first created `S4F-1A` as the backend-only access/subscription deployable-cut packet under `road-002-01/M1-P3`.
 - 2026-04-20: completed `P1-C1-S1S2` by binding the packet to the stable `S4D` operator workflow and fixing the first three deployed access-aware verify probes.
+- 2026-04-20: completed `P2-C1-S1S2` by adding the first runnable access/subscription drill harness, dispatching `drill-labs-scenario`, and capturing one green member/admin/lifecycle evidence sample at head `1ad8dc57cdb343a5014c0d5dd1d2e211d8601b7b`.

--- a/docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md
+++ b/docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md
@@ -9,7 +9,7 @@
 **scope**: `S4`
 **tags**: `EVOLUTION, OpsRuntime, CloudRuntime, AccessControl, Verification, Drills, Evidence, epic/s4, sub/1a`
 **links**: ``
-  **issue**: ``
+  **issue**: `https://github.com/samuelhu324-dev/wordloom-v3/issues/507`
   **pr**: ``
   **runbook**: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
   **roadmap**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`

--- a/docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md
+++ b/docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md
@@ -1,0 +1,340 @@
+# log-S4F-1A (Phase 1: Backend-only access / subscription deployable cut)
+
+---
+
+**id**: `S4F-1A`
+**kind**: `log`
+**title**: `backend-only access / subscription deployable cut (S4D workflow reuse, access-aware verify, and drills/evidence) v1`
+**status**: `draft`
+**scope**: `S4`
+**tags**: `EVOLUTION, OpsRuntime, CloudRuntime, AccessControl, Verification, Drills, Evidence, epic/s4, sub/1a`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
+  **roadmap**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
+  **parent_log**: `docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md`
+  **previous_log**: `docs/logs/log-S4D-4A-cloud-runtime-semi-automated-release-workflow.md`
+  **reference_log_1**: `docs/logs/log-S4D-1A-cloud-runtime-release-path.md`
+  **reference_log_2**: `docs/logs/log-S0F-9C-backend-vertical-slice-for-subscription-access-minimum-closure.md`
+  **reference_log_3**: `docs/logs/log-S0F-9H-shared-auth-provider-realism-invite-onboarding-and-membership-admission.md`
+  **reference_log_4**: `docs/logs/log-S0F-10D-scenario-catalog-and-mock-state-machine-replays.md`
+**issue_keyword**: `runtime`
+**issue_top_labels**: ``
+**issue_scope_labels**: ``
+**issue_module_labels**: ``
+**issue_milestone**: ``
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
+**roadmap_milestone**: `M1`
+**roadmap_phase**: `M1-P3`
+**roadmap_bridge_refs**: ``
+**pr_labels**: `drills`
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-20`
+**updated**: `2026-04-20`
+**reviewed**: `pending`
+
+---
+
+## Frontmatter Lifecycle-Time Rule
+
+- `created`, `updated`, and optional `reviewed` are the minimum artifact-lifecycle fields for this runtime packet.
+- Day-level precision is acceptable here because the lane is opening as one bounded deployable-cut packet rather than one fine-grained execution replay.
+- `reviewed` should remain `pending` until the first backend-only access/subscription deployable cut is explicitly accepted.
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S4F-1A` opens the first concrete `road-002-01/M1` execution packet as a backend-only access/subscription deployable cut.
+- The packet reuses the stable `S4D` single-entry release workflow, target shape, and evidence bundle, but replaces generic backend smoke with access-aware verify and member/admin drill contracts.
+
+**Default choices (phase defaults / v1)**:
+
+- Keep the deployable unit as one backend container on one Linux VM against external cloud-dev RDS.
+- Keep frontend cloud closure out of scope for this first lane; the deployed proof should come from backend/API truth first.
+- The first verify contract must prove more than `health` and `libraries`: it must cover at least one member-facing access read, one admin-facing subscription read, and one bounded lifecycle mutation followed by re-read.
+- Reuse `summary.json`, `operator_guidance.txt`, and the existing `S4D` failure taxonomy shape unless one access-specific gap proves a bounded extension is needed.
+- Do not widen into provider realism, UI hosting, worker runtime, or object-storage work in this packet.
+- If any `issue_*` field is blank, automation must leave it blank and ask for human confirmation instead of inferring a keyword, labels, or milestone.
+- If any `pr_*` field is blank, PR automation must leave that PR field blank and report it explicitly instead of copying issue metadata by guesswork.
+- Top-level issues/logs must leave `issue_parent` blank; roadmap bridging must stay explicit through `roadmap_path + roadmap_milestone + roadmap_phase`, not prose-only references.
+
+## PR Summary Inputs (optional)
+
+- Use this block because `S4F-1A` is expected to drive the first concrete deployable-cut PR under `road-002-01/M1`.
+
+**PR summary bullets**:
+
+- Reuse the stable `S4D` cloud release workflow for the first backend-only access/subscription deployable cut.
+- Fix an access-aware verify contract that checks member read, admin read, and bounded lifecycle re-read instead of generic backend smoke only.
+- Prove the first deployed member/admin drill pair on the existing backend access/subscription slice before considering frontend cloud closure.
+
+**PR checklist source**:
+
+- Default source: reuse this log's execution checklist for the generated PR checklist block.
+
+**PR links**:
+
+- Log: `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
+- Runbook: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
+- Evidence artifact: ``
+
+**Evidence Footer Source**:
+
+- `P1-C1-S1S2` | artifact: ``
+
+## Definitions (optional)
+
+- `backend-only deployable cut`: one deployed runtime proof that stops at backend/API truth and does not yet require cloud-hosted UI.
+- `access-aware verify`: one verify surface that checks the deployed access/subscription contract rather than generic runtime liveness alone.
+- `member flow`: one bounded user-facing read path derived from current tenant, subscription state, and effective entitlement truth.
+- `admin flow`: one bounded admin-facing read or mutation path for subscription state and membership-aware access standing.
+
+## Constraints
+
+- Do not invent a second release workflow beside `scripts/ops/cloud_release_workflow.sh`.
+- Do not redefine the stable backend module contract already fixed in `S0F-9C`; consume it as the deployable feature surface.
+- Do not require full frontend cloud hosting or browser E2E for the first packet to pass.
+- Do not accept a verify contract that proves only generic container liveness while skipping access/subscription semantics.
+
+## Scope
+
+- `P0`: contract (deployable cut boundary, verify surface, evidence contract)
+- `P1`: implementation / packaging (bind the current backend access/subscription slice into the reused `S4D` release path)
+- `P2`: drill / verify (run deployed member/admin/lifecycle checks)
+- `P3`: close-out / next-lane decision (decide whether frontend cloud closure is now justified)
+
+## Success Criteria (DoD)
+
+- The packet fixes one explicit backend-only AWS v1 cut for the access/subscription slice.
+- The packet reuses the stable `S4D` release workflow and evidence shape without creating a second operator path.
+- The deployed verify contract covers at least:
+  - one member-facing access-context read
+  - one admin-facing subscription-state read
+  - one bounded lifecycle mutation followed by deterministic re-read
+- The packet leaves one explicit decision about whether the next lane should add frontend cloud closure.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - the deployable-cut boundary is explicit;
+  - the access-aware verify and drill contract is explicit;
+  - at least one deployed evidence bundle proves the backend-only member/admin/lifecycle flow end to end.
+
+## P0 (Contract | v1)
+
+### P0-C1-S1 (Backend-only deployable cut boundary | v1)
+
+- Reuse the existing `S4D` target shape:
+  - one Linux VM
+  - one backend container
+  - one external cloud-dev RDS
+- The feature slice inside that target is the current backend access/subscription surface, not the whole product.
+- The first packet includes:
+  - shared auth/admission-backed backend truth already present in repo
+  - current tenant context and membership-aware access truth
+  - subscription/access aggregation reads
+  - bounded admin lifecycle mutation support
+- The first packet excludes:
+  - frontend cloud hosting
+  - worker deployment
+  - provider callbacks and real billing integration
+
+### P0-C1-S2 (Access-aware verify contract | v1)
+
+- The verify surface must extend generic runtime smoke with the following feature checks:
+  - member read: current access-context or equivalent member-facing aggregated read returns expected standing
+  - admin read: current subscription/admin detail read returns expected state/history
+  - lifecycle re-read: one bounded admin event changes lifecycle state and the resulting read path reflects the change deterministically
+- Generic `health` and startup checks remain necessary but are no longer sufficient by themselves.
+
+### P0-C1-S3 (Evidence contract | v1)
+
+- Evidence JSON must include:
+  - `headSha`
+  - `targetHostKind`
+  - `envFilePath`
+  - `imageTag`
+  - `memberReadResult`
+  - `adminReadResult`
+  - `lifecycleMutationResult`
+  - `rerenderedStateResult`
+  - `deployResult`
+  - `verifyResult`
+  - `rollbackResult`
+  - `result`
+
+## P1 (Implementation / packaging | v1)
+
+### P1-C1-S1 (Reuse binding onto the stable `S4D` workflow | v1)
+
+- `S4F-1A` does not open a second deploy path; the canonical operator entry remains `bash scripts/ops/cloud_release_workflow.sh`.
+- The reused deploy target remains exactly the stable `S4D` target tuple:
+  - one Linux VM reached over SSH
+  - one backend container
+  - one cloud-dev env file
+  - one external cloud-dev RDS
+- `S4F-1A` reuses the existing `S4D` stage contract unchanged for preflight, deploy, generic runtime verify, summary, guidance, and optional rollback:
+  - `preflight.log`
+  - `deploy.log`
+  - `verify.log`
+  - `rollback.log`
+  - `summary.json`
+  - `operator_guidance.txt`
+- The only `S4F-1A` specialization in `P1` is the feature-level verify overlay that must run against the deployed API after the generic `S4D` verify gate is green.
+- The deployed API contract reused by this packet is:
+  - auth carrier: `Authorization: Bearer <jwt>`
+  - tenant carrier: `X-Library-Id: <library-id>`
+  - base URL shape: `http://<target-host>:<api-port>/api/v1`
+- `P1` fixes one explicit operator-supplied verify tuple instead of inventing setup automation in this packet:
+  - `VERIFY_LIBRARY_ID`: one existing library id that already has a valid subscription row in the deployed environment
+  - `MEMBER_TOKEN`: one JWT whose `user_id` resolves to `member` standing for `VERIFY_LIBRARY_ID`
+  - `ADMIN_TOKEN`: one JWT whose `user_id` resolves to `admin` or `owner` standing for `VERIFY_LIBRARY_ID`
+  - `API_BASE_URL`: deployed backend base URL rooted at `/api/v1`
+- `P1` therefore binds the current access/subscription slice into the reused `S4D` path as: `S4D deploy + generic verify PASS` -> `S4F access-aware probes` -> `S4F evidence write-up`.
+
+### P1-C1-S2 (Deploy-time feature probes fixed | v1)
+
+- The first deployed verify contract is fixed as exactly three probes and one shared input block:
+
+```bash
+API_BASE_URL="http://<target-host>:<api-port>/api/v1"
+VERIFY_LIBRARY_ID="<uuid>"
+MEMBER_TOKEN="<jwt>"
+ADMIN_TOKEN="<jwt>"
+```
+
+- Probe 1: member read
+
+```bash
+curl -sS "$API_BASE_URL/access-context/me" \
+  -H "Authorization: Bearer $MEMBER_TOKEN" \
+  -H "X-Library-Id: $VERIFY_LIBRARY_ID"
+```
+
+  Expected result:
+  - HTTP `200`
+  - response `tenant_id == VERIFY_LIBRARY_ID`
+  - response `roles` contains `member`
+  - response contains non-empty `plan_code`
+  - response contains non-empty `subscription_state`
+  - response `entitlements` contains `read_library`
+
+- Probe 2: admin read
+
+```bash
+curl -sS "$API_BASE_URL/admin/subscriptions/$VERIFY_LIBRARY_ID" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "X-Library-Id: $VERIFY_LIBRARY_ID"
+```
+
+  Expected result:
+  - HTTP `200`
+  - response `library_id == VERIFY_LIBRARY_ID`
+  - response contains non-empty `plan_code`
+  - response contains non-empty `subscription_state`
+  - response `entitlements` contains `read_library`
+
+- Probe 3: lifecycle mutation + deterministic re-read
+
+```bash
+curl -sS -X POST "$API_BASE_URL/admin/subscriptions/$VERIFY_LIBRARY_ID/events" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "X-Library-Id: $VERIFY_LIBRARY_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"event_type":"upgrade_success"}'
+
+curl -sS "$API_BASE_URL/admin/subscriptions/$VERIFY_LIBRARY_ID" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "X-Library-Id: $VERIFY_LIBRARY_ID"
+
+curl -sS "$API_BASE_URL/admin/subscriptions/$VERIFY_LIBRARY_ID/history" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "X-Library-Id: $VERIFY_LIBRARY_ID"
+```
+
+  Expected result:
+  - mutation call HTTP `200`
+  - mutation response `library_id == VERIFY_LIBRARY_ID`
+  - mutation response `subscription_state == active`
+  - re-read call HTTP `200`
+  - re-read response `subscription_state == active`
+  - history call HTTP `200`
+  - history response contains at least one item whose `event_type == upgrade_success`
+- The first lifecycle probe is intentionally fixed as one single-step `upgrade_success` promotion. `renewal_failed` or longer chains can be added later in `P2` evidence if one deployed sample proves they are worth widening.
+- `P1` does not require a separate feature script yet. The minimum acceptable implementation for this packet is that the three HTTP probes above can be run deterministically against one deployed backend cut and written back into the `S4D` evidence bundle as `memberReadResult`, `adminReadResult`, `lifecycleMutationResult`, and `rerenderedStateResult`.
+
+## Numbering
+
+- `S<n>`: Step.
+- `C<n>`: Cycle.
+
+**Commit / PR naming**:
+
+- `S4F-1A/P<phase>-C<cycle>-S<steps>: <summary>`
+
+**Branch convention**:
+
+- `S4F-1A` 相关实现与文档优先落在 `S4F-access-subscription-deployable-runtime-cut` 分支。
+
+**Commit discipline (recommended)**:
+
+- 每完成一个有明确边界的 `P*-C*-S*` 单元，应尽量及时 `commit/push` 到 `S4F-access-subscription-deployable-runtime-cut`。
+
+## Plan (draft)
+
+### P1 (Implementation / packaging)
+
+- P1-C1-S1: map the current backend access/subscription slice onto the reused `S4D` release target
+- P1-C1-S2: define the concrete deploy-time verify commands and feature-specific probes
+
+### P2 (Drill / Verify)
+
+- P2-C1-S1: execute one deployed member-facing access read
+- P2-C1-S2: execute one deployed admin read and one bounded lifecycle mutation followed by re-read
+
+### P3 (Close-out / next-lane decision)
+
+- P3-C1-S1: record whether backend-only deployed proof is sufficient or whether frontend cloud closure should open next
+
+## Execution Checklist (unchecked)
+
+### P0 (Contract)
+
+- [x] `P0-C1-S1`: backend-only deployable cut boundary fixed
+- [x] `P0-C1-S2`: access-aware verify contract fixed
+- [x] `P0-C1-S3`: evidence contract fixed
+
+### P1 (Implementation / packaging)
+
+- [x] `P1-C1-S1`: reused `S4D` release path bound to the current access/subscription backend slice
+- [x] `P1-C1-S2`: deploy-time feature probes fixed
+
+### P2 (Drill / Verify)
+
+- [ ] `P2-C1-S1`: deployed member read proved
+- [ ] `P2-C1-S2`: deployed admin read + lifecycle re-read proved
+
+### P3 (Close-out / next-lane decision)
+
+- [ ] `P3-C1-S1`: next-lane decision recorded
+
+## Current Status (recommended)
+
+- `S4F-1A/P1` is now fixed at the contract level: the packet reuses the stable `S4D` workflow and now carries one explicit deployed verify tuple plus three concrete feature probes.
+- The next step is `P2`: run the deployed member read, admin read, and lifecycle re-read against one real `VERIFY_LIBRARY_ID`, then write the resulting evidence bundle back into this log.
+
+## Evidence (reserved)
+
+- Artifacts are the source of truth for evidence; this log records the head SHA, deploy parameters, and deployed member/admin verify artifacts once they exist.
+
+## Recent changes (for traceability, optional)
+
+- 2026-04-20: first created `S4F-1A` as the backend-only access/subscription deployable-cut packet under `road-002-01/M1-P3`.
+- 2026-04-20: completed `P1-C1-S1S2` by binding the packet to the stable `S4D` operator workflow and fixing the first three deployed access-aware verify probes.

--- a/docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md
+++ b/docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md
@@ -270,6 +270,22 @@ curl -sS "$API_BASE_URL/admin/subscriptions/$VERIFY_LIBRARY_ID/history" \
 - The first lifecycle probe is intentionally fixed as one single-step `upgrade_success` promotion. `renewal_failed` or longer chains can be added later in `P2` evidence if one deployed sample proves they are worth widening.
 - `P1` does not require a separate feature script yet. The minimum acceptable implementation for this packet is that the three HTTP probes above can be run deterministically against one deployed backend cut and written back into the `S4D` evidence bundle as `memberReadResult`, `adminReadResult`, `lifecycleMutationResult`, and `rerenderedStateResult`.
 
+## P3 (Close-out / next-lane decision | v1)
+
+### P3-C1-S1 (Decide whether backend-only proof is sufficient | v1)
+
+- Decision: `backend-only proof is sufficient for S4F-1A v1`; do not open frontend cloud closure as the immediate next lane.
+- Why this packet can stop at backend-only:
+  - the current branch-road `M1` goal is a deployable runtime slice, not a full product-hosting closure;
+  - `S4F-1A` already proved the runtime-critical member/admin/lifecycle contract on a real API + Postgres process instead of browser-local state only;
+  - the packet's narrow purpose was to validate access/subscription runtime truth and release-path reuse, not to prove UI residency.
+- The remaining highest-value gap is not frontend hosting; it is operator-facing cloud-target evidence on the reused `S4D` substrate.
+- Therefore the next recommended lane is:
+  - keep the frontend/UI cloud closure deferred;
+  - reuse the same access-aware verify overlay on top of one real `S4D` cloud-target release run;
+  - record one operator-facing release evidence sample where generic `S4D` deploy/verify and `S4F` access-aware probes pass in the same bundle.
+- Only after that cloud-target runtime sample exists should the branch consider a separate packet for frontend cloud closure, broader product-entry residency, or later `Asset Platform` readiness work.
+
 ## Numbering
 
 - `S<n>`: Step.
@@ -323,12 +339,12 @@ curl -sS "$API_BASE_URL/admin/subscriptions/$VERIFY_LIBRARY_ID/history" \
 
 ### P3 (Close-out / next-lane decision)
 
-- [ ] `P3-C1-S1`: next-lane decision recorded
+- [x] `P3-C1-S1`: next-lane decision recorded
 
 ## Current Status (recommended)
 
-- `S4F-1A/P2` now has one executable access/subscription drill runner plus one green runtime evidence sample on GitHub-hosted CI: member read, admin read, lifecycle mutation, and deterministic re-read all passed against the same real API + Postgres slice.
-- The packet still reuses the `S4D` deploy contract for operator-facing cloud release, but the first runnable probe harness is now fixed and proven independently from the local Windows/WSL Docker surface.
+- `S4F-1A/P0-P3` is now complete: the packet fixes the backend-only deployable-cut boundary, reuses the stable `S4D` release path, proves the member/admin/lifecycle contract on runnable infrastructure, and records the next-lane decision.
+- The immediate next step is not frontend cloud closure. The immediate next step is one cloud-target `S4D + S4F` combined evidence sample that proves the same access-aware verify overlay on the operator-facing runtime path.
 
 ## Evidence (reserved)
 
@@ -349,3 +365,4 @@ curl -sS "$API_BASE_URL/admin/subscriptions/$VERIFY_LIBRARY_ID/history" \
 - 2026-04-20: first created `S4F-1A` as the backend-only access/subscription deployable-cut packet under `road-002-01/M1-P3`.
 - 2026-04-20: completed `P1-C1-S1S2` by binding the packet to the stable `S4D` operator workflow and fixing the first three deployed access-aware verify probes.
 - 2026-04-20: completed `P2-C1-S1S2` by adding the first runnable access/subscription drill harness, dispatching `drill-labs-scenario`, and capturing one green member/admin/lifecycle evidence sample at head `1ad8dc57cdb343a5014c0d5dd1d2e211d8601b7b`.
+- 2026-04-20: completed `P3-C1-S1` by deciding that backend-only runtime proof is sufficient for `S4F-1A` v1 and that the next lane should target cloud-path operator evidence before any frontend cloud closure.

--- a/docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md
+++ b/docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md
@@ -1,0 +1,165 @@
+# log-S4F (Access / Subscription Deployable Runtime Cut)
+
+---
+
+**id**: `S4F`
+**kind**: `log`
+**title**: `access / subscription deployable runtime cut v1`
+**status**: `draft`
+**scope**: `S4`
+**tags**: `EVOLUTION, OpsRuntime, CloudRuntime, AccessControl, ReleaseOperations, epic/s4, epic/s4f`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **adr**: ``
+  **runbook**: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
+  **roadmap**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
+  **reference_log_1**: `docs/logs/log-S4D-cloud-runtime-deploy-verify-rollback.md`
+  **reference_log_2**: `docs/logs/log-S4D-4A-cloud-runtime-semi-automated-release-workflow.md`
+  **phase_log_1**: `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
+  **phase_log_2**: ``
+  **phase_log_3**: ``
+  **phase_log_4**: ``
+  **phase_log_5**: ``
+  **phase_log_6**: ``
+**issue_keyword**: `platform`
+**issue_top_labels**: ``
+**issue_scope_labels**: ``
+**issue_module_labels**: ``
+**issue_milestone**: ``
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
+**roadmap_milestone**: `M1`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-20`
+**updated**: `2026-04-20`
+
+---
+
+## Decision / Outcome（结论区）
+
+**Decision**:
+
+- Open `S4F` as the new `S4` top-level spine for the first `road-002-01` deployable runtime cut that reuses the proven `S4D` cloud release path instead of inventing a second release family.
+- Treat `S4F` as the runtime-execution owner for the branch-road's first cloud closure: backend-first access/subscription deployment, access-aware verify gates, and bounded member/admin drills.
+
+**Default choices（默认基线 / v1）**:
+
+- Reuse the stable `S4D` single-VM, backend-container, external-RDS release workflow as the default release substrate.
+- Keep the first `S4F` lane backend-only; do not require frontend cloud closure before the first deployable-cut proof exists.
+- Replace generic backend smoke as the success center with access-aware verify and drill contracts that match the recent auth/access/subscription slice.
+- Keep provider realism, UI cloud hosting, worker cloud residency, and asset-platform work out of the first `S4F` packet.
+- 若 `issue_*` 字段为空，automation 必须保守留空并要求人工确认，而不是猜测 title keyword、labels 或 milestone。
+- 若 `pr_*` 字段为空，PR automation 必须保守留空并显式报告缺口，而不是复制 issue metadata 或猜测 base / milestone / development issue。
+- roadmap 与 logs 的机械桥接必须通过 `roadmap_path + roadmap_milestone + roadmap_phase` 明确声明；roadmap 内的正式 bridge ledger 默认只计入 child logs，而不是 parent/spine prose。
+
+## PR Summary Inputs（可选）
+
+- This parent/spine is intended to define one bounded runtime execution family under `road-002-01`; the concrete review packet should come from `S4F-1A`.
+
+**PR summary bullets**:
+
+- Open one new `S4` spine for the first backend-first access/subscription deployable runtime cut under `road-002-01`.
+- Reuse the stable `S4D` operator workflow and evidence contract instead of creating a second cloud release path.
+- Route the first actual deployable packet into `S4F-1A`, where access-aware verify and member/admin drills are fixed explicitly.
+
+**PR checklist source**:
+
+- Default source: reuse the concrete execution checklist from `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`.
+
+**PR links**:
+
+- Parent log: `docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md`
+- Child log source(s): `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
+- Evidence artifact: ``
+
+## Background（背景）
+
+- `road-002-01` already fixed the first branch-road goal: one deployable AWS-oriented runtime cut for the stable access/auth/subscription slice.
+- The repository already has one proven cloud release substrate in `S4D`: single VM, backend container, external cloud-dev RDS, single-entry operator workflow, failure taxonomy, and machine-readable evidence.
+- The missing piece is no longer generic release plumbing; it is a feature-scoped runtime family that reuses that plumbing for the recent access/subscription slice and replaces generic smoke with access-aware verification.
+
+## Constraints（约束）
+
+- Do not reopen `S4D` as if the cloud release path itself were still undefined.
+- Do not widen the first lane into frontend cloud hosting, worker runtime, or asset-platform readiness.
+- Do not treat local-first access/subscription semantics as sufficient proof once the slice is deployed; `S4F` must define explicit deployed verification and drills.
+- Do not introduce a second competing release workflow when the current `S4D` workflow is already stable and reusable.
+
+## Scope（本 log 范围）
+
+- 本 log 负责：
+  - define `S4F` as the top-level `S4` spine for the first access/subscription deployable runtime cut;
+  - fix the default reuse rule from `S4D` into `road-002-01/M1`;
+  - route the first concrete execution packet to `S4F-1A`.
+- 本 log 不负责：
+  - detailed endpoint lists, drill steps, or evidence blocks for the first packet;
+  - frontend cloud closure or asset-platform design.
+
+## Success Criteria（DoD）
+
+- 结构层面：
+  - readers can see in one place why `S4F` exists and why it is distinct from `S4D` and `S4E`;
+  - `S4F-1A` is explicitly named as the first runtime packet under this spine.
+- 工程层面：
+  - the default release substrate is explicitly the stable `S4D` operator workflow;
+  - the first packet is explicitly backend-only and access-aware.
+- 证据层面：
+  - later `S4F-*` evidence can reuse `S4D` bundle shape while adding access-specific verify/drill results.
+
+## Phases（切片）
+
+- `S4F-1A`（Phase 1）：backend-only access/subscription deployable cut
+  - 详见：`docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
+
+## Execution Checklist（当前骨架里程碑汇总）
+
+- [x] `P0`：`S4F` parent/spine created for the first `road-002-01/M1` runtime packet
+- [x] `P1`：first child packet fixed as `S4F-1A`
+- [x] `P2`：default reuse boundary from `S4D` fixed
+- [ ] `P3`：first concrete deployable packet executed and evidenced
+
+## Current Status（进展摘要）
+
+- `S4F` is newly opened as a draft spine.
+- The first concrete work is delegated immediately to `S4F-1A`.
+- The current next step is not further parent-spine drafting; it is to fix the exact backend-only deployable cut and access-aware verify contract in `S4F-1A`.
+
+## Notes（落地原则，可选）
+
+- Reuse infrastructure and workflow first; only specialize the verify/drill contract.
+- Keep the first deployed proof narrow enough that one operator can explain it end to end.
+
+## Stability（stable 口径）
+
+- 本 log 标记为 `stable` 表示：
+  - the `S4F` family boundary is fixed;
+  - the default reuse rule from `S4D` is fixed;
+  - the first concrete packet and its success criteria are explicit.
+
+## Numbering & Commit Naming（编号与提交命名）
+
+- 编号约定：`P<n>` 表示 Phase，`C<n>` 表示 Cycle，`S<n>` 表示 Step。
+- Commit / PR 命名：
+  - 基础形式：`S4F/P<phase>-C<cycle>-S<steps>: <summary>`；
+  - 若一个 PR 一次性汇总多个完整 phase，应优先压缩成 phase 范围标题：`S4F/P0-P3: access / subscription deployable runtime cut`。
+
+**Branch 约定（建议）**:
+
+- `S4F` 相关实现与文档当前优先落在 `S4F-access-subscription-deployable-runtime-cut` 分支。
+
+**Commit 纪律（建议）**:
+
+- 每完成一个有明确边界的 `P*-C*-S*` 单元，应尽量及时 `commit/push`；
+- phase-specific 变更优先使用对应 child log 前缀，例如 `S4F-1A/...`。
+
+## Recent changes（for traceability，可选）
+
+- 2026-04-20：首次创建 `S4F`，作为 `road-002-01/M1` 的新 `S4` 顶层 spine，并把第一条 execution lane 固定到 `S4F-1A`。

--- a/docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md
+++ b/docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md
@@ -78,7 +78,7 @@
 
 - Parent log: `docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md`
 - Child log source(s): `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
-- Evidence artifact: ``
+- Evidence artifact: `artifacts/_tmp_s4f1a_p2_run_24652525475/labs-evidence-verify_access_subscription_deployable_cut-24652525475-1-verify_access_subscription_deployable_cut/summary.json`
 
 ## Background（背景）
 
@@ -124,13 +124,12 @@
 - [x] `P0`：`S4F` parent/spine created for the first `road-002-01/M1` runtime packet
 - [x] `P1`：first child packet fixed as `S4F-1A`
 - [x] `P2`：default reuse boundary from `S4D` fixed
-- [ ] `P3`：first concrete deployable packet executed and evidenced
+- [x] `P3`：first concrete deployable packet executed and evidenced
 
 ## Current Status（进展摘要）
 
-- `S4F` is newly opened as a draft spine.
-- The first concrete work is delegated immediately to `S4F-1A`.
-- The current next step is not further parent-spine drafting; it is to fix the exact backend-only deployable cut and access-aware verify contract in `S4F-1A`.
+- `S4F` now has one completed first packet in `S4F-1A`: backend-only access/subscription deployable cut, runnable access-aware drills, and a recorded next-lane decision.
+- The next `S4F` lane should not reopen the parent spine or jump directly to frontend cloud hosting; it should package one operator-facing cloud-target evidence run where the reused `S4D` release path and the `S4F` access-aware verify overlay pass together.
 
 ## Notes（落地原则，可选）
 
@@ -163,3 +162,4 @@
 ## Recent changes（for traceability，可选）
 
 - 2026-04-20：首次创建 `S4F`，作为 `road-002-01/M1` 的新 `S4` 顶层 spine，并把第一条 execution lane 固定到 `S4F-1A`。
+- 2026-04-20：`S4F-1A` completed `P0-P3`, so the parent spine now has its first executed and evidenced child packet plus one explicit next-lane decision: prioritize cloud-path operator evidence before frontend cloud closure.

--- a/scripts/drills/s4f1a_p2c1s1_access_subscription_runner.py
+++ b/scripts/drills/s4f1a_p2c1s1_access_subscription_runner.py
@@ -1,0 +1,548 @@
+"""S4F-1A P2 access/subscription drills runner.
+
+Runs the three access-aware probes defined by the S4F-1A packet against a
+real local API process started inside the drill runtime:
+- member access-context read
+- admin subscription read
+- admin lifecycle mutation followed by deterministic re-read/history
+
+The script is designed for GitHub Actions `drill-labs-scenario` execution, but
+it can also be run locally when a PostgreSQL database is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+import jwt
+from sqlalchemy import create_engine, text
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = REPO_ROOT / "backend"
+DEFAULT_SCENARIO = "verify/access_subscription/deployable_cut"
+DEFAULT_SUITE_ID = "access_subscription_deployable_cut"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _load_env_file(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        env[key] = value
+    return env
+
+
+def _convert_to_psycopg(url: str) -> str:
+    if url.startswith("postgresql+psycopg://"):
+        return url
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+psycopg://", 1)
+    if url.startswith("postgresql+asyncpg://"):
+        return url.replace("postgresql+asyncpg://", "postgresql+psycopg://", 1)
+    if url.startswith("postgresql+"):
+        parts = url.split("://", 1)
+        if len(parts) == 2:
+            return f"postgresql+psycopg://{parts[1]}"
+    return url
+
+
+def _redact_database_url(url: str) -> str:
+    return re.sub(r":([^@]+)@", r":***@", url, count=1)
+
+
+def _get_git_sha() -> str | None:
+    sha = os.getenv("GITHUB_SHA", "").strip()
+    if sha:
+        return sha
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(REPO_ROOT),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return None
+
+
+def _make_token(*, user_id: uuid.UUID, secret_key: str, algorithm: str) -> str:
+    payload = {
+        "user_id": str(user_id),
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=30),
+    }
+    return jwt.encode(payload, secret_key, algorithm=algorithm)
+
+
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _append_log(path: Path, line: str) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line.rstrip() + "\n")
+
+
+def _parse_json_response(response: httpx.Response) -> Any:
+    content_type = (response.headers.get("content-type") or "").lower()
+    if "application/json" not in content_type:
+        return None
+    try:
+        return response.json()
+    except Exception:
+        return None
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _start_api_process(*, env: dict[str, str], logs_dir: Path) -> subprocess.Popen[str]:
+    api_stdout = (logs_dir / "api.stdout.log").open("w", encoding="utf-8")
+    api_stderr = (logs_dir / "api.stderr.log").open("w", encoding="utf-8")
+    command = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "api.app.main:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        env["API_PORT"],
+    ]
+    return subprocess.Popen(
+        command,
+        cwd=str(BACKEND_DIR),
+        env=env,
+        stdout=api_stdout,
+        stderr=api_stderr,
+        text=True,
+    )
+
+
+def _wait_for_health(*, base_url: str, process: subprocess.Popen[str], log_path: Path, timeout_s: float = 60.0) -> None:
+    deadline = time.time() + timeout_s
+    last_error = "health_timeout"
+    while time.time() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"api_process_exited:{process.returncode}")
+        try:
+            response = httpx.get(f"{base_url}/api/v1/health", timeout=3.0)
+            if response.status_code == 200:
+                _append_log(log_path, f"api_health=200 base_url={base_url}")
+                return
+            last_error = f"health_status_{response.status_code}"
+        except Exception as exc:  # noqa: BLE001
+            last_error = f"{type(exc).__name__}:{exc}"
+        time.sleep(1.0)
+    raise RuntimeError(last_error)
+
+
+def _seed_subscription_state(*, database_url: str, library_id: str, log_path: Path) -> None:
+    engine = create_engine(_convert_to_psycopg(database_url), future=True)
+    try:
+        with engine.begin() as conn:
+            subscription_id = str(uuid.uuid4())
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO subscriptions (id, library_id, plan_code, state, created_at, updated_at)
+                    VALUES (:id, :library_id, 'trial', 'trialing', TIMEZONE('utc', NOW()), TIMEZONE('utc', NOW()))
+                    """
+                ),
+                {"id": subscription_id, "library_id": library_id},
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO entitlement_snapshots (
+                      id,
+                      library_id,
+                      plan_code,
+                      subscription_state,
+                      entitlements,
+                      created_at,
+                      updated_at
+                    )
+                    VALUES (
+                      :id,
+                      :library_id,
+                      'trial',
+                      'trialing',
+                      'read_library',
+                      TIMEZONE('utc', NOW()),
+                      TIMEZONE('utc', NOW())
+                    )
+                    """
+                ),
+                {"id": str(uuid.uuid4()), "library_id": library_id},
+            )
+        _append_log(log_path, f"seed_subscription_state=ok library_id={library_id}")
+    finally:
+        engine.dispose()
+
+
+def _normalize_roles(value: Any) -> list[str]:
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value]
+    return []
+
+
+def _normalize_history_items(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    items = value.get("items")
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def run(*, env_file: Path, run_id: str, outdir: Path, scenario: str) -> dict[str, Any]:
+    _ensure_dir(outdir)
+    logs_dir = outdir / "_logs"
+    metrics_dir = outdir / "_metrics"
+    _ensure_dir(logs_dir)
+    _ensure_dir(metrics_dir)
+
+    runner_log = logs_dir / "runner.log"
+    _append_log(runner_log, f"started_at={_now_iso()}")
+    _append_log(runner_log, f"run_id={run_id}")
+
+    base_env = os.environ.copy()
+    base_env.update(_load_env_file(env_file))
+
+    owner_user_id = uuid.uuid4()
+    member_user_id = uuid.uuid4()
+    admin_user_id = uuid.uuid4()
+
+    api_port = str(base_env.get("API_PORT") or "30011")
+    api_base_url = (base_env.get("WORDLOOM_API_BASE_URL") or f"http://127.0.0.1:{api_port}").rstrip("/")
+    database_url = (base_env.get("DATABASE_URL") or "").strip()
+    secret_key = (base_env.get("WORDLOOM_JWT_SECRET_KEY") or base_env.get("SECRET_KEY") or "dev-secret-key-change-in-production").strip()
+    algorithm = (base_env.get("WORDLOOM_JWT_ALG") or base_env.get("ALGORITHM") or "HS256").strip()
+
+    _require(bool(database_url), "DATABASE_URL is required")
+
+    api_env = base_env.copy()
+    api_env["API_PORT"] = api_port
+    api_env["DEV_USER_ID"] = str(owner_user_id)
+    api_env["PYTHONPATH"] = str(BACKEND_DIR)
+    api_env.setdefault("WORDLOOM_ENV", "test")
+    api_env.setdefault("ENVIRONMENT", "ci-test")
+
+    git_sha = _get_git_sha()
+    started_at = _now_iso()
+
+    recipe = {
+        "schema_version": "s4f-1a.recipe.v1",
+        "scenario": scenario,
+        "suite_id": DEFAULT_SUITE_ID,
+        "run_id": run_id,
+        "meta": {
+            "started_at": started_at,
+            "git_sha": git_sha,
+        },
+        "config": {
+            "env_file": str(env_file),
+            "api_base_url": api_base_url,
+            "database_url_redacted": _redact_database_url(database_url),
+            "jwt_algorithm": algorithm,
+            "owner_user_id": str(owner_user_id),
+        },
+        "contract": {
+            "member_probe": "/api/v1/access-context/me",
+            "admin_probe": "/api/v1/admin/subscriptions/{library_id}",
+            "lifecycle_probe": "/api/v1/admin/subscriptions/{library_id}/events",
+        },
+    }
+    _write_json(outdir / "_recipe.json", recipe)
+
+    api_process: subprocess.Popen[str] | None = None
+    result_payload: dict[str, Any] = {}
+    timings: dict[str, float] = {}
+
+    try:
+        api_process = _start_api_process(env=api_env, logs_dir=logs_dir)
+        _wait_for_health(base_url=api_base_url, process=api_process, log_path=runner_log)
+
+        owner_token = _make_token(user_id=owner_user_id, secret_key=secret_key, algorithm=algorithm)
+        member_token = _make_token(user_id=member_user_id, secret_key=secret_key, algorithm=algorithm)
+        admin_token = _make_token(user_id=admin_user_id, secret_key=secret_key, algorithm=algorithm)
+
+        t_create = time.time()
+        with httpx.Client(base_url=api_base_url, timeout=30.0) as client:
+            create_response = client.post(
+                "/api/v1/libraries",
+                json={
+                    "name": f"s4f1a-{run_id[:8]}",
+                    "description": "S4F-1A drill library",
+                },
+            )
+            create_json = _parse_json_response(create_response) or {}
+            _require(create_response.status_code == 201, f"create_library_status={create_response.status_code}")
+            library_id = str(create_json.get("id") or "")
+            _require(bool(library_id), "create_library_missing_id")
+            timings["create_library_seconds"] = round(time.time() - t_create, 3)
+
+            _seed_subscription_state(database_url=database_url, library_id=library_id, log_path=runner_log)
+
+            owner_headers = {
+                "Authorization": f"Bearer {owner_token}",
+                "X-Library-Id": library_id,
+            }
+            for granted_user_id, role in ((member_user_id, "member"), (admin_user_id, "admin")):
+                grant_response = client.post(
+                    f"/api/v1/libraries/{library_id}/memberships",
+                    headers=owner_headers,
+                    json={"user_id": str(granted_user_id), "role": role},
+                )
+                _require(grant_response.status_code == 204, f"grant_membership_{role}_status={grant_response.status_code}")
+
+            t_member = time.time()
+            member_response = client.get(
+                "/api/v1/access-context/me",
+                headers={
+                    "Authorization": f"Bearer {member_token}",
+                    "X-Library-Id": library_id,
+                },
+            )
+            member_json = _parse_json_response(member_response) or {}
+            timings["member_probe_seconds"] = round(time.time() - t_member, 3)
+
+            t_admin = time.time()
+            admin_response = client.get(
+                f"/api/v1/admin/subscriptions/{library_id}",
+                headers={
+                    "Authorization": f"Bearer {admin_token}",
+                    "X-Library-Id": library_id,
+                },
+            )
+            admin_json = _parse_json_response(admin_response) or {}
+            timings["admin_probe_seconds"] = round(time.time() - t_admin, 3)
+
+            t_lifecycle = time.time()
+            lifecycle_response = client.post(
+                f"/api/v1/admin/subscriptions/{library_id}/events",
+                headers={
+                    "Authorization": f"Bearer {admin_token}",
+                    "X-Library-Id": library_id,
+                },
+                json={"event_type": "upgrade_success"},
+            )
+            lifecycle_json = _parse_json_response(lifecycle_response) or {}
+
+            reread_response = client.get(
+                f"/api/v1/admin/subscriptions/{library_id}",
+                headers={
+                    "Authorization": f"Bearer {admin_token}",
+                    "X-Library-Id": library_id,
+                },
+            )
+            reread_json = _parse_json_response(reread_response) or {}
+
+            history_response = client.get(
+                f"/api/v1/admin/subscriptions/{library_id}/history",
+                headers={
+                    "Authorization": f"Bearer {admin_token}",
+                    "X-Library-Id": library_id,
+                },
+            )
+            history_json = _parse_json_response(history_response) or {}
+            timings["lifecycle_probe_seconds"] = round(time.time() - t_lifecycle, 3)
+
+        member_roles = _normalize_roles(member_json.get("roles"))
+        admin_entitlements = member_json.get("entitlements") if isinstance(member_json.get("entitlements"), list) else member_json.get("entitlements")
+        history_items = _normalize_history_items(history_json)
+
+        member_ok = (
+            member_response.status_code == 200
+            and str(member_json.get("tenant_id")) == library_id
+            and "member" in member_roles
+            and bool(member_json.get("plan_code"))
+            and bool(member_json.get("subscription_state"))
+            and "read_library" in list(member_json.get("entitlements") or [])
+        )
+        admin_ok = (
+            admin_response.status_code == 200
+            and str(admin_json.get("library_id")) == library_id
+            and bool(admin_json.get("plan_code"))
+            and bool(admin_json.get("subscription_state"))
+            and "read_library" in list(admin_json.get("entitlements") or [])
+        )
+        lifecycle_ok = (
+            lifecycle_response.status_code == 200
+            and str(lifecycle_json.get("library_id")) == library_id
+            and lifecycle_json.get("subscription_state") == "active"
+        )
+        rerender_ok = (
+            reread_response.status_code == 200
+            and reread_json.get("subscription_state") == "active"
+            and history_response.status_code == 200
+            and any(item.get("event_type") == "upgrade_success" for item in history_items)
+        )
+
+        finished_at = _now_iso()
+        result_payload = {
+            "schema_version": "s4f-1a.result.v1",
+            "scenario": scenario,
+            "suite_id": DEFAULT_SUITE_ID,
+            "run_id": run_id,
+            "run_dir": str(outdir.resolve()),
+            "ok": bool(member_ok and admin_ok and lifecycle_ok and rerender_ok),
+            "meta": {
+                "started_at": started_at,
+                "finished_at": finished_at,
+                "git_sha": git_sha,
+                "api_base_url": api_base_url,
+                "database_url_redacted": _redact_database_url(database_url),
+                "library_id": library_id,
+                "owner_user_id": str(owner_user_id),
+                "member_user_id": str(member_user_id),
+                "admin_user_id": str(admin_user_id),
+            },
+            "checks": {
+                "memberReadResult": member_ok,
+                "adminReadResult": admin_ok,
+                "lifecycleMutationResult": lifecycle_ok,
+                "rerenderedStateResult": rerender_ok,
+            },
+            "observed": {
+                "createLibrary": {
+                    "status_code": create_response.status_code,
+                    "body": create_json,
+                },
+                "memberReadResult": {
+                    "status_code": member_response.status_code,
+                    "body": member_json,
+                },
+                "adminReadResult": {
+                    "status_code": admin_response.status_code,
+                    "body": admin_json,
+                },
+                "lifecycleMutationResult": {
+                    "status_code": lifecycle_response.status_code,
+                    "body": lifecycle_json,
+                },
+                "rerenderedStateResult": {
+                    "status_code": reread_response.status_code,
+                    "body": reread_json,
+                },
+                "historyResult": {
+                    "status_code": history_response.status_code,
+                    "body": history_json,
+                },
+            },
+            "summary": {
+                "total": 4,
+                "passed": int(member_ok) + int(admin_ok) + int(lifecycle_ok) + int(rerender_ok),
+                "failed": 4 - (int(member_ok) + int(admin_ok) + int(lifecycle_ok) + int(rerender_ok)),
+            },
+        }
+        _write_json(metrics_dir / "timings.json", timings)
+        return result_payload
+    finally:
+        if api_process is not None:
+            api_process.terminate()
+            try:
+                api_process.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                api_process.kill()
+                api_process.wait(timeout=15)
+        if not (metrics_dir / "timings.json").exists():
+            _write_json(metrics_dir / "timings.json", timings)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run S4F-1A P2 access/subscription drills")
+    parser.add_argument("--env-file", default=os.getenv("ENV_FILE", ".env.test"))
+    parser.add_argument("--run-id", default=os.getenv("RUN_ID") or str(uuid.uuid4()))
+    parser.add_argument("--outdir", default="")
+    parser.add_argument("--scenario", default=DEFAULT_SCENARIO)
+    args = parser.parse_args()
+
+    env_file = Path(args.env_file)
+    if not env_file.is_absolute():
+        env_file = (REPO_ROOT / env_file).resolve()
+    if not env_file.exists():
+        raise SystemExit(f"env_file_not_found:{env_file}")
+
+    if args.outdir:
+        outdir = Path(args.outdir)
+        if not outdir.is_absolute():
+            outdir = (REPO_ROOT / outdir).resolve()
+    else:
+        outdir = REPO_ROOT / "docs" / "labs" / "_snapshot" / "auto" / "S4F-1A" / DEFAULT_SUITE_ID / str(args.run_id)
+
+    started_at = _now_iso()
+    try:
+        result = run(env_file=env_file, run_id=str(args.run_id), outdir=outdir, scenario=str(args.scenario))
+    except Exception as exc:  # noqa: BLE001
+        failed_at = _now_iso()
+        _ensure_dir(outdir)
+        _ensure_dir(outdir / "_logs")
+        _ensure_dir(outdir / "_metrics")
+        _append_log(outdir / "_logs" / "runner.log", f"error={type(exc).__name__}:{exc}")
+        failure_payload = {
+            "schema_version": "s4f-1a.result.v1",
+            "scenario": str(args.scenario),
+            "suite_id": DEFAULT_SUITE_ID,
+            "run_id": str(args.run_id),
+            "run_dir": str(outdir.resolve()),
+            "ok": False,
+            "meta": {
+                "started_at": started_at,
+                "finished_at": failed_at,
+                "git_sha": _get_git_sha(),
+            },
+            "checks": {
+                "memberReadResult": False,
+                "adminReadResult": False,
+                "lifecycleMutationResult": False,
+                "rerenderedStateResult": False,
+            },
+            "observed": {
+                "error": {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                }
+            },
+            "summary": {"total": 4, "passed": 0, "failed": 4},
+        }
+        _write_json(outdir / "_result.json", failure_payload)
+        _write_json(outdir / "_metrics" / "timings.json", {"failed": True})
+        return 2
+
+    _write_json(outdir / "_result.json", result)
+    return 0 if bool(result.get("ok")) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Metadata

- Requested ID: `S4F-1A`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s4f-1a`
- Source log: `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
- Labels: `drills`
- Development issue: #507

## Summary

- Reuse the stable `S4D` cloud release workflow for the first backend-only access/subscription deployable cut.
- Fix an access-aware verify contract that checks member read, admin read, and bounded lifecycle re-read instead of generic backend smoke only.
- Prove the first deployed member/admin drill pair on the existing backend access/subscription slice before considering frontend cloud closure.

## Execution Checklist

- [x] `P0-C1-S1`: backend-only deployable cut boundary fixed
- [x] `P0-C1-S2`: access-aware verify contract fixed
- [x] `P0-C1-S3`: evidence contract fixed
- [x] `P1-C1-S1`: reused `S4D` release path bound to the current access/subscription backend slice
- [x] `P1-C1-S2`: deploy-time feature probes fixed
- [x] `P2-C1-S1`: deployed member read proved
- [x] `P2-C1-S2`: deployed admin read + lifecycle re-read proved
- [x] `P3-C1-S1`: next-lane decision recorded

## Links

- Log: `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
- Runbook: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
- Evidence artifact: `artifacts/_tmp_s4f1a_p2_run_24652525475/labs-evidence-verify_access_subscription_deployable_cut-24652525475-1-verify_access_subscription_deployable_cut/summary.json`

## Evidence Footer

- `P2-C1-S1S2` | artifact: `artifacts/_tmp_s4f1a_p2_run_24652525475/labs-evidence-verify_access_subscription_deployable_cut-24652525475-1-verify_access_subscription_deployable_cut/summary.json`

Closes #507
