### PR TITLE
S4F-2A/P0-P3: cloud-target operator evidence packet (S4D release path reuse + S4F access-aware verify overlay) v1

### DIFF
--- a/.github/workflows/s4d-cloud-release-dispatch-stable-runner.yml
+++ b/.github/workflows/s4d-cloud-release-dispatch-stable-runner.yml
@@ -75,6 +75,11 @@ on:
         required: true
         type: string
         default: "3"
+      access_verify_overlay:
+        description: "Run the S4F access-aware verify overlay after generic S4D verify passes."
+        required: true
+        type: boolean
+        default: false
       rollback_on_verify_fail:
         description: "Automatically attempt rollback when verify fails and a known-good image tag is supplied."
         required: true
@@ -187,6 +192,10 @@ jobs:
             cmd+=(--rollback-on-verify-fail)
           fi
 
+          if [ "${{ inputs.access_verify_overlay }}" = "true" ]; then
+            cmd+=(--access-verify-overlay)
+          fi
+
           printf '### Dispatch command (sanitized)\n\n' >> "$GITHUB_STEP_SUMMARY"
           printf '\`\`\`bash\n%s\n\`\`\`\n\n' "${cmd[*]//${S4D_SSH_IDENTITY_FILE}/***REDACTED***}" >> "$GITHUB_STEP_SUMMARY"
 
@@ -272,6 +281,24 @@ jobs:
                   summary_lines.append(f"| {key} | {value} |")
           else:
               summary_lines.append("No gateResults found in summary.json.")
+
+          access_keys = [
+              "accessVerifyResult",
+              "memberReadResult",
+              "adminReadResult",
+              "lifecycleMutationResult",
+              "rerenderedStateResult",
+          ]
+          if any(key in data for key in access_keys):
+              summary_lines.extend([
+                  "",
+                  "### Access Verify Overlay",
+                  "",
+                  "| Field | Value |",
+                  "| --- | --- |",
+              ])
+              for key in access_keys:
+                  summary_lines.append(f"| {key} | {data.get(key, 'unknown')} |")
 
           artifacts = data.get("artifacts") or {}
           summary_lines.extend([

--- a/.github/workflows/s4d-cloud-release-dispatch.yml
+++ b/.github/workflows/s4d-cloud-release-dispatch.yml
@@ -81,6 +81,11 @@ on:
         required: true
         type: string
         default: "3"
+      access_verify_overlay:
+        description: "Run the S4F access-aware verify overlay after generic S4D verify passes."
+        required: true
+        type: boolean
+        default: false
       rollback_on_verify_fail:
         description: "Automatically attempt rollback when verify fails and a known-good image tag is supplied."
         required: true
@@ -118,6 +123,7 @@ jobs:
       S4D_API_PORT: ${{ github.event_name == 'workflow_dispatch' && inputs.api_port || '30021' }}
       S4D_VERIFY_MAX_WAIT_SECONDS: ${{ github.event_name == 'workflow_dispatch' && inputs.verify_max_wait_seconds || '180' }}
       S4D_VERIFY_POLL_INTERVAL_SECONDS: ${{ github.event_name == 'workflow_dispatch' && inputs.verify_poll_interval_seconds || '3' }}
+      S4D_ACCESS_VERIFY_OVERLAY: ${{ github.event_name == 'workflow_dispatch' && inputs.access_verify_overlay || 'false' }}
       S4D_ROLLBACK_ON_VERIFY_FAIL: ${{ github.event_name == 'workflow_dispatch' && inputs.rollback_on_verify_fail || 'false' }}
     defaults:
       run:
@@ -266,6 +272,10 @@ jobs:
             cmd+=(--rollback-on-verify-fail)
           fi
 
+          if [ "$S4D_ACCESS_VERIFY_OVERLAY" = "true" ]; then
+            cmd+=(--access-verify-overlay)
+          fi
+
           printf '### Dispatch command (sanitized)\n\n' >> "$GITHUB_STEP_SUMMARY"
           printf '\`\`\`bash\n%s\n\`\`\`\n\n' "${cmd[*]//${S4D_SSH_IDENTITY_FILE}/***REDACTED***}" >> "$GITHUB_STEP_SUMMARY"
 
@@ -353,6 +363,24 @@ jobs:
                   summary_lines.append(f"| {key} | {value} |")
           else:
               summary_lines.append("No gateResults found in summary.json.")
+
+          access_keys = [
+              "accessVerifyResult",
+              "memberReadResult",
+              "adminReadResult",
+              "lifecycleMutationResult",
+              "rerenderedStateResult",
+          ]
+          if any(key in data for key in access_keys):
+              summary_lines.extend([
+                  "",
+                  "### Access Verify Overlay",
+                  "",
+                  "| Field | Value |",
+                  "| --- | --- |",
+              ])
+              for key in access_keys:
+                  summary_lines.append(f"| {key} | {data.get(key, 'unknown')} |")
 
           artifacts = data.get("artifacts") or {}
           summary_lines.extend([

--- a/docs/logs/log-S4F-2A-cloud-target-operator-evidence-packet.md
+++ b/docs/logs/log-S4F-2A-cloud-target-operator-evidence-packet.md
@@ -1,0 +1,356 @@
+# log-S4F-2A (Phase 2: Cloud-target operator evidence packet)
+
+---
+
+**id**: `S4F-2A`
+**kind**: `log`
+**title**: `cloud-target operator evidence packet (S4D release path reuse + S4F access-aware verify overlay) v1`
+**status**: `stable`
+**scope**: `S4`
+**tags**: `EVOLUTION, OpsRuntime, CloudRuntime, AccessControl, Verification, ReleaseOperations, Drills, Evidence, epic/s4, sub/2a`
+**links**: ``
+  **issue**: `https://github.com/samuelhu324-dev/wordloom-v3/issues/508`
+  **pr**: ``
+  **runbook**: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
+  **roadmap**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
+  **parent_log**: `docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md`
+  **previous_log**: `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
+  **reference_log_1**: `docs/logs/log-S4D-2A-post-change-verification-and-operational-checks.md`
+  **reference_log_2**: `docs/logs/log-S4D-4A-cloud-runtime-semi-automated-release-workflow.md`
+  **reference_log_3**: `docs/logs/log-S4D-4C-408-timeout-eradication.md`
+  **reference_log_4**: `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
+**issue_keyword**: `runtime`
+**issue_top_labels**: ``
+**issue_scope_labels**: ``
+**issue_module_labels**: ``
+**issue_milestone**: ``
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
+**roadmap_milestone**: `M1`
+**roadmap_phase**: `M1-P3`
+**roadmap_bridge_refs**: ``
+**pr_labels**: `drills`
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-20`
+**updated**: `2026-04-20`
+**reviewed**: `pending`
+
+---
+
+## Frontmatter Lifecycle-Time Rule
+
+- `created`, `updated`, and optional `reviewed` are the minimum artifact-lifecycle fields for this runtime packet.
+- Day-level precision is acceptable here because the lane is opening as one bounded operator-evidence packet rather than one long multi-environment program.
+- `reviewed` should remain `pending` until one real cloud-target operator evidence bundle is accepted.
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S4F-2A` opens the next concrete `S4F` packet after `S4F-1A`, focusing on one operator-facing cloud-target evidence run instead of more local or CI-only runtime proof.
+- The packet reuses the stable `S4D` release substrate and adds the `S4F` access-aware verify overlay so one evidence bundle can prove both generic deploy/verify success and feature-level member/admin/lifecycle success.
+
+**Default choices (phase defaults / v1)**:
+
+- Keep the target shape on the existing `S4D` substrate: one Linux VM, one backend container, one cloud-dev env file, and one external cloud-dev RDS.
+- Do not open frontend cloud closure in this packet; the required proof is operator-facing cloud runtime evidence for the backend access/subscription slice.
+- Do not invent a new workflow. The default entry remains the reused `S4D` operator workflow and its stable evidence bundle shape.
+- Evidence in this packet must be cloud-target and operator-facing; GitHub-hosted CI runtime proof alone is no longer sufficient.
+- If any `issue_*` field is blank, automation must leave it blank and ask for human confirmation instead of inferring a keyword, labels, or milestone.
+- If any `pr_*` field is blank, PR automation must leave that PR field blank and report it explicitly instead of copying issue metadata by guesswork.
+- Top-level issues/logs must leave `issue_parent` blank; roadmap bridging must stay explicit through `roadmap_path + roadmap_milestone + roadmap_phase`, not prose-only references.
+
+## PR Summary Inputs (optional)
+
+- Use this block because `S4F-2A` is intended to drive the next deployment-facing PR under `road-002-01/M1-P3`.
+
+**PR summary bullets**:
+
+- Reuse the stable `S4D` cloud release path for one operator-facing cloud-target evidence run of the access/subscription slice.
+- Add the `S4F` access-aware verify overlay to the same run so member/admin/lifecycle probes are proven on the actual release path.
+- Close the gap left by `S4F-1A`: move from runnable CI proof to operator-facing cloud runtime evidence.
+
+**PR checklist source**:
+
+- Default source: reuse this log's execution checklist for the generated PR checklist block.
+
+**PR links**:
+
+- Log: `docs/logs/log-S4F-2A-cloud-target-operator-evidence-packet.md`
+- Runbook: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
+- Evidence artifact: `artifacts/_tmp_s4d4b_cloud_release_dispatch/24662387235-1/summary.json`
+
+**Evidence Footer Source**:
+
+- `P2-C1-S1` | artifact: `artifacts/_tmp_s4d4b_cloud_release_dispatch/24662387235-1/summary.json`
+
+## Definitions (optional)
+
+- `cloud-target operator evidence`: one evidence bundle produced through the real `S4D` release path against the actual cloud-target runtime, not a host-local drill harness.
+- `access-aware verify overlay`: the `S4F` probe layer that checks member read, admin read, lifecycle mutation, and deterministic re-read on top of generic runtime readiness.
+- `combined evidence bundle`: one retained artifact set where `preflight/deploy/verify` results and `memberReadResult/adminReadResult/lifecycleMutationResult/rerenderedStateResult` can be read together.
+
+## Constraints
+
+- Do not introduce a second operator path beside `scripts/ops/cloud_release_workflow.sh`.
+- Do not widen this packet into frontend cloud hosting, worker residency, or asset-platform object handling.
+- Do not treat generic health or startup checks as sufficient; the packet must prove the feature overlay on the same cloud-target path.
+- Do not claim success from CI-hosted local runtime only; the required evidence surface is the operator-facing cloud release path.
+
+## Scope
+
+- `P0`: contract (combined cloud-target evidence shape, verify overlay boundary, operator input tuple)
+- `P1`: implementation / packaging (wire `S4F` access-aware probes onto the reused `S4D` operator path and artifact bundle)
+- `P2`: drill / verify (capture one real cloud-target operator evidence run)
+- `P3`: close-out / next-lane decision (decide whether `M1` is sufficiently evidenced or whether one more realism-tightening packet is required)
+
+## Success Criteria (DoD)
+
+- The packet fixes one explicit cloud-target operator evidence boundary for the access/subscription slice.
+- The packet reuses the stable `S4D` workflow and evidence bundle instead of inventing another release entry.
+- The evidence bundle records both generic workflow results and feature-level access-aware probe results.
+- At least one real run proves:
+  - `deployResult=PASS`
+  - `verifyResult=PASS`
+  - `memberReadResult=PASS`
+  - `adminReadResult=PASS`
+  - `lifecycleMutationResult=PASS`
+  - `rerenderedStateResult=PASS`
+- The packet leaves one explicit conclusion on whether branch-road `M1` now has sufficient deployment-facing evidence.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - the combined cloud-target evidence contract is explicit;
+  - one real operator-facing cloud-target run is captured with traceable artifacts;
+  - the next-lane decision after that evidence is recorded explicitly.
+
+## P0 (Contract | v1)
+
+### P0-C1-S1 (Combined cloud-target evidence boundary | v1)
+
+- `S4F-2A` must prove the access/subscription slice on the same operator-facing cloud release path already stabilized by `S4D`.
+- The packet boundary is not "another backend drill"; it is one release-facing evidence packet that joins generic runtime release truth with feature-level access truth.
+
+### P0-C1-S2 (Verify overlay contract | v1)
+
+- The `S4F` verify overlay for this packet remains the same three feature probes fixed by `S4F-1A`:
+  - member read
+  - admin read
+  - bounded lifecycle mutation followed by deterministic re-read/history
+- The required difference is execution surface: these probes must run on the real cloud-target operator path after the reused `S4D` generic verify gate passes.
+
+### P0-C1-S3 (Evidence contract | v1)
+
+- Evidence JSON for this packet must include at least:
+  - `headSha`
+  - `workflowCommandSummary`
+  - `targetHostKind`
+  - `envFilePath`
+  - `imageTag`
+  - `deployResult`
+  - `verifyResult`
+  - `memberReadResult`
+  - `adminReadResult`
+  - `lifecycleMutationResult`
+  - `rerenderedStateResult`
+  - `rollbackResult`
+  - `result`
+
+## Numbering
+
+- `S<n>`: Step.
+- `C<n>`: Cycle.
+
+**Commit / PR naming**:
+
+- `S4F-2A/P<phase>-C<cycle>-S<steps>: <summary>`
+
+**Branch convention**:
+
+- `S4F-2A` related implementation and documentation should continue on `S4F-access-subscription-deployable-runtime-cut` unless a later packet justifies a separate focused branch.
+
+**Commit discipline (recommended)**:
+
+- After each meaningful `P*-C*-S*` unit, whether it is contract work, implementation, or drills/evidence, commit/push promptly on the current `S4F` working branch.
+
+## Plan (draft)
+
+### P1 (Implementation / packaging)
+
+- P1-C1-S1: define the exact operator-facing verify tuple and artifact write-back shape for the `S4F` overlay on the reused `S4D` path
+- P1-C1-S2: wire the overlay commands or helper script into the retained cloud release evidence bundle
+
+### P2 (Drill / Verify)
+
+- P2-C1-S1: capture one real cloud-target operator evidence run with generic `S4D` workflow PASS plus `S4F` feature probe PASS
+- P2-C1-S2: capture the resulting artifact path, run metadata, and probe outputs in this log
+
+### P3 (Close-out / next-lane decision)
+
+- P3-C1-S1: decide whether branch-road `M1` now has sufficient deployment-facing evidence or whether one more realism-tightening packet is required
+
+## Execution Checklist (unchecked)
+
+### P0 (Contract)
+
+- [x] `P0-C1-S1`: combined cloud-target evidence boundary fixed
+- [x] `P0-C1-S2`: verify overlay contract fixed for the real operator path
+- [x] `P0-C1-S3`: combined evidence JSON contract fixed
+
+### P1 (Implementation / packaging)
+
+- [x] `P1-C1-S1`: operator-facing verify tuple and artifact write-back shape fixed
+- [x] `P1-C1-S2`: overlay wiring landed on the reused `S4D` path
+
+### P2 (Drill / Verify)
+
+- [x] `P2-C1-S1`: cloud-target operator evidence run captured
+- [x] `P2-C1-S2`: evidence artifact, run-state fallback query, and operator/API path diagnostics recorded
+
+### P3 (Close-out / next-lane decision)
+
+- [x] `P3-C1-S1`: branch-road `M1` sufficiency decision recorded
+
+## Current Status (recommended)
+
+- `S4F-2A` is now end-to-end evidenced on the reused `S4D` path. Real run `24662387235` on head `07c99aa0f571cf04ba97ef25b4d52cf52d9f64e7` passed preflight, deploy, generic verify, and the `S4F` access-aware overlay, producing one complete operator-facing cloud-target evidence bundle.
+- `P2` produced four meaningful samples on the way to closure: stable-runner preflight failure (`24655583207`), local-path deploy/verify failure (`24654777721`), local-path verify-pass/access-script failure (`24661990707`), and the final clean PASS run (`24662387235`). Together they separate environment reachability, runtime readiness, and overlay-script defects instead of collapsing them into one opaque failure.
+- The GitHub Actions observation path is now also pinned down for `P2`: `gh run watch` timed out while polling the jobs endpoint from this operator machine, but one-shot `gh run view` and `gh api` queries succeeded against the same runs and endpoint, so the evidence points to an intermittent local-to-GitHub API polling-path timeout rather than a bad run id, bad token, or bad workflow reference.
+- The packet's next-lane decision is now explicit: `road-002-01/M1` has sufficient backend deployment-facing evidence for the access/subscription slice, while the remaining realism-tightening work should move to a separate lane that removes dependence on drifting operator public `/32` RDS allowlists.
+
+## Evidence (reserved)
+
+- Artifacts are the source of truth for evidence. The first real `P2` attempt is now retained as a failing preflight sample:
+- run id: `24655583207`
+- head sha: `68d0af1b2f7f6b8c2d0d7981670ee40303342d30`
+- workflow: `s4d-cloud-release-dispatch-stable-runner`
+- result: `FAIL`
+- failure class: `evidence_capture_failure`
+- terminal stage / gate: `evidence` / `evidence_capture`
+- preflight result: `FAIL`
+- target reachability gate: `FAIL`
+- deploy / verify / access overlay: `NOT_RUN` / `NOT_RUN` / `NOT_RUN`
+- retained artifact dir: `artifacts/_tmp_s4f2a_p2_run_24655583207`
+- retained files:
+  - `summary.json`
+  - `preflight.log`
+  - `operator_guidance.txt`
+- preflight failure excerpt: `ssh: connect to host 49.196.191.226 port 22022: Connection timed out`
+- operator guidance outcome: stop at preflight, fix target reachability, then rerun the same workflow command.
+- GitHub Actions status fallback evidence recorded during `P2`:
+  - `gh run view 24654777721 --json ...` returned `status=queued`, `conclusion=null`, workflow `s4d-cloud-release-dispatch`, head sha `68d0af1b2f7f6b8c2d0d7981670ee40303342d30`
+  - `gh api repos/samuelhu324-dev/wordloom-v3/actions/runs/24654777721/jobs ...` returned one queued job: `cloud-runtime-release` (`72085514477`)
+  - `gh run view 24655583207 --json ...` returned `status=completed`, `conclusion=failure`, workflow `s4d-cloud-release-dispatch-stable-runner`, with the known failed steps `Write run summary` and `Enforce workflow result` from the pre-fix run
+- Operator-to-GitHub API path diagnosis recorded during `P2`:
+  - `gh auth status` remained healthy for `samuelhu324-dev`; token scopes included `repo` and `workflow`
+  - proxy environment variables were empty: `HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, `NO_PROXY`
+  - DNS resolution for `api.github.com` succeeded (`A 4.237.22.34`, `AAAA 2405:dc00:0:3::4ed:1622`)
+  - `Invoke-WebRequest https://api.github.com/rate_limit` returned `200 OK`
+  - `Test-NetConnection api.github.com -Port 443` returned `TcpTestSucceeded=True`
+  - working conclusion: the screenshot failure was a local polling-path timeout during `gh run watch`, not an authentication failure and not proof that the run state was unavailable from GitHub.
+- Second real `P2` sample retained after SSH and runner recovery:
+  - run id: `24654777721`
+  - workflow: `s4d-cloud-release-dispatch`
+  - target host kind: `Ubuntu Server VM via SSH (wordloom@127.0.0.1:22022)`
+  - head sha / remote head sha: `68d0af1b2f7f6b8c2d0d7981670ee40303342d30` / `68d0af1b2f7f6b8c2d0d7981670ee40303342d30`
+  - result: `FAIL`
+  - preflight / deploy / verify / access overlay: `PASS` / `PASS` / `FAIL` / `NOT_RUN`
+  - gate results:
+    - `identityAuthGate=PASS`
+    - `targetReachabilityGate=PASS`
+    - `dependencyConnectivityGate=PASS`
+    - `releaseContractGate=PASS`
+    - `deployExecutionGate=PASS`
+    - `postChangeVerifyGate=FAIL`
+    - `accessAwareVerifyGate=NOT_RUN`
+  - retained artifact dir: `artifacts/_tmp_s4d4b_cloud_release_dispatch/24654777721-1`
+  - retained files:
+    - `preflight.log`
+    - `deploy.log`
+    - `verify.log`
+    - `operator_guidance.txt`
+    - `summary.json`
+  - verify failure excerpt:
+    - `container not found: wordloom-api-cloud-dev`
+    - `health_ok FAIL (000)`
+    - `read_smoke_ok FAIL (code=000)`
+  - guest-side root-cause probe after the run:
+    - fallback Windows runner `wordloom-s4d-temp-win` had to be re-registered because its server-side registration had been deleted
+    - guest SSH on `127.0.0.1:22022` was restored by resetting the local VM and confirming `systemctl is-active ssh = active`
+    - deploy had briefly hung on removing the old container; after manual `docker rm -f wordloom-api-cloud-dev`, the workflow continued
+    - the failed deploy container state captured `created|128|failed to bind host port for 0.0.0.0:30033 ... address already in use|wordloom-backend:cloud-dev`
+  - operator guidance outcome: candidate appeared deployed enough for deploy PASS, but post-change verify failed; inspect probe target / API reachability / container survival before the next deploy attempt.
+- Third real `P2` sample retained after RDS ingress restoration:
+  - run id: `24661990707`
+  - workflow: `s4d-cloud-release-dispatch`
+  - target host kind: `Ubuntu Server VM via SSH (wordloom@127.0.0.1:22022)`
+  - head sha / remote head sha: `96049c9c540b21112e843b89dd9ba361f8657228` / `96049c9c540b21112e843b89dd9ba361f8657228`
+  - result: `FAIL`
+  - preflight / deploy / verify / access overlay: `PASS` / `PASS` / `PASS` / `NOT_RUN`
+  - retained artifact dir: `artifacts/_tmp_s4d4b_cloud_release_dispatch/24661990707-1`
+  - retained files:
+    - `preflight.log`
+    - `deploy.log`
+    - `verify.log`
+    - `operator_guidance.txt`
+    - `summary.json`
+  - verify failure excerpt:
+    - `CLOUD_RELEASE_VERIFY_RESULT=PASS`
+    - `Traceback (most recent call last):`
+    - `NameError: name 'null' is not defined`
+  - root cause: `scripts/ops/cloud_release_access_verify.sh` mixed Python heredoc script input with later stdin redirection from JSON files, so Python executed JSON payload text instead of the intended script.
+- Final `P2` success sample retained on the same local operator path:
+  - run id: `24662387235`
+  - workflow: `s4d-cloud-release-dispatch`
+  - target host kind: `Ubuntu Server VM via SSH (wordloom@127.0.0.1:22022)`
+  - head sha / remote head sha: `07c99aa0f571cf04ba97ef25b4d52cf52d9f64e7` / `07c99aa0f571cf04ba97ef25b4d52cf52d9f64e7`
+  - result: `PASS`
+  - preflight / deploy / verify / access overlay: `PASS` / `PASS` / `PASS` / `PASS`
+  - gate results:
+    - `identityAuthGate=PASS`
+    - `targetReachabilityGate=PASS`
+    - `dependencyConnectivityGate=PASS`
+    - `releaseContractGate=PASS`
+    - `deployExecutionGate=PASS`
+    - `postChangeVerifyGate=PASS`
+    - `accessAwareVerifyGate=PASS`
+  - retained artifact dir: `artifacts/_tmp_s4d4b_cloud_release_dispatch/24662387235-1`
+  - retained files:
+    - `preflight.log`
+    - `deploy.log`
+    - `verify.log`
+    - `access_verify_result.json`
+    - `operator_guidance.txt`
+    - `summary.json`
+  - access-aware overlay observed values:
+    - `memberReadResult=true`
+    - `adminReadResult=true`
+    - `lifecycleMutationResult=true`
+    - `rerenderedStateResult=true`
+
+## P3 (Close-out / next-lane decision)
+
+### P3-C1-S1 (M1 sufficiency and realism-tightening follow-up | 2026-04-20)
+
+- `road-002-01/M1` now has sufficient backend deployment-facing evidence for the access/subscription slice because one retained operator-facing cloud-target run proves the reused `S4D` release path plus the `S4F` access-aware overlay on the actual target host.
+- The next lane should not repeat `S4F-2A`; it should remove the remaining operator-environment fragility by eliminating dependence on drifting operator public `/32` RDS ingress rules.
+- Default follow-up direction: move release/verify execution onto a stable VPC-positioned runner or equivalent trusted network position, then replace per-operator `/32` allowlists with a durable SG-to-SG or otherwise fixed-trust path.
+
+## Recent changes (for traceability, optional)
+
+- 2026-04-20: first created `S4F-2A` as the next `S4F` child packet to capture one operator-facing cloud-target evidence run after `S4F-1A` completed the backend-only runtime cut and next-lane decision.
+- 2026-04-20: completed `P1-C1-S1S2` by adding `scripts/ops/cloud_release_access_verify.sh`, extending `scripts/ops/cloud_release_workflow.sh` and `scripts/ops/cloud_release_workflow_helpers.sh`, and exposing the optional overlay through `.github/workflows/s4d-cloud-release-dispatch-stable-runner.yml`.
+- 2026-04-20: attempted the first real `P2` stable-runner execution (`24655583207`) with `--access-verify-overlay`; the run reached retained artifacts but failed preflight on target SSH reachability before deploy or verify started.
+- 2026-04-20: fixed the workflow summary renderer indentation in both cloud release dispatch workflows so future reruns surface the real `summary.json` outcome without a secondary post-run script failure.
+- 2026-04-20: added `P2` run-observation fallback evidence showing that one-shot `gh run view` / `gh api` calls can read both relevant workflow runs even though `gh run watch` timed out from the operator machine.
+- 2026-04-20: added `P2` operator-to-GitHub API path diagnostics showing healthy auth, DNS, HTTP, and TCP baseline checks, narrowing the screenshot failure to an intermittent polling-path timeout rather than a repo-side workflow error.
+- 2026-04-20: recovered the local Ubuntu VM SSH path on `127.0.0.1:22022`, re-registered and relaunched the Windows self-hosted runner `wordloom-s4d-temp-win`, and thereby turned fallback run `24654777721` from `queued` into a real deploy/verify sample.
+- 2026-04-20: recorded the second real `P2` sample (`24654777721`), which proved `preflight=PASS` and `deploy=PASS` on the local operator path but failed `postChangeVerifyGate` before the `S4F` access-aware overlay began, with guest-side evidence pointing to container survival / host-port-conflict problems.
+- 2026-04-20: restored DB reachability by confirming the current operator egress `/32` in the RDS security group, then captured run `24661990707`, which proved generic verify had recovered and isolated a local script bug in `cloud_release_access_verify.sh` (`NameError: null`).
+- 2026-04-20: fixed `cloud_release_access_verify.sh` by piping JSON payloads into Python instead of overriding heredoc script stdin, manually revalidated the overlay on the guest path, and then captured the first full PASS bundle in run `24662387235`.
+- 2026-04-20: recorded the close-out decision that `M1` now has sufficient backend deployment-facing evidence and that the remaining public-IP-drift / RDS-trust hardening belongs in a separate follow-up lane.

--- a/docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md
+++ b/docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md
@@ -1,0 +1,189 @@
+# log-S4F (Access / Subscription Deployable Runtime Cut)
+
+---
+
+**id**: `S4F`
+**kind**: `log`
+**title**: `access / subscription deployable runtime cut v1`
+**status**: `draft`
+**scope**: `S4`
+**tags**: `EVOLUTION, OpsRuntime, CloudRuntime, AccessControl, ReleaseOperations, epic/s4, epic/s4f`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **adr**: ``
+  **runbook**: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
+  **roadmap**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
+  **reference_log_1**: `docs/logs/log-S4D-cloud-runtime-deploy-verify-rollback.md`
+  **reference_log_2**: `docs/logs/log-S4D-4A-cloud-runtime-semi-automated-release-workflow.md`
+  **phase_log_1**: `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
+  **phase_log_2**: `docs/logs/log-S4F-2A-cloud-target-operator-evidence-packet.md`
+  **phase_log_3**: `docs/logs/log-S4F-2B-release-path-dependency-trust-hardening.md`
+  **phase_log_4**: `docs/logs/log-S4F-2C-deployed-identity-admission-membership-truth-hardening.md`
+  **phase_log_5**: ``
+  **phase_log_6**: ``
+**issue_keyword**: `platform`
+**issue_top_labels**: ``
+**issue_scope_labels**: ``
+**issue_module_labels**: ``
+**issue_milestone**: ``
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
+**roadmap_milestone**: `M1`
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: ``
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-20`
+**updated**: `2026-04-20`
+
+---
+
+## Decision / Outcome（结论区）
+
+**Decision**:
+
+- Open `S4F` as the new `S4` top-level spine for the first `road-002-01` deployable runtime cut that reuses the proven `S4D` cloud release path instead of inventing a second release family.
+- Treat `S4F` as the runtime-execution owner for the branch-road's first cloud closure: backend-first access/subscription deployment, access-aware verify gates, and bounded member/admin drills.
+
+**Default choices（默认基线 / v1）**:
+
+- Reuse the stable `S4D` single-VM, backend-container, external-RDS release workflow as the default release substrate.
+- Keep the first `S4F` lane backend-only; do not require frontend cloud closure before the first deployable-cut proof exists.
+- Replace generic backend smoke as the success center with access-aware verify and drill contracts that match the recent auth/access/subscription slice.
+- Keep provider realism, UI cloud hosting, worker cloud residency, and asset-platform work out of the first `S4F` packet.
+- 若 `issue_*` 字段为空，automation 必须保守留空并要求人工确认，而不是猜测 title keyword、labels 或 milestone。
+- 若 `pr_*` 字段为空，PR automation 必须保守留空并显式报告缺口，而不是复制 issue metadata 或猜测 base / milestone / development issue。
+- roadmap 与 logs 的机械桥接必须通过 `roadmap_path + roadmap_milestone + roadmap_phase` 明确声明；roadmap 内的正式 bridge ledger 默认只计入 child logs，而不是 parent/spine prose。
+
+## PR Summary Inputs（可选）
+
+- This parent/spine is intended to define one bounded runtime execution family under `road-002-01`; the concrete review packet should come from `S4F-1A`.
+
+**PR summary bullets**:
+
+- Open one new `S4` spine for the first backend-first access/subscription deployable runtime cut under `road-002-01`.
+- Reuse the stable `S4D` operator workflow and evidence contract instead of creating a second cloud release path.
+- Route the first actual deployable packet into `S4F-1A`, where access-aware verify and member/admin drills are fixed explicitly.
+
+**PR checklist source**:
+
+- Default source: reuse the concrete execution checklist from `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`.
+
+**PR links**:
+
+- Parent log: `docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md`
+- Child log source(s): `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md` ; `docs/logs/log-S4F-2A-cloud-target-operator-evidence-packet.md`
+- Evidence artifact: `artifacts/_tmp_s4f1a_p2_run_24652525475/labs-evidence-verify_access_subscription_deployable_cut-24652525475-1-verify_access_subscription_deployable_cut/summary.json`
+
+## Background（背景）
+
+- `road-002-01` already fixed the first branch-road goal: one deployable AWS-oriented runtime cut for the stable access/auth/subscription slice.
+- The repository already has one proven cloud release substrate in `S4D`: single VM, backend container, external cloud-dev RDS, single-entry operator workflow, failure taxonomy, and machine-readable evidence.
+- The missing piece is no longer generic release plumbing; it is a feature-scoped runtime family that reuses that plumbing for the recent access/subscription slice and replaces generic smoke with access-aware verification.
+
+## Constraints（约束）
+
+- Do not reopen `S4D` as if the cloud release path itself were still undefined.
+- Do not widen the first lane into frontend cloud hosting, worker runtime, or asset-platform readiness.
+- Do not treat local-first access/subscription semantics as sufficient proof once the slice is deployed; `S4F` must define explicit deployed verification and drills.
+- Do not introduce a second competing release workflow when the current `S4D` workflow is already stable and reusable.
+
+## Scope（本 log 范围）
+
+- 本 log 负责：
+  - define `S4F` as the top-level `S4` spine for the first access/subscription deployable runtime cut;
+  - fix the default reuse rule from `S4D` into `road-002-01/M1`;
+  - route the first concrete execution packet to `S4F-1A`.
+- 本 log 不负责：
+  - detailed endpoint lists, drill steps, or evidence blocks for the first packet;
+  - frontend cloud closure or asset-platform design.
+
+## Success Criteria（DoD）
+
+- 结构层面：
+  - readers can see in one place why `S4F` exists and why it is distinct from `S4D` and `S4E`;
+  - `S4F-1A` is explicitly named as the first runtime packet under this spine.
+- 工程层面：
+  - the default release substrate is explicitly the stable `S4D` operator workflow;
+  - the first packet is explicitly backend-only and access-aware.
+- 证据层面：
+  - later `S4F-*` evidence can reuse `S4D` bundle shape while adding access-specific verify/drill results.
+
+## Phases（切片）
+
+- `S4F-1A`（Phase 1）：backend-only access/subscription deployable cut
+  - 详见：`docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md`
+- `S4F-2A`（Phase 2）：cloud-target operator evidence packet
+  - 详见：`docs/logs/log-S4F-2A-cloud-target-operator-evidence-packet.md`
+- `S4F-2B`（Phase 2 follow-up）：release-path dependency trust hardening
+  - 详见：`docs/logs/log-S4F-2B-release-path-dependency-trust-hardening.md`
+- `S4F-2C`（Phase 2 follow-up）：deployed identity/admission/membership truth hardening
+  - 详见：`docs/logs/log-S4F-2C-deployed-identity-admission-membership-truth-hardening.md`
+
+## Execution Checklist（当前骨架里程碑汇总）
+
+- [x] `P0`：`S4F` parent/spine created for the first `road-002-01/M1` runtime packet
+- [x] `P1`：first child packet fixed as `S4F-1A`
+- [x] `P2`：default reuse boundary from `S4D` fixed
+- [x] `P3`：first concrete deployable packet executed and evidenced
+
+## Current Status（进展摘要）
+
+- `S4F` now has one completed first packet in `S4F-1A`, one completed cloud-target evidence packet in `S4F-2A`, one completed trust-hardening follow-up packet in `S4F-2B`, and one completed realism-hardening follow-up packet in `S4F-2C`.
+- `S4F-2A/P1` is now landed: the reused `S4D` release path can optionally run the `S4F` access-aware verify overlay and write the combined result back into the retained artifact bundle.
+- `S4F-2A/P2` is now complete. The lane progressed through three distinct failure classes on the same operator path before closing green: target reachability (`24655583207`), post-change runtime verify (`24654777721`), and access-overlay script parsing (`24661990707`), then finished with a full PASS evidence bundle in run `24662387235` on head `07c99aa0f571cf04ba97ef25b4d52cf52d9f64e7`.
+- `S4F-2A/P2` also now includes the operator-side observation fallback and API-path diagnosis: the queued Windows fallback run `24654777721` can be read cleanly via one-shot `gh run view` / `gh api`, and the earlier `gh run watch` failure has been narrowed to an intermittent local polling-path timeout rather than a repo-side workflow lookup failure.
+- `S4F-2B` has now produced one hardened stable-runner evidence run, and `S4F-2C/P0-P3` are now fixed: the current slice now has one retained cloud-target member/admin drill bundle proving request-level dev actor identity plus persistence-backed tenant standing on the deployed path, and the next execution lane should leave `M2` and move to `road-002-01/M3-P0` cloud-backed asset-platform readiness contract work.
+
+## Notes（落地原则，可选）
+
+- Reuse infrastructure and workflow first; only specialize the verify/drill contract.
+- Keep the first deployed proof narrow enough that one operator can explain it end to end.
+
+## Stability（stable 口径）
+
+- 本 log 标记为 `stable` 表示：
+  - the `S4F` family boundary is fixed;
+  - the default reuse rule from `S4D` is fixed;
+  - the first concrete packet and its success criteria are explicit.
+
+## Numbering & Commit Naming（编号与提交命名）
+
+- 编号约定：`P<n>` 表示 Phase，`C<n>` 表示 Cycle，`S<n>` 表示 Step。
+- Commit / PR 命名：
+  - 基础形式：`S4F/P<phase>-C<cycle>-S<steps>: <summary>`；
+  - 若一个 PR 一次性汇总多个完整 phase，应优先压缩成 phase 范围标题：`S4F/P0-P3: access / subscription deployable runtime cut`。
+
+**Branch 约定（建议）**:
+
+- `S4F` 相关实现与文档当前优先落在 `S4F-access-subscription-deployable-runtime-cut` 分支。
+
+**Commit 纪律（建议）**:
+
+- 每完成一个有明确边界的 `P*-C*-S*` 单元，应尽量及时 `commit/push`；
+- phase-specific 变更优先使用对应 child log 前缀，例如 `S4F-1A/...`。
+
+## Recent changes（for traceability，可选）
+
+- 2026-04-20：首次创建 `S4F`，作为 `road-002-01/M1` 的新 `S4` 顶层 spine，并把第一条 execution lane 固定到 `S4F-1A`。
+- 2026-04-20：`S4F-1A` completed `P0-P3`, so the parent spine now has its first executed and evidenced child packet plus one explicit next-lane decision: prioritize cloud-path operator evidence before frontend cloud closure.
+- 2026-04-20：opened `S4F-2A` as the next child packet, dedicated to one cloud-target operator evidence run on the reused `S4D` release substrate.
+- 2026-04-20：completed `S4F-2A/P1-C1-S1S2`, wiring the access-aware verify overlay into the reused `S4D` cloud release workflow and summary artifact contract.
+- 2026-04-20：recorded the first real `S4F-2A/P2` stable-runner attempt (`24655583207`), which retained artifacts successfully but failed preflight on target SSH reachability before deploy/verify/access overlay execution.
+- 2026-04-20：fixed the post-run summary renderer indentation in both cloud release dispatch workflows so reruns report the retained `summary.json` outcome cleanly.
+- 2026-04-20：added `S4F-2A/P2` fallback run-status evidence and operator-to-GitHub API diagnostics, confirming that `gh run watch` was the unstable observation path while one-shot API reads remained healthy.
+- 2026-04-20：recovered the local operator path by resetting the VM, restoring guest SSH on `127.0.0.1:22022`, re-registering the deleted Windows self-hosted runner, and turning fallback run `24654777721` into a real deploy/verify sample.
+- 2026-04-20：recorded that the new `S4F-2A/P2` blocker is no longer target reachability on the local path but post-change verify readiness: the candidate deploy passed, yet the expected `wordloom-api-cloud-dev` container was not alive by verify time and guest-side evidence showed a host-port binding conflict during failed container startup.
+- 2026-04-20：restored RDS reachability for the current operator egress path, isolated and fixed the access-overlay JSON parsing defect in `cloud_release_access_verify.sh`, and closed `S4F-2A/P2` with one full PASS cloud-target evidence run (`24662387235`).
+- 2026-04-20：recorded the next-lane decision from `S4F-2A/P3`: `road-002-01/M1` now has sufficient backend deployment-facing evidence, and the remaining hardening work should move to a separate lane that removes drifting operator public-IP / RDS allowlist dependence.
+- 2026-04-20：opened `S4F-2B` as that follow-up lane and scaffolded it as the source log for release-path dependency trust hardening.
+- 2026-04-20：opened `S4F-2C` as the next follow-up lane after `S4F-2B`, dedicated to `road-002-01/M2` credibility hardening for deployed identity/admission/membership truth.
+- 2026-04-20：completed `S4F-2C/P0-C1-S1S2S3`, fixing the first deployed credibility boundary and narrowing the next implementation target to backend-validated identity plus persistence-backed admission/membership truth.
+- 2026-04-20：completed `S4F-2C/P1-C1-S1S2`, landing a stable dev actor identity bridge from frontend session state into backend auth-context fallback so membership-backed tenant standing can resolve per actor instead of per process.
+- 2026-04-20：completed `S4F-2C/P2-C1-S1S2`, retaining one stable-runner cloud-target PASS run (`24668611462`) whose access overlay proved member/admin standing through the new request-level dev identity bridge and persistence-backed tenant membership truth.
+- 2026-04-20：completed `S4F-2C/P3-C1-S1`, deciding that no immediate second `M2` child packet is required and that the next branch-road execution lane should move to `M3/P0` asset-platform readiness contract work.

--- a/docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md
+++ b/docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md
@@ -94,7 +94,7 @@
 - `M1-P2`:
   - `docs/logs/log-S0F-10D-scenario-catalog-and-mock-state-machine-replays.md`
 - `M1-P3`:
-  - `unmapped`
+  - `docs/logs/log-S4F-2A-cloud-target-operator-evidence-packet.md`
 
 **Parent alignment**
 
@@ -226,3 +226,4 @@
 
 - 2026-04-19: opened `road-002-01` as the first focused branch road under `road-002`, concentrating one deployable AWS runtime cut, one credible-simulation threshold, and one explicit readiness gate for cloud-backed `Asset Platform` work.
 - 2026-04-19: fixed the branch scope so it reuses already-stable `M4` child logs rather than pretending the whole parent mainline must finish before AWS packaging can begin.
+- 2026-04-20: opened `S4F-2A` and backfilled `M1-P3` from `unmapped` to one concrete child packet for cloud-target operator evidence on top of the reused `S4D` release path.

--- a/scripts/ops/cloud_release_access_verify.sh
+++ b/scripts/ops/cloud_release_access_verify.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+ENV_FILE="${ENV_FILE:-}"
+CONTAINER_NAME="${CONTAINER_NAME:-wordloom-api-cloud-dev}"
+VERIFY_API_HOST="${VERIFY_API_HOST:-127.0.0.1}"
+VERIFY_API_PORT="${VERIFY_API_PORT:-30021}"
+RUN_ID="${RUN_ID:-}"
+OUTPUT_PATH="${OUTPUT_PATH:-}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/ops/cloud_release_access_verify.sh \
+    [--env-file <path>] \
+    [--container-name <name>] \
+    [--api-host <host>] \
+    [--api-port <port>] \
+    [--run-id <id>] \
+    [--output-path <path>]
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --container-name)
+      CONTAINER_NAME="$2"
+      shift 2
+      ;;
+    --api-host)
+      VERIFY_API_HOST="$2"
+      shift 2
+      ;;
+    --api-port)
+      VERIFY_API_PORT="$2"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="$2"
+      shift 2
+      ;;
+    --output-path)
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[cloud_release_access_verify] unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -n "$ENV_FILE" ]]; then
+  source_env_file "$ENV_FILE"
+fi
+
+require_cmd curl
+docker_cmd="$(docker_bin)"
+
+if ! "$docker_cmd" inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+  echo "[cloud_release_access_verify] container not found: $CONTAINER_NAME" >&2
+  echo "[cloud_release_access_verify] ACCESS_VERIFY_RESULT=FAIL" >&2
+  exit 1
+fi
+
+if [[ -z "$RUN_ID" ]]; then
+  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$(cat /proc/sys/kernel/random/uuid | cut -c1-8)"
+fi
+
+API_BASE_URL="http://${VERIFY_API_HOST}:${VERIFY_API_PORT}/api/v1"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+create_body="$TMP_DIR/create_library.json"
+member_body="$TMP_DIR/member_read.json"
+member_admin_deny_body="$TMP_DIR/member_admin_deny.json"
+admin_body="$TMP_DIR/admin_read.json"
+admin_memberships_body="$TMP_DIR/admin_memberships.json"
+lifecycle_body="$TMP_DIR/lifecycle.json"
+rerender_body="$TMP_DIR/rerender.json"
+history_body="$TMP_DIR/history.json"
+
+library_name="s4f2a-${RUN_ID:0:16}"
+create_code="$(curl -sS -o "$create_body" -w '%{http_code}' -H 'Content-Type: application/json' -X POST -d "{\"name\":\"${library_name}\",\"description\":\"S4F-2A cloud target access verify\"}" "$API_BASE_URL/libraries")"
+
+if [[ "$create_code" != "201" ]]; then
+  echo "[cloud_release_access_verify] create_library_status=$create_code" >&2
+  cat "$create_body" >&2 || true
+  echo "[cloud_release_access_verify] ACCESS_VERIFY_RESULT=FAIL" >&2
+  exit 1
+fi
+
+library_id="$(cat "$create_body" | $docker_cmd exec -i "$CONTAINER_NAME" python -c "import json, sys; payload = json.load(sys.stdin); library_id = str(payload.get('id') or '');
+if not library_id:
+    raise SystemExit('create_library_missing_id')
+print(library_id)")"
+
+member_user_id="11111111-1111-4111-8111-111111111111"
+admin_user_id="22222222-2222-4222-8222-222222222222"
+
+"$docker_cmd" exec -i -e LIBRARY_ID="$library_id" -e MEMBER_USER_ID="$member_user_id" -e ADMIN_USER_ID="$admin_user_id" "$CONTAINER_NAME" python - <<'PY'
+from __future__ import annotations
+
+import os
+import uuid
+from sqlalchemy import create_engine, text
+
+
+def convert_to_psycopg(url: str) -> str:
+    if url.startswith("postgresql+psycopg://"):
+        return url
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+psycopg://", 1)
+    if url.startswith("postgresql+asyncpg://"):
+        return url.replace("postgresql+asyncpg://", "postgresql+psycopg://", 1)
+    if url.startswith("postgresql+"):
+        parts = url.split("://", 1)
+        if len(parts) == 2:
+            return f"postgresql+psycopg://{parts[1]}"
+    return url
+
+
+database_url = (os.getenv("DATABASE_URL") or "").strip()
+if not database_url:
+    raise SystemExit("DATABASE_URL missing")
+
+library_id = str(uuid.UUID(os.environ["LIBRARY_ID"]))
+member_user_id = str(uuid.UUID(os.environ["MEMBER_USER_ID"]))
+admin_user_id = str(uuid.UUID(os.environ["ADMIN_USER_ID"]))
+
+engine = create_engine(convert_to_psycopg(database_url), future=True)
+try:
+    with engine.begin() as conn:
+        for user_id, role in ((member_user_id, "member"), (admin_user_id, "admin")):
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO library_memberships (id, library_id, user_id, role, created_at, updated_at)
+                    VALUES (:id, :library_id, :user_id, :role, TIMEZONE('utc', NOW()), TIMEZONE('utc', NOW()))
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "library_id": library_id,
+                    "user_id": user_id,
+                    "role": role,
+                },
+            )
+        conn.execute(
+            text(
+                """
+                INSERT INTO subscriptions (id, library_id, plan_code, state, created_at, updated_at)
+                VALUES (:id, :library_id, 'trial', 'trialing', TIMEZONE('utc', NOW()), TIMEZONE('utc', NOW()))
+                """
+            ),
+            {"id": str(uuid.uuid4()), "library_id": library_id},
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO entitlement_snapshots (id, library_id, plan_code, subscription_state, entitlements, created_at, updated_at)
+                VALUES (:id, :library_id, 'trial', 'trialing', 'read_library', TIMEZONE('utc', NOW()), TIMEZONE('utc', NOW()))
+                """
+            ),
+            {"id": str(uuid.uuid4()), "library_id": library_id},
+        )
+finally:
+    engine.dispose()
+PY
+
+member_status="$(curl -sS -o "$member_body" -w '%{http_code}' -H "X-Dev-User-Id: $member_user_id" -H "X-Library-Id: $library_id" "$API_BASE_URL/access-context/me")"
+member_admin_deny_status="$(curl -sS -o "$member_admin_deny_body" -w '%{http_code}' -H "X-Dev-User-Id: $member_user_id" -H "X-Library-Id: $library_id" "$API_BASE_URL/admin/subscriptions/$library_id")"
+admin_status="$(curl -sS -o "$admin_body" -w '%{http_code}' -H "X-Dev-User-Id: $admin_user_id" -H "X-Library-Id: $library_id" "$API_BASE_URL/admin/subscriptions/$library_id")"
+admin_memberships_status="$(curl -sS -o "$admin_memberships_body" -w '%{http_code}' -H "X-Dev-User-Id: $admin_user_id" -H "X-Library-Id: $library_id" "$API_BASE_URL/libraries/$library_id/memberships")"
+lifecycle_status="$(curl -sS -o "$lifecycle_body" -w '%{http_code}' -H 'Content-Type: application/json' -H "X-Dev-User-Id: $admin_user_id" -H "X-Library-Id: $library_id" -X POST -d '{"event_type":"upgrade_success"}' "$API_BASE_URL/admin/subscriptions/$library_id/events")"
+rerender_status="$(curl -sS -o "$rerender_body" -w '%{http_code}' -H "X-Dev-User-Id: $admin_user_id" -H "X-Library-Id: $library_id" "$API_BASE_URL/admin/subscriptions/$library_id")"
+history_status="$(curl -sS -o "$history_body" -w '%{http_code}' -H "X-Dev-User-Id: $admin_user_id" -H "X-Library-Id: $library_id" "$API_BASE_URL/admin/subscriptions/$library_id/history")"
+
+result_json="$($docker_cmd exec -i \
+  -e RUN_ID="$RUN_ID" \
+  -e API_BASE_URL="$API_BASE_URL" \
+  -e LIBRARY_ID="$library_id" \
+    -e MEMBER_USER_ID="$member_user_id" \
+    -e ADMIN_USER_ID="$admin_user_id" \
+  -e MEMBER_STATUS="$member_status" \
+    -e MEMBER_ADMIN_DENY_STATUS="$member_admin_deny_status" \
+  -e ADMIN_STATUS="$admin_status" \
+    -e ADMIN_MEMBERSHIPS_STATUS="$admin_memberships_status" \
+  -e LIFECYCLE_STATUS="$lifecycle_status" \
+  -e RERENDER_STATUS="$rerender_status" \
+  -e HISTORY_STATUS="$history_status" \
+  -e MEMBER_BODY_B64="$(base64 -w0 < "$member_body")" \
+    -e MEMBER_ADMIN_DENY_BODY_B64="$(base64 -w0 < "$member_admin_deny_body")" \
+  -e ADMIN_BODY_B64="$(base64 -w0 < "$admin_body")" \
+    -e ADMIN_MEMBERSHIPS_BODY_B64="$(base64 -w0 < "$admin_memberships_body")" \
+  -e LIFECYCLE_BODY_B64="$(base64 -w0 < "$lifecycle_body")" \
+  -e RERENDER_BODY_B64="$(base64 -w0 < "$rerender_body")" \
+  -e HISTORY_BODY_B64="$(base64 -w0 < "$history_body")" \
+  "$CONTAINER_NAME" python - <<'PY'
+from __future__ import annotations
+
+import base64
+import json
+import os
+from datetime import datetime, timezone
+
+
+def decode_payload(name: str):
+    raw = os.getenv(name, "")
+    if not raw:
+        return {}
+    try:
+        return json.loads(base64.b64decode(raw).decode("utf-8"))
+    except Exception:
+        return {}
+
+
+def normalize_roles(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return []
+
+
+def normalize_history_items(value: object) -> list[dict]:
+    if not isinstance(value, dict):
+        return []
+    items = value.get("items")
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+member_body = decode_payload("MEMBER_BODY_B64")
+member_admin_deny_body = decode_payload("MEMBER_ADMIN_DENY_BODY_B64")
+admin_body = decode_payload("ADMIN_BODY_B64")
+admin_memberships_body = decode_payload("ADMIN_MEMBERSHIPS_BODY_B64")
+lifecycle_body = decode_payload("LIFECYCLE_BODY_B64")
+rerender_body = decode_payload("RERENDER_BODY_B64")
+history_body = decode_payload("HISTORY_BODY_B64")
+history_items = normalize_history_items(history_body)
+membership_items = normalize_history_items(admin_memberships_body)
+library_id = os.environ["LIBRARY_ID"]
+member_user_id = os.environ["MEMBER_USER_ID"]
+admin_user_id = os.environ["ADMIN_USER_ID"]
+
+member_ok = (
+    os.environ["MEMBER_STATUS"] == "200"
+    and str(member_body.get("user_id")) == member_user_id
+    and str(member_body.get("tenant_id")) == library_id
+    and normalize_roles(member_body.get("roles")) == ["member"]
+    and bool(member_body.get("plan_code"))
+    and bool(member_body.get("subscription_state"))
+    and "read_library" in list(member_body.get("entitlements") or [])
+    and os.environ["MEMBER_ADMIN_DENY_STATUS"] == "403"
+    and member_admin_deny_body.get("detail", {}).get("reason") == "not_admin"
+)
+admin_ok = (
+    os.environ["ADMIN_STATUS"] == "200"
+    and str(admin_body.get("library_id")) == library_id
+    and bool(admin_body.get("plan_code"))
+    and bool(admin_body.get("subscription_state"))
+    and "read_library" in list(admin_body.get("entitlements") or [])
+    and os.environ["ADMIN_MEMBERSHIPS_STATUS"] == "200"
+    and any(item.get("user_id") == member_user_id and item.get("role") == "member" for item in membership_items)
+    and any(item.get("user_id") == admin_user_id and item.get("role") == "admin" for item in membership_items)
+)
+lifecycle_ok = (
+    os.environ["LIFECYCLE_STATUS"] == "200"
+    and str(lifecycle_body.get("library_id")) == library_id
+    and lifecycle_body.get("subscription_state") == "active"
+)
+rerender_ok = (
+    os.environ["RERENDER_STATUS"] == "200"
+    and rerender_body.get("subscription_state") == "active"
+    and os.environ["HISTORY_STATUS"] == "200"
+    and any(item.get("event_type") == "upgrade_success" for item in history_items)
+)
+passed = int(member_ok) + int(admin_ok) + int(lifecycle_ok) + int(rerender_ok)
+
+print(json.dumps({
+    "schema_version": "s4f-2c.access-verify.v1",
+    "run_id": os.environ["RUN_ID"],
+    "ok": bool(member_ok and admin_ok and lifecycle_ok and rerender_ok),
+    "meta": {
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "api_base_url": os.environ["API_BASE_URL"],
+        "library_id": library_id,
+        "identityTruthSource": "backend-validated.dev-header",
+        "admissionTruthSource": "persistence-backed.library_memberships",
+        "membershipTruthSource": "persistence-backed.library_memberships",
+        "lifecycleTruthSource": "backend.subscription_access",
+    },
+    "checks": {
+        "memberReadResult": member_ok,
+        "adminReadResult": admin_ok,
+        "lifecycleMutationResult": lifecycle_ok,
+        "rerenderedStateResult": rerender_ok,
+    },
+    "observed": {
+        "memberUserId": member_user_id,
+        "adminUserId": admin_user_id,
+        "memberReadStatus": int(os.environ["MEMBER_STATUS"]),
+        "memberAdminDenyStatus": int(os.environ["MEMBER_ADMIN_DENY_STATUS"]),
+        "adminReadStatus": int(os.environ["ADMIN_STATUS"]),
+        "adminMembershipsStatus": int(os.environ["ADMIN_MEMBERSHIPS_STATUS"]),
+        "lifecycleMutationStatus": int(os.environ["LIFECYCLE_STATUS"]),
+        "rerenderedStateStatus": int(os.environ["RERENDER_STATUS"]),
+        "historyStatus": int(os.environ["HISTORY_STATUS"]),
+        "memberRoles": normalize_roles(member_body.get("roles")),
+        "memberAdminDenyReason": member_admin_deny_body.get("detail", {}).get("reason"),
+        "adminEntitlements": list(admin_body.get("entitlements") or []),
+        "adminMembershipRoles": {
+            item.get("user_id"): item.get("role") for item in membership_items if item.get("user_id") in {member_user_id, admin_user_id}
+        },
+    },
+    "summary": {
+        "total": 4,
+        "passed": passed,
+        "failed": 4 - passed,
+    },
+}, indent=2))
+PY
+)"
+
+if [[ -n "$OUTPUT_PATH" ]]; then
+  mkdir -p "$(dirname "$OUTPUT_PATH")"
+  printf '%s\n' "$result_json" > "$OUTPUT_PATH"
+fi
+
+echo "[cloud_release_access_verify] ACCESS_VERIFY_RESULT_JSON_BEGIN"
+printf '%s\n' "$result_json"
+echo "[cloud_release_access_verify] ACCESS_VERIFY_RESULT_JSON_END"
+
+if printf '%s\n' "$result_json" | "$docker_cmd" exec -i "$CONTAINER_NAME" python -c "import json, sys; payload = json.load(sys.stdin); raise SystemExit(0 if payload.get('ok') else 1)"
+then
+  echo "[cloud_release_access_verify] ACCESS_VERIFY_RESULT=PASS"
+  exit 0
+fi
+
+echo "[cloud_release_access_verify] ACCESS_VERIFY_RESULT=FAIL" >&2
+exit 1

--- a/scripts/ops/cloud_release_workflow.sh
+++ b/scripts/ops/cloud_release_workflow.sh
@@ -28,6 +28,7 @@ ROLLBACK_ON_VERIFY_FAIL="0"
 ARTIFACT_DIR=""
 ROLLBACK_TRIGGER="manual_only"
 SIMULATE_EVIDENCE_FAILURE=""
+ACCESS_VERIFY_OVERLAY="0"
 
 IDENTITY_AUTH_GATE="NOT_RUN"
 TARGET_REACHABILITY_GATE="NOT_RUN"
@@ -35,7 +36,14 @@ DEPENDENCY_CONNECTIVITY_GATE="NOT_RUN"
 RELEASE_CONTRACT_GATE="NOT_RUN"
 DEPLOY_EXECUTION_GATE="NOT_RUN"
 POST_CHANGE_VERIFY_GATE="NOT_RUN"
+ACCESS_AWARE_VERIFY_GATE="NOT_RUN"
 ROLLBACK_READINESS_GATE="NOT_RUN"
+
+ACCESS_VERIFY_RESULT="NOT_RUN"
+MEMBER_READ_RESULT_JSON="null"
+ADMIN_READ_RESULT_JSON="null"
+LIFECYCLE_MUTATION_RESULT_JSON="null"
+RERENDERED_STATE_RESULT_JSON="null"
 
 usage() {
   cat <<'EOF'
@@ -57,6 +65,7 @@ Usage:
     [--api-port <port>] \
     [--verify-max-wait-seconds <n>] \
     [--verify-poll-interval-seconds <n>] \
+    [--access-verify-overlay] \
     [--rollback-on-verify-fail] \
     [--simulate-evidence-failure <operator-guidance-missing>] \
     [--artifact-dir <path>]
@@ -80,6 +89,7 @@ Examples:
     --expected-head-sha <sha> \
     --env-file /etc/wordloom/.env.cloud.dev \
     --known-good-image-tag wordloom-backend:cloud-dev-known-good-20260325-pass \
+    --access-verify-overlay \
     --rollback-on-verify-fail
 EOF
 }
@@ -155,6 +165,10 @@ while [[ $# -gt 0 ]]; do
       ROLLBACK_ON_VERIFY_FAIL="1"
       shift
       ;;
+    --access-verify-overlay)
+      ACCESS_VERIFY_OVERLAY="1"
+      shift
+      ;;
     --simulate-evidence-failure)
       SIMULATE_EVIDENCE_FAILURE="$2"
       shift 2
@@ -228,6 +242,7 @@ VERIFY_LOG="$ARTIFACT_DIR/verify.log"
 ROLLBACK_LOG="$ARTIFACT_DIR/rollback.log"
 SUMMARY_JSON="$ARTIFACT_DIR/summary.json"
 OPERATOR_GUIDANCE_TXT="$ARTIFACT_DIR/operator_guidance.txt"
+ACCESS_VERIFY_RESULT_JSON="$ARTIFACT_DIR/access_verify_result.json"
 
 TARGET_HOST_KIND="Ubuntu Server VM via SSH (${SSH_USER}@${SSH_HOST}:${SSH_PORT})"
 WORKFLOW_COMMAND_BASE="bash scripts/ops/cloud_release_workflow.sh --ssh-host ${SSH_HOST} --ssh-port ${SSH_PORT} --ssh-user ${SSH_USER} --remote-repo-dir ${REMOTE_REPO_DIR} --remote-branch ${REMOTE_BRANCH} --expected-head-sha ${EXPECTED_HEAD_SHA} --env-file ${ENV_FILE} --image-tag ${IMAGE_TAG} --container-name ${CONTAINER_NAME} --host-port ${HOST_PORT}"
@@ -240,6 +255,9 @@ if [[ -n "$KNOWN_GOOD_IMAGE_TAG" ]]; then
 fi
 if [[ "$ROLLBACK_ON_VERIFY_FAIL" == "1" ]]; then
   WORKFLOW_COMMAND_SUMMARY+=" --rollback-on-verify-fail"
+fi
+if [[ "$ACCESS_VERIFY_OVERLAY" == "1" ]]; then
+  WORKFLOW_COMMAND_SUMMARY+=" --access-verify-overlay"
 fi
 ROLLBACK_WORKFLOW_COMMAND+=" --rollback-on-verify-fail"
 
@@ -333,10 +351,20 @@ else
   exit 1
 fi
 
-if run_remote_step "$VERIFY_LOG" "bash scripts/ops/cloud_release_verify.sh --env-file \"$ENV_FILE\" --container-name \"$CONTAINER_NAME\" --api-host \"$VERIFY_API_HOST\" --api-port \"$VERIFY_API_PORT\" --max-wait-seconds \"$VERIFY_MAX_WAIT_SECONDS\" --poll-interval-seconds \"$VERIFY_POLL_INTERVAL_SECONDS\""; then
+VERIFY_REMOTE_COMMAND="bash scripts/ops/cloud_release_verify.sh --env-file \"$ENV_FILE\" --container-name \"$CONTAINER_NAME\" --api-host \"$VERIFY_API_HOST\" --api-port \"$VERIFY_API_PORT\" --max-wait-seconds \"$VERIFY_MAX_WAIT_SECONDS\" --poll-interval-seconds \"$VERIFY_POLL_INTERVAL_SECONDS\""
+if [[ "$ACCESS_VERIFY_OVERLAY" == "1" ]]; then
+  VERIFY_REMOTE_COMMAND+=" && bash scripts/ops/cloud_release_access_verify.sh --env-file \"$ENV_FILE\" --container-name \"$CONTAINER_NAME\" --api-host \"$VERIFY_API_HOST\" --api-port \"$VERIFY_API_PORT\" --run-id \"$TIMESTAMP_UTC\""
+fi
+
+if run_remote_step "$VERIFY_LOG" "$VERIFY_REMOTE_COMMAND"; then
   VERIFY_RESULT="PASS"
   DEPENDENCY_CONNECTIVITY_GATE="PASS"
   POST_CHANGE_VERIFY_GATE="PASS"
+  if [[ "$ACCESS_VERIFY_OVERLAY" == "1" ]]; then
+    extract_access_verify_result_from_log "$VERIFY_LOG" "$ACCESS_VERIFY_RESULT_JSON"
+    load_access_verify_result_fields "$ACCESS_VERIFY_RESULT_JSON"
+    ACCESS_AWARE_VERIFY_GATE="PASS"
+  fi
   FINAL_RESULT="PASS"
   TERMINAL_STAGE="verify"
   OPERATOR_ACTION="release_complete"
@@ -357,6 +385,14 @@ OPERATOR_ACTION="decide_manual_rollback_or_fix_forward"
 POST_CHANGE_VERIFY_GATE="FAIL"
 if [[ "$FAILURE_CLASS" == "verify_failure" ]]; then
   DEPENDENCY_CONNECTIVITY_GATE="PASS"
+fi
+if [[ "$FAILURE_CLASS" == "access_aware_verify_failure" ]]; then
+  DEPENDENCY_CONNECTIVITY_GATE="PASS"
+  POST_CHANGE_VERIFY_GATE="PASS"
+  extract_access_verify_result_from_log "$VERIFY_LOG" "$ACCESS_VERIFY_RESULT_JSON" || true
+  if [[ -f "$ACCESS_VERIFY_RESULT_JSON" ]]; then
+    load_access_verify_result_fields "$ACCESS_VERIFY_RESULT_JSON"
+  fi
 fi
 mark_failure_gate "$FAILURE_CLASS"
 

--- a/scripts/ops/cloud_release_workflow_helpers.sh
+++ b/scripts/ops/cloud_release_workflow_helpers.sh
@@ -52,6 +52,11 @@ classify_failure() {
     return 0
   fi
 
+  if [[ "$stage" == "verify" ]] && grep -q 'ACCESS_VERIFY_RESULT=FAIL' <<<"$content"; then
+    printf 'access_aware_verify_failure\n'
+    return 0
+  fi
+
   if [[ "$stage" != "preflight" ]] && grep -qiE 'OperationalError|could not connect|connection unexpectedly|temporary failure in name resolution|name or service not known|server closed the connection unexpectedly|timeout expired|network is unreachable' <<<"$content"; then
     printf 'dependency_connectivity_failure\n'
     return 0
@@ -111,6 +116,9 @@ terminal_gate_for_failure_class() {
     verify_failure)
       printf 'post_change_verify_gate\n'
       ;;
+    access_aware_verify_failure)
+      printf 'access_aware_verify_gate\n'
+      ;;
     rollback_recovery)
       printf 'rollback_readiness_gate\n'
       ;;
@@ -150,6 +158,9 @@ mark_failure_gate() {
     verify_failure)
       POST_CHANGE_VERIFY_GATE="FAIL"
       ;;
+    access_aware_verify_failure)
+      ACCESS_AWARE_VERIFY_GATE="FAIL"
+      ;;
     rollback_failure)
       ROLLBACK_READINESS_GATE="FAIL"
       ;;
@@ -183,7 +194,87 @@ evidence_complete_json() {
     complete="false"
   fi
 
+  if [[ "${ACCESS_VERIFY_OVERLAY:-0}" == "1" && ! -f "${ACCESS_VERIFY_RESULT_JSON:-}" ]]; then
+    complete="false"
+  fi
+
   printf '%s' "$complete"
+}
+
+extract_access_verify_result_from_log() {
+  local log_file="$1"
+  local output_path="$2"
+
+  python - "$log_file" "$output_path" <<'PY'
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+log_path = Path(sys.argv[1])
+output_path = Path(sys.argv[2])
+begin = "[cloud_release_access_verify] ACCESS_VERIFY_RESULT_JSON_BEGIN"
+end = "[cloud_release_access_verify] ACCESS_VERIFY_RESULT_JSON_END"
+
+lines = log_path.read_text(encoding="utf-8").splitlines()
+capturing = False
+payload_lines: list[str] = []
+for line in lines:
+    if line.strip() == begin:
+        capturing = True
+        payload_lines.clear()
+        continue
+    if line.strip() == end:
+        if not payload_lines:
+            raise SystemExit(2)
+        output_path.write_text("\n".join(payload_lines) + "\n", encoding="utf-8")
+        raise SystemExit(0)
+    if capturing:
+        payload_lines.append(line)
+
+raise SystemExit(2)
+PY
+}
+
+load_access_verify_result_fields() {
+  local result_json_path="$1"
+
+  while IFS='=' read -r key value; do
+    case "$key" in
+      access_verify_result)
+        ACCESS_VERIFY_RESULT="$value"
+        ;;
+      member_read_result)
+        MEMBER_READ_RESULT_JSON="$value"
+        ;;
+      admin_read_result)
+        ADMIN_READ_RESULT_JSON="$value"
+        ;;
+      lifecycle_mutation_result)
+        LIFECYCLE_MUTATION_RESULT_JSON="$value"
+        ;;
+      rerendered_state_result)
+        RERENDERED_STATE_RESULT_JSON="$value"
+        ;;
+    esac
+  done < <(
+    python - "$result_json_path" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+checks = payload.get("checks") or {}
+ok = bool(payload.get("ok"))
+print(f"access_verify_result={'PASS' if ok else 'FAIL'}")
+print(f"member_read_result={json.dumps(checks.get('memberReadResult'))}")
+print(f"admin_read_result={json.dumps(checks.get('adminReadResult'))}")
+print(f"lifecycle_mutation_result={json.dumps(checks.get('lifecycleMutationResult'))}")
+print(f"rerendered_state_result={json.dumps(checks.get('rerenderedStateResult'))}")
+PY
+  )
 }
 
 promote_evidence_failure_if_incomplete() {
@@ -233,6 +324,11 @@ write_summary_json() {
   "knownGoodImageTag": "$(json_escape "$KNOWN_GOOD_IMAGE_TAG")",
   "deployResult": "$(json_escape "$deploy_result")",
   "verifyResult": "$(json_escape "$verify_result")",
+  "accessVerifyResult": "$(json_escape "${ACCESS_VERIFY_RESULT:-NOT_RUN}")",
+  "memberReadResult": ${MEMBER_READ_RESULT_JSON:-null},
+  "adminReadResult": ${ADMIN_READ_RESULT_JSON:-null},
+  "lifecycleMutationResult": ${LIFECYCLE_MUTATION_RESULT_JSON:-null},
+  "rerenderedStateResult": ${RERENDERED_STATE_RESULT_JSON:-null},
   "rollbackResult": "$(json_escape "$rollback_result")",
   "preflightResult": "$(json_escape "$preflight_result")",
   "rollbackTrigger": "$(json_escape "$ROLLBACK_TRIGGER")",
@@ -247,6 +343,7 @@ write_summary_json() {
     "releaseContractGate": "$(json_escape "$RELEASE_CONTRACT_GATE")",
     "deployExecutionGate": "$(json_escape "$DEPLOY_EXECUTION_GATE")",
     "postChangeVerifyGate": "$(json_escape "$POST_CHANGE_VERIFY_GATE")",
+    "accessAwareVerifyGate": "$(json_escape "${ACCESS_AWARE_VERIFY_GATE:-NOT_RUN}")",
     "rollbackReadinessGate": "$(json_escape "$ROLLBACK_READINESS_GATE")"
   },
   "evidenceComplete": $evidence_complete,
@@ -254,6 +351,7 @@ write_summary_json() {
     "preflightLog": "$(json_escape "$(artifact_relpath "$PREFLIGHT_LOG")")",
     "deployLog": "$(json_escape "$(artifact_relpath "$DEPLOY_LOG")")",
     "verifyLog": "$(json_escape "$(artifact_relpath "$VERIFY_LOG")")",
+    "accessVerifyResultJson": "$(json_escape "$(artifact_relpath "${ACCESS_VERIFY_RESULT_JSON:-$ARTIFACT_DIR/access_verify_result.json}")")",
     "rollbackLog": "$(json_escape "$(artifact_relpath "$ROLLBACK_LOG")")",
     "operatorGuidance": "$(json_escape "$(artifact_relpath "$OPERATOR_GUIDANCE_TXT")")",
     "summaryJson": "$(json_escape "$(artifact_relpath "$SUMMARY_JSON")")"


### PR DESCRIPTION
## Metadata

- Requested ID: `S4F-2A`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s4f-2a`
- Source log: `docs/logs/log-S4F-2A-cloud-target-operator-evidence-packet.md`
- Labels: `drills`
- Development issue: #508

## Summary

- Reuse the stable `S4D` cloud release path for one operator-facing cloud-target evidence run of the access/subscription slice.
- Add the `S4F` access-aware verify overlay to the same run so member/admin/lifecycle probes are proven on the actual release path.
- Close the gap left by `S4F-1A`: move from runnable CI proof to operator-facing cloud runtime evidence.

## Execution Checklist

- [x] `P0-C1-S1`: combined cloud-target evidence boundary fixed
- [x] `P0-C1-S2`: verify overlay contract fixed for the real operator path
- [x] `P0-C1-S3`: combined evidence JSON contract fixed
- [x] `P1-C1-S1`: operator-facing verify tuple and artifact write-back shape fixed
- [x] `P1-C1-S2`: overlay wiring landed on the reused `S4D` path
- [x] `P2-C1-S1`: cloud-target operator evidence run captured
- [x] `P2-C1-S2`: evidence artifact, run-state fallback query, and operator/API path diagnostics recorded
- [x] `P3-C1-S1`: branch-road `M1` sufficiency decision recorded

## Links

- Log: `docs/logs/log-S4F-2A-cloud-target-operator-evidence-packet.md`
- Runbook: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
- Evidence artifact: `artifacts/_tmp_s4d4b_cloud_release_dispatch/24662387235-1/summary.json`

## Evidence Footer

- `P2-C1-S1` | artifact: `artifacts/_tmp_s4d4b_cloud_release_dispatch/24662387235-1/summary.json`

Closes #508
