### PR TITLE
RUN-LEDGER-PATCH-001: WORKFLOW-GITHUB-001 admitted run and patch packet

### DIFF
--- a/docs/runbook/support-only/ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md
+++ b/docs/runbook/support-only/ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md
@@ -1,0 +1,65 @@
+# ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline
+
+```yaml
+runbook_run_ledger:
+  run_ledger_id: ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline
+  ledger_kind: runbook-run-ledger
+  status: active
+  owner_lane: S0G-2A
+  runbook_family: WORKFLOW-GITHUB
+  runbook_release: 001
+  runbook_id: run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline
+  runbook_ref: docs/runbook/run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md
+  run_sequence: 001
+  governance_area: workflow
+  functional_domain: GitHub lifecycle automation
+  environment_class: local-plus-github
+  target_surface: issue creation, PR creation, merge follow-through, and issue conclusion
+  created_at: 2026-04-20
+  reviewed_at: 2026-04-21
+  accepted_at: pending
+  target_reading_goal: show the first admitted accounting surface for the WORKFLOW-GITHUB-001 family after one real four-sample full-auto pilot run completed through issue conclusion.
+```
+
+## Decision Frame
+
+- This ledger now remains `active` instead of `draft` because the first real admitted full-auto sample batch has executed across issue creation, PR creation, human merge, and post-merge issue conclusion refresh.
+- The purpose of this ledger is now twofold: preserve the durable accounting surface for the first live run, and admit the concrete evidence rows that tie `RUN-001` to the four S4F samples and the bounded repairs consumed during that run.
+
+## Run Ledger Table
+
+| run row id | trigger kind | environment | target kind | submitted by | command summary | artifact root | verdict status | review status | approval status | downstream consumption | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `RUN-001` | `manual-plus-guarded-scripts` | `local-plus-github` | `issue-pr-conclusion-lifecycle` | `role:workflow-operator` | `Execute the first real WORKFLOW-GITHUB-001 sample batch across issue create -> PR create -> human merge -> guarded issue conclusion refresh.` | `artifacts/` | `pass_after_recovery` | `reviewed` | `pending` | `docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md` | Four S4F samples now landed as live issue/PR/conclusion packets; bounded repairs in `PATCH-001-I02` and `PATCH-001-I03` were required but stayed inside the defended release. |
+
+## Evidence Extraction Table
+
+| evidence item id | run row id | artifact file | evidence type | extraction scope | admitted fields | verification status | used by | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `RUN-001-E01` | `RUN-001` | `docs/runbook/run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md` | `md` | `full` | `runbook family, release, ledger binding, minimum admitted fields` | `verified` | `S0G-2A/P2` | The bound runbook release remains the root contract evidence for the first admitted live run. |
+| `RUN-001-E02` | `RUN-001` | `docs/runbook/support-only/ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md` | `md` | `partial` | `parent run row binding, bounded repair refs, patch-ledger placement` | `verified` | `RUN-001 patch binding` | The first admitted run consumed two bounded repairs and now binds the reserved patch ledger back to `RUN-001`. |
+| `RUN-001-E03` | `RUN-001` | `docs/logs/log-S4F-1A-backend-only-access-subscription-deployable-cut.md` | `md` | `partial` | `requested_id, issue link, PR link, sample lineage` | `verified` | `RUN-001 live sample set` | `S4F-1A` is admitted as part of the first live four-sample batch. |
+| `RUN-001-E04` | `RUN-001` | `docs/logs/log-S4F-2A-cloud-target-operator-evidence-packet.md` | `md` | `partial` | `requested_id, issue link, PR link, sample lineage` | `verified` | `RUN-001 live sample set` | `S4F-2A` is admitted as part of the first live four-sample batch. |
+| `RUN-001-E05` | `RUN-001` | `docs/logs/log-S4F-2B-release-path-dependency-trust-hardening.md` | `md` | `partial` | `requested_id, issue link, PR link, sample lineage` | `verified` | `RUN-001 live sample set` | `S4F-2B` is admitted as part of the first live four-sample batch. |
+| `RUN-001-E06` | `RUN-001` | `docs/logs/log-S4F-2C-deployed-identity-admission-membership-truth-hardening.md` | `md` | `partial` | `requested_id, issue link, PR link, sample lineage` | `verified` | `RUN-001 live sample set` | `S4F-2C` is admitted as part of the first live four-sample batch. |
+| `RUN-001-E07` | `RUN-001` | `artifacts/_tmp_s4f_1a_issue_conclusion_apply_result.json` | `json` | `full` | `requested_id, issue_number, final_issue_state, issue_url` | `verified` | `RUN-001 conclusion admission` | The guarded post-merge conclusion refresh for `S4F-1A` completed with final issue state `CLOSED`. |
+| `RUN-001-E08` | `RUN-001` | `artifacts/_tmp_s4f_2a_issue_conclusion_apply_result_retry.json` | `json` | `full` | `requested_id, issue_number, final_issue_state, issue_url` | `verified` | `RUN-001 conclusion admission` | The guarded post-merge conclusion refresh for `S4F-2A` completed with final issue state `CLOSED`. |
+| `RUN-001-E09` | `RUN-001` | `artifacts/_tmp_s4f_2b_issue_conclusion_apply_result.json` | `json` | `full` | `requested_id, issue_number, final_issue_state, issue_url` | `verified` | `RUN-001 conclusion admission` | The guarded post-merge conclusion refresh for `S4F-2B` completed with final issue state `CLOSED`. |
+| `RUN-001-E10` | `RUN-001` | `artifacts/_tmp_s4f_2c_issue_conclusion_apply_result_retry2.json` | `json` | `full` | `requested_id, issue_number, final_issue_state, issue_url` | `verified` | `RUN-001 conclusion admission` | The guarded post-merge conclusion refresh for `S4F-2C` completed with final issue state `CLOSED`. |
+
+## Actor and Provenance Review Table
+
+| row id | submitted by | evidence owner | reviewed by | verified by | verification method | approved by | approval state | approval basis | provenance note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `RUN-001` | `role:workflow-operator` | `role:runbook-maintainer` | `role:workflow-reviewer` | `role:evidence-verifier` | `direct-artifact-inspection and live-github-state-check` | `pending` | `pending` | The four-sample run completed with concrete issue, PR, patch, and conclusion evidence rows admitted into the parent ledger, but explicit human approval is still left pending. | GitHub-side issue states for `#507` through `#510` were checked live after conclusion apply, and the local apply-result artifacts preserve the exact post-merge write-back evidence. |
+
+## Optional Run Time Audit
+
+| run row id | run started at | run completed at | source recorded at | time precision | timezone note | notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `RUN-001` | `2026-04-21` | `2026-04-21` | `2026-04-21` | `day` | `GitHub merged-at timestamps were recorded in UTC; run-ledger write-back was completed from the local operator session on the same date.` | The first admitted run spanned four S4F samples through issue creation, PR creation, human merge, and guarded issue-conclusion refresh. |
+
+## Reader Notes
+
+- This file is now the durable accounting surface for the first admitted `WORKFLOW-GITHUB-001` live sample batch.
+- Future sample rounds should either append a new run ledger row or open the next run ledger file instead of rewriting the admitted evidence for `RUN-001`.

--- a/docs/runbook/support-only/ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md
+++ b/docs/runbook/support-only/ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md
@@ -1,0 +1,60 @@
+# ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline
+
+```yaml
+runbook_run_patch_ledger:
+  patch_ledger_id: ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline
+  patch_kind: runbook-run-ledger-patch
+  status: active
+  owner_lane: S0G-2B
+  parent_runbook_id: run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline
+  parent_runbook_ref: docs/runbook/run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md
+  parent_run_ledger_id: ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline
+  parent_run_ledger_ref: docs/runbook/support-only/ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md
+  parent_run_row_id: RUN-001
+  patch_sequence: 001
+  created_at: 2026-04-21
+  reviewed_at: 2026-04-21
+  accepted_at: pending
+  writeback_started_at: 2026-04-21
+  writeback_completed_at: 2026-04-21
+  patch_scope: bind the first bounded repair packet surface for WORKFLOW-GITHUB-001 to the first admitted four-sample run without forcing a runbook release bump.
+  patch_reason_class: mixed-bounded-repair
+  approval_boundary: runbook-bound patch packets should remain reviewable and approvable before they rewrite admitted run accounting or source-log conclusions.
+  target_reading_goal: show how the first runbook-bound repair packet for WORKFLOW-GITHUB-001 attached to RUN-001 after the first real sample run exposed bounded fixes.
+```
+
+## Decision Frame
+
+- This file still preserves the first canonical patch-ledger name for `WORKFLOW-GITHUB-001`, but it is no longer only a reserved surface.
+- The patch ledger is now bound to `RUN-001`, because the first admitted live sample run exposed bounded repairs that were fixed without changing the defended runbook release.
+- Future bounded repairs for this same release should still land here rather than in an unstructured log-first patch note.
+
+## Patch Change Table
+
+| patch item id | parent run row id | target artifact or path | change class | evidence refs | verification status | approval status | effect on current runbook release | proposed parent-ledger action | downstream impact | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `PATCH-001-I01` | `RUN-001` | `docs/runbook/run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md` | `mixed-bounded-repair` | `docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md` | `verified` | `pending` | `no-release-bump` | `append-patch-ref` | `none` | The first patch ledger entry now remains attached to the admitted run that consumed the support-only placement and patch-ledger bridge contract. |
+| `PATCH-001-I02` | `RUN-001` | `scripts/issues/gen_issue_draft.py` | `operator-override-gap-repair` | `docs/issues/issue-S4F-1A-backend-only-access-subscription-deployable-cut.json` | `verified` | `pending` | `no-release-bump` | `append-patch-ref` | `unblock-first-s4f-sample-batch` | Add one explicit milestone-skip override so historical sample logs with roadmap-derived milestones can still enter live create mode when the target GitHub repo does not maintain matching milestone rows. |
+| `PATCH-001-I03` | `RUN-001` | `scripts/issues/plan_pr_prep.py` | `multi-item-preview-body-repair` | `artifacts/_tmp_s4f_2a_front_half_preflight_result.json` | `verified` | `pending` | `no-release-bump` | `append-patch-ref` | `unblock-batched-s4f-pr-create` | Generate one preview body file per PR-prep item so multi-item manifests do not overwrite earlier item bodies and fail front-half preflight against the wrong sample. |
+
+## Attachment Review Table
+
+| attachment id | patch item id | click-through asset ref | review status | approval basis | review note |
+| --- | --- | --- | --- | --- | --- |
+| `PATCH-001-I01-ATT-01` | `PATCH-001-I01` | `docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md` | `accepted-for-packet` | The patch ledger naming and bridge rule were fixed before the first live run and are now part of the admitted repair surface attached to `RUN-001`. | This attachment remains the contract-defining bridge evidence that allowed the first bounded repair packet to land in the support-only patch ledger. |
+| `PATCH-001-I02-ATT-01` | `PATCH-001-I02` | `docs/issues/issue-S4F-1A-backend-only-access-subscription-deployable-cut.json` | `accepted-for-packet` | The first live S4F sample exposed a fail-closed milestone mismatch between roadmap-derived milestone names and the current GitHub milestone catalog. | Live create now succeeds under explicit milestone-skip override, so this repair is verified for the first S4F sample batch. |
+| `PATCH-001-I03-ATT-01` | `PATCH-001-I03` | `artifacts/_tmp_s4f_2a_front_half_preflight_result.json` | `accepted-for-packet` | The first batched S4F PR-preflight exposed that earlier PR-prep items were reusing the last rendered preview body and therefore failed the body-shape contract against the wrong sample. | Re-running `S4F-2A` preflight after the per-item preview-path fix returned `allow-front-half-preflight`, confirming the bounded repair. |
+
+## Actor and Provenance Review Table
+
+| patch item id | submitted by | evidence owner | reviewed by | verified by | verification method | approved by | approval state | approval basis | provenance note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `PATCH-001-I01` | `role:workflow-operator` | `role:runbook-maintainer` | `pending` | `role:evidence-verifier` | `direct-doc-inspection` | `pending` | `pending` | The support-only patch surface is now attached to the first admitted run and remains pending only for explicit human approval. | This row records the contract bridge that allowed later bounded repairs in the same packet to attach cleanly to `RUN-001`. |
+| `PATCH-001-I02` | `role:workflow-operator` | `role:workflow-maintainer` | `pending` | `role:evidence-verifier` | `live-create-replay-after-explicit-milestone-skip` | `pending` | `pending` | The repair is bounded to one explicit operator override path and preserves the default fail-closed milestone contract for normal create mode. | This row is opened by the first real S4F sample attempt, which failed closed on missing GitHub milestone `M1` before live issue creation could complete. |
+| `PATCH-001-I03` | `role:workflow-operator` | `role:workflow-maintainer` | `pending` | `role:evidence-verifier` | `front-half-preflight-replay-after-per-item-preview-path-fix` | `pending` | `pending` | The repair is bounded to preview artifact generation for multi-item PR-prep manifests and does not relax any live create or body-contract checks. | This row was opened only after the first batched S4F PR-preflight showed `S4F-2A` reading `S4F-2C`'s preview body because all items shared one preview path. |
+
+## Reader Notes
+
+- Patch ledgers for `WORKFLOW-GITHUB-001` should remain under `docs/runbook/support-only/`.
+- `PATCH-001` is now attached to parent run row `RUN-001`; later bounded repairs for this release should preserve that binding unless a new admitted run row becomes the true trigger.
+- If a future bounded repair changes runbook semantics materially, do not continue under this patch series; open a new source log and a new runbook release instead.

--- a/scripts/issues/gen_issue_draft.py
+++ b/scripts/issues/gen_issue_draft.py
@@ -73,7 +73,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--output-path", dest="output_path", help="Override output markdown path")
     parser.add_argument("--result-path", dest="result_path", help="Override structured result JSON path")
     parser.add_argument("--parent-issue", dest="parent_issue", help="Override parent issue URL/number")
-    parser.add_argument("--milestone-override", dest="milestone_override", help="Override milestone")
+    parser.add_argument(
+        "--milestone-override",
+        dest="milestone_override",
+        help="Override milestone; use none|blank|skip to suppress milestone application explicitly",
+    )
     parser.add_argument(
         "--module-label-override",
         dest="module_label_overrides",
@@ -388,6 +392,10 @@ def _derive_issue_projects(fields: dict[str, str], log_rel_path: str) -> list[st
 def _derive_milestone(fields: dict[str, str], milestone_override: str | None) -> tuple[str | None, list[str]]:
     warnings: list[str] = []
     if milestone_override:
+        normalized_override = milestone_override.strip().lower()
+        if normalized_override in {"none", "blank", "skip"}:
+            warnings.append("issue_milestone explicitly skipped by milestone override")
+            return None, warnings
         return milestone_override, warnings
 
     explicit = fields.get("issue_milestone", "").strip()

--- a/scripts/issues/plan_pr_prep.py
+++ b/scripts/issues/plan_pr_prep.py
@@ -553,11 +553,12 @@ def _collect_branch_commits(base_branch: str, head_ref: str) -> tuple[str, list[
     return merge_base, items
 
 
-def _build_plan_item(item: dict, defaults: dict, repo_root: Path, preview_path: Path) -> PrPrepPlanItem:
+def _build_plan_item(item: dict, defaults: dict, repo_root: Path, preview_dir: Path, preview_stem: str) -> PrPrepPlanItem:
     warnings: list[str] = []
     requested_id = (item.get("requested_id") or defaults.get("requested_id") or "").strip()
     if not requested_id:
         raise SystemExit("PR-prep manifest item missing requested_id")
+    preview_path = preview_dir / f"{preview_stem}-{requested_id.lower()}-body.md"
 
     source_log_value = item.get("source_log_path") or defaults.get("source_log_path")
     if not source_log_value:
@@ -731,8 +732,9 @@ def plan_pr_prep(args: argparse.Namespace) -> PrPrepPlanResult:
     plan_path = _coerce_path(args.plan_path, repo_root) if args.plan_path else default_plan_path
     plan_path.parent.mkdir(parents=True, exist_ok=True)
 
-    preview_path = plan_path.with_name(f"{manifest_slug}-body.md")
-    plan_items = [_build_plan_item(item, defaults, repo_root, preview_path) for item in items]
+    preview_dir = plan_path.parent
+    preview_stem = manifest_slug
+    plan_items = [_build_plan_item(item, defaults, repo_root, preview_dir, preview_stem) for item in items]
     top_warnings: list[str] = []
     for item in plan_items:
         for warning in item.warnings:


### PR DESCRIPTION
## Summary
- add the admitted RUN-001 and PATCH-001 support-only ledger surfaces to main
- carry the paired issue-prep script updates required by the same packet

## Scope
- docs/runbook/support-only/ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md
- docs/runbook/support-only/ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md
- scripts/issues/gen_issue_draft.py
- scripts/issues/plan_pr_prep.py

## Notes
- this PR intentionally contains only the runbook-family packet
- S0F historical content is excluded