### PR TITLE
S0G-3A/P1-P3-C1-S1: runbook governance and parent issue alignment

### DIFF
--- a/docs/issues/issue-S0G-parent-live.json
+++ b/docs/issues/issue-S0G-parent-live.json
@@ -1,5 +1,5 @@
 {
-  "mode": "create-issue",
+  "mode": "draft-generation",
   "result": "ok",
   "context_mode": "scaffold",
   "log_path": "docs/logs/log-S0G-docs-management-v7.md",
@@ -21,24 +21,17 @@
   ],
   "milestone": "road-002: projection runtime platformization and evidence governance",
   "parent_issue": null,
-  "body_markdown": "## Metadata\n\n- Labels: `EVOLUTION`, `s0/knowledge system`, `sub/0`, `drills`\n- Projects: `wordloom Board`\n- Milestone: `road-002: projection runtime platformization and evidence governance`\n\n## Context\n\n\n## Definition of Done (DoD)\n\n\n## Links\n\n- Log: `docs/logs/log-S0G-docs-management-v7.md`\n- Runbook: `docs/runbook/run-S0E-log-to-issue-creation.md`\n- Roadmap: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`\n",
+  "body_markdown": "## Metadata\n\n- Labels: `EVOLUTION`, `s0/knowledge system`, `sub/0`, `drills`\n- Projects: `wordloom Board`\n- Milestone: `road-002: projection runtime platformization and evidence governance`\n\n## Context\n\n\n## Definition of Done (DoD)\n\n- #505\n\n## Links\n\n- Log: `docs/logs/log-S0G-docs-management-v7.md`\n- Runbook: `docs/runbook/run-S0E-log-to-issue-creation.md`\n- Roadmap: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`\n",
   "warnings": [
     "module labels left blank",
-    "live label preflight passed against samuelhu324-dev/wordloom-v3",
     "Context section was left intentionally empty at create time; generate or author substantive Context text during issue conclusion",
-    "Definition of Done (DoD) remains intentionally blank pending operator input",
-    "source log write-back not performed; update links.issue in a later tracked docs change"
+    "Definition of Done (DoD) was populated from the known child issue ledger because this is a top-level parent issue"
   ],
-  "live_label_check_enabled": true,
-  "live_label_check_repo": "samuelhu324-dev/wordloom-v3",
-  "matched_live_labels": [
-    "EVOLUTION",
-    "s0/knowledge system",
-    "sub/0",
-    "drills"
-  ],
+  "live_label_check_enabled": false,
+  "live_label_check_repo": null,
+  "matched_live_labels": [],
   "missing_live_labels": [],
-  "issue_number": 504,
-  "issue_url": "https://github.com/samuelhu324-dev/wordloom-v3/issues/504",
-  "created_at": "2026-04-20T03:14:14.397050+00:00"
+  "issue_number": null,
+  "issue_url": null,
+  "created_at": null
 }

--- a/docs/issues/issue-S0G-parent-live.md
+++ b/docs/issues/issue-S0G-parent-live.md
@@ -9,6 +9,7 @@
 
 ## Definition of Done (DoD)
 
+- #505
 
 ## Links
 

--- a/docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md
+++ b/docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md
@@ -1,0 +1,196 @@
+# log-S0G-2B (Phase 2B: support-only ledger placement and patch-ledger bridge)
+
+---
+
+**id**: `S0G-2B`
+**kind**: `log`
+**title**: `support-only ledger placement and patch-ledger bridge v1`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Workflow, Automation, Evidence, epic/s0, sub/2b`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: `docs/runbook/run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0G-docs-management-v7.md`
+  **previous_log**: `docs/logs/log-S0G-2A-runbook-ledger-aware-operator-surface-and-execution-accounting.md`
+  **reference_log_1**: `docs/logs/log-S0G-2A-runbook-ledger-aware-operator-surface-and-execution-accounting.md`
+  **reference_log_2**: `docs/logs/log-S0F-2B-family-patch-and-ops-maintenance-model.md`
+  **reference_log_3**: `docs/runbook/support-only/_template-run-ledger-SUP.md`
+**issue_keyword**: `workflow`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/2`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: ``
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: `drills`
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-21`
+**updated**: `2026-04-21`
+**reviewed**: `pending`
+
+---
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0G-2B` exists as the next bounded follow-up after `S0G-2A`: all ledger-class files for the new runbook family should live under `docs/runbook/support-only/`, not at the runbook root.
+- Runbook-bound patch packets should no longer default to log-first patch notes; they should use a support-only patch-ledger surface that is supplement-class and keeps the same ownership, approval, timing, verification, and attachment affordances as other ledger packets.
+- The first canonical patch-ledger naming rule for `WORKFLOW-GITHUB-001` is fixed as `ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`.
+
+**Default choices (phase defaults / v1)**:
+
+- Parent run ledgers, SUP ledgers, and PATCH ledgers should all live under `docs/runbook/support-only/`.
+- Root `docs/runbook/` remains for family-level runbooks only; it is not the canonical home for ledger-class packets.
+- PATCH ledgers are support-only supplement-class packets for bounded repair work that stays inside one defended runbook release.
+- PATCH ledgers may carry screenshots, transcripts, and approval-facing attachments the same way SUP ledgers do.
+- PATCH ledgers must record explicit ownership, review, verification, approval, and lifecycle-time fields.
+- If a patch materially changes operator semantics, evidence admission rules, or runbook/ledger binding, stop and open a new source log plus a new runbook release instead of continuing inside the patch ledger series.
+
+## Constraints
+
+- Do not leave canonical ledger-class references pointing at the runbook root once support-only placement is fixed.
+- Do not treat patch notes as freeform prose-only packets when they are intended to feed later extraction, approval, or audit.
+- Do not force every bounded repair to become a runbook release bump.
+- Do not use a PATCH ledger to hide contract-level semantic change.
+
+## Scope
+
+- `P0`: support-only placement rule for parent, SUP, and PATCH ledgers
+- `P1`: patch-ledger bridge contract and template surface
+- `P2`: `WORKFLOW-GITHUB-001` binding rewrite plus first reserved PATCH ledger surface
+- `P3`: next-lane decision after support-only and patch bridge hardening
+
+## Success Criteria (DoD)
+
+- Canonical ledger-class placement is fixed to `docs/runbook/support-only/`.
+- A PATCH ledger template exists and carries ownership, approval, timing, verification, and attachment-review fields.
+- `WORKFLOW-GITHUB-001` binds to support-only parent and patch ledger surfaces consistently.
+- The next step is explicit: only after these rules are fixed should the first real full-auto sample batch begin.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - support-only placement and patch-ledger bridge rules are explicit;
+  - the canonical template and reserved `PATCH-001` surface exist;
+  - the next lane is fixed back to real sample execution rather than more placement debate.
+
+## Plan (closed in this packet)
+
+### P0 (Placement rule)
+
+- P0-C1-S1: fix support-only as the canonical home for ledger-class packets
+
+### P1 (Patch-ledger bridge)
+
+- P1-C1-S1: publish a support-only PATCH ledger template with SUP-like ownership, approval, timing, and attachment review fields
+- P1-C1-S2: demote the old log-first patch-note template into a legacy compatibility note with bridge guidance
+
+### P2 (Binding rewrite)
+
+- P2-C1-S1: rewrite `WORKFLOW-GITHUB-001` ledger binding to support-only paths
+- P2-C1-S2: reserve the first canonical patch-ledger surface for `WORKFLOW-GITHUB-001`
+
+### P3 (Next-lane decision)
+
+- P3-C1-S1: fix the next step back to the first real `WORKFLOW-GITHUB-001` full-auto sample batch after the placement and patch bridge rules are in place
+
+## Execution Checklist
+
+### P0 (Placement rule)
+
+- [x] `P0-C1-S1`: support-only ledger placement fixed as canonical
+
+### P1 (Patch-ledger bridge)
+
+- [x] `P1-C1-S1`: support-only PATCH ledger template published
+- [x] `P1-C1-S2`: legacy log-first patch note demoted into bridge-only compatibility guidance
+
+### P2 (Binding rewrite)
+
+- [x] `P2-C1-S1`: `WORKFLOW-GITHUB-001` binding rewritten to support-only ledger paths
+- [x] `P2-C1-S2`: first reserved `PATCH-001` ledger surface opened
+
+### P3 (Next-lane decision)
+
+- [x] `P3-C1-S1`: next step fixed to real full-auto samples only after these rules
+
+## Current Status
+
+- `S0G-2B` has now fixed the canonical ledger home as `docs/runbook/support-only/`.
+- The new patch-ledger bridge is explicit: patch packets that belong to one stable runbook release should use `ledger-run-PATCH-*` support-only files, not unstructured log-first notes.
+- `WORKFLOW-GITHUB-001` is now rebound to support-only ledger surfaces, and the first reserved patch-ledger name exists.
+- The first real `WORKFLOW-GITHUB-001` full-auto sample batch has now executed and updated admitted run accounting under `RUN-001`, with `PATCH-001` bound back to the same parent run row.
+
+## Evidence
+
+### P1-C1-S1 (support-only PATCH ledger template published | 2026-04-21)
+
+- headSha: `WORKTREE`
+- artifacts:
+  - `docs/runbook/support-only/_template-run-ledger-PATCH.md`
+- expected:
+  - patch packets should gain a supplement-class template with ownership, verification, approval, timing, and attachment review fields.
+- observed:
+  - the new template now gives patch packets the same structured review and lifecycle surface that SUP ledgers already have, while keeping patch-specific release-bound rules.
+
+### P1-C1-S2 (legacy patch-note template reduced to bridge-only compatibility note | 2026-04-21)
+
+- headSha: `WORKTREE`
+- artifacts:
+  - `docs/logs/patch/_template-log-patch-note.md`
+- expected:
+  - the old log-first patch template should stop acting like the canonical new path for runbook-bound repairs.
+- observed:
+  - the template now explicitly routes new runbook-bound patch packets to support-only `ledger-run-PATCH-*` files instead of keeping prose-only patch notes as the default.
+
+### P2-C1-S1 (WORKFLOW-GITHUB-001 rebound to support-only ledger paths | 2026-04-21)
+
+- headSha: `WORKTREE`
+- artifacts:
+  - `docs/runbook/run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+  - `docs/runbook/support-only/ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+- expected:
+  - the runbook should no longer point at root-level ledger paths once support-only placement is canonical.
+- observed:
+  - the runbook now binds to the parent ledger, supplement ledger series, and patch ledger series under `docs/runbook/support-only/`.
+
+### P2-C1-S2 (reserved PATCH-001 support-only surface opened | 2026-04-21)
+
+- headSha: `WORKTREE`
+- artifacts:
+  - `docs/runbook/support-only/ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+- expected:
+  - the first canonical patch-ledger name should exist before live samples begin so future bounded repairs have one defended landing surface.
+- observed:
+  - the reserved `PATCH-001` surface was opened before live samples began and is now the bound repair surface for the first admitted `WORKFLOW-GITHUB-001` run.
+
+### P3-C1-S1 (next lane fixed back to real full-auto samples after bridge hardening | 2026-04-21)
+
+- headSha: `WORKTREE`
+- artifacts:
+  - `docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md`
+  - `docs/runbook/support-only/ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+  - `docs/runbook/support-only/ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+- expected:
+  - once support-only placement and patch-ledger bridge rules are fixed, the next step should return to real sample execution rather than keep widening policy.
+- observed:
+  - the next bounded step did return to the first real `WORKFLOW-GITHUB-001` full-auto sample batch, and that batch is now admitted under `RUN-001` with the bounded repair packet bound under `PATCH-001`.
+
+## Recent changes
+
+- 2026-04-21: fixed `docs/runbook/support-only/` as the canonical home for ledger-class packets.
+- 2026-04-21: published the new support-only `PATCH` ledger template and reserved the first `ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md` surface.
+- 2026-04-21: rebound `WORKFLOW-GITHUB-001` to support-only parent, supplement, and patch ledger paths before the first live sample batch.
+- 2026-04-21: admitted the first real four-sample `WORKFLOW-GITHUB-001` run under `RUN-001` after issue creation, PR creation, human merge, and guarded issue-conclusion refresh.
+- 2026-04-21: bound `PATCH-001` back to `RUN-001` because the first admitted run consumed the milestone-skip and multi-item preview-body repairs.

--- a/docs/logs/log-S0G-3A-runbook-release-issue-concentration-and-ledger-naming-governance.md
+++ b/docs/logs/log-S0G-3A-runbook-release-issue-concentration-and-ledger-naming-governance.md
@@ -1,0 +1,253 @@
+# log-S0G-3A (Phase 3: runbook release issue concentration and ledger naming governance)
+
+---
+
+**id**: `S0G-3A`
+**kind**: `log`
+**title**: `runbook release issue concentration and ledger naming governance v1`
+**status**: `draft`
+**scope**: `S0`
+**tags**: `EVOLUTION, Docs, Workflow, Automation, Evidence, epic/s0, sub/3a`
+**links**: ``
+  **issue**: ``
+  **pr**: ``
+  **runbook**: `docs/runbook/run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+  **roadmap**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+  **parent_log**: `docs/logs/log-S0G-docs-management-v7.md`
+  **previous_log**: `docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md`
+  **reference_log_1**: `docs/logs/log-S0G-2A-runbook-ledger-aware-operator-surface-and-execution-accounting.md`
+  **reference_log_2**: `docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md`
+  **reference_log_3**: `docs/runbook/support-only/_template-run-ledger-PATCH.md`
+**issue_keyword**: `workflow`
+**issue_top_labels**: `EVOLUTION`
+**issue_scope_labels**: `s0/knowledge system, sub/3`
+**issue_module_labels**: ``
+**issue_milestone**: `road-002: projection runtime platformization and evidence governance`
+**issue_parent**: ``
+**issue_projects**: ``
+**roadmap_path**: `docs/roadmap/road-002-projection-runtime-platformization-and-evidence-governance.md`
+**roadmap_milestone**: ``
+**roadmap_phase**: ``
+**roadmap_bridge_refs**: ``
+**pr_labels**: `drills`
+**pr_projects**: ``
+**pr_milestone**: ``
+**pr_base**: `main`
+**pr_development_issue**: ``
+**created**: `2026-04-21`
+**updated**: `2026-04-21`
+**reviewed**: `pending`
+
+---
+
+## Frontmatter Lifecycle-Time Rule
+
+- `created`, `updated`, and optional `reviewed` are the minimum artifact-lifecycle fields for this packet.
+- Day-level precision is acceptable while the naming and issue-topology contract is still being fixed.
+- `reviewed` should remain `pending` until the release issue topology, commit/PR naming grammar, and legacy placement rule are explicit enough to drive later commit/push discipline.
+
+## Decision / Outcome
+
+**Decision**:
+
+- `S0G-3A` opens the next bounded follow-up after `S0G-2B`: fix one explicit governance rule for how runbook-family work should map to GitHub issues, PRs, and commit naming once the operator surface has moved from evolution-log-only slices into release/ledger/supplement/patch objects.
+- The default issue topology is now intentionally concentrated: generate one release-scoped issue for the runbook family release, and let later ledger, supplement, and patch PRs attach back to that same release issue instead of opening a new issue per ledger-class packet.
+- Commit and PR naming for runbook-family objects should stop inheriting the older `SxY/P*-C*-S*` grammar as their reader-facing primary label; they should instead use the bound object class and exact runbook-family token, while the source log remains the place that explains why the object exists.
+- Older runbooks that no longer represent the defended current operator surface should be treated explicitly as `legacy` rather than left mixed with the current runbook family, and that placement decision belongs in this lane instead of being deferred indefinitely.
+- Branches that already carry mixed history from earlier cherry-pick or backfill rounds should be treated as historical carriers; new runbook-family work should start from fresh `main`-based clean branches so commit discovery and later PR automation stay bounded.
+
+**Default choices (phase defaults / v1)**:
+
+- One runbook release should normally own exactly one live release issue.
+- Parent run-ledger, SUP-ledger, and PATCH-ledger packets should reuse that release issue as their PR linkage anchor unless a later contract proves that a separate issue class is necessary.
+- The reader-facing family token should stay identical to the file/object token, for example `WORKFLOW-GITHUB-001`, rather than being rewritten into spaced prose for commit and PR subjects.
+- Reader-facing commit and PR titles for runbook-family objects should prefer object-class prefixes such as `RUN-RELEASE`, `RUN-LEDGER-001`, `RUN-LEDGER-SUP-001`, and `RUN-LEDGER-PATCH-001`.
+- The older slice-style `SxY/P*-C*-S*` grammar remains valid for evolution source logs and other pre-runbook-family work; it is not deleted, but it should no longer be the primary naming surface for new runbook-family packets.
+- If a runbook file no longer represents the defended operator surface, record the placement decision explicitly as `legacy` rather than leaving it at the active root by inertia.
+- When a working branch already contains mixed ancestry from earlier cherry-pick or backfill rounds, do not try to beautify that branch as the long-term carrier; open a fresh branch from `main` for the next bounded packet.
+
+## PR Summary Inputs (optional)
+
+- This packet is expected to drive later release-scoped issue and PR work, so the review summary should focus on issue concentration, naming grammar, and legacy/current-state separation.
+
+**PR summary bullets**:
+
+- Concentrate runbook-family GitHub issue generation onto one release issue instead of opening one issue per ledger or patch packet.
+- Fix one object-first naming grammar for release, ledger, supplement, and patch commits and PR titles.
+- Record that older runbooks should move under `legacy` once a newer defended runbook-family surface exists, and that future work should start from fresh clean branches instead of polluted historical carriers.
+
+**PR checklist source**:
+
+- Default source: reuse this log's execution checklist for the generated PR checklist block.
+
+**PR links**:
+
+- Log: `docs/logs/log-S0G-3A-runbook-release-issue-concentration-and-ledger-naming-governance.md`
+- Runbook: `docs/runbook/run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+- Evidence artifact: `docs/runbook/support-only/ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+
+**Evidence Footer Source**:
+
+- `P0-C1-S1` | artifact: `docs/runbook/run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+- `P1-C1-S1` | artifact: `docs/runbook/support-only/ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+- `P1-C1-S2` | artifact: `docs/runbook/support-only/ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+
+## Definitions (optional)
+
+- **release issue concentration**: one rule that later ledger, supplement, and patch PRs should point back to the bound runbook release issue instead of generating one new issue per object.
+- **object-first naming**: reader-facing commit and PR naming that starts from the defended object class, for example `RUN-LEDGER-001`, instead of the source-log slice id.
+- **historical carrier branch**: an older mixed branch that remains useful as reference, but should not continue as the default branch for new bounded work once ancestry has been polluted by cherry-pick or retrospective close-out rounds.
+- **legacy runbook placement**: the explicit decision that older runbooks remain readable but no longer claim current operator authority once a newer defended runbook family exists.
+
+## Constraints
+
+- Do not reopen issue proliferation by generating one GitHub issue per ledger, supplement, or patch packet unless a later defended contract proves that concentration fails.
+- Do not let commit/PR naming drift away from the exact runbook-family token carried by the bound files.
+- Do not quietly keep older runbooks at the active root once they are no longer the defended current operator surface.
+- Do not continue new packet work on long-lived polluted branches when a fresh `main`-based clean branch would preserve clearer commit ancestry.
+
+## Scope
+
+- `P0`: release-issue concentration rule and object boundary
+- `P1`: commit/PR naming grammar for release, ledger, supplement, and patch packets
+- `P2`: legacy runbook placement decision and branch-carrier rule
+- `P3`: next-lane execution rule for later commit/push discipline under mixed workspace state
+
+## Success Criteria (DoD)
+
+- One explicit rule states that runbook-family GitHub issue generation defaults to one release issue, not one issue per ledger packet.
+- One explicit reader-facing naming grammar exists for `RUN-RELEASE`, `RUN-LEDGER-001`, `RUN-LEDGER-SUP-001`, and `RUN-LEDGER-PATCH-001`.
+- The lane states when older runbooks should move under `legacy` rather than continue to appear as current-state operator surfaces.
+- The lane states that future bounded work should begin from fresh clean branches when the older lane branch is already polluted by mixed ancestry.
+- The next discussion step is explicit: classify current workspace changes into `runbook-family commit/push now` vs `still evolution-log lane` before mutating git history.
+
+## Stability (what stable means)
+
+- This log can be marked `stable` when:
+  - the release-issue concentration rule is explicit;
+  - the object-first naming grammar is explicit;
+  - the legacy runbook placement rule is explicit;
+  - the next classification step for current workspace changes is fixed explicitly.
+
+## P0 (Contract | v1)
+
+### P0-C1-S1 (Release issue concentration fixed | v1)
+
+- A runbook family release should normally create one release issue only.
+- Later parent-ledger, SUP-ledger, and PATCH-ledger PRs should attach to that release issue by default instead of generating separate issues.
+- If a later packet truly needs a separate issue, that should be treated as an exception that must be justified explicitly in a source log or contract, not as the default topology.
+
+### P0-C1-S2 (Object boundary vs source-log boundary fixed | v1)
+
+- The source log remains the governance and explanation surface for why the object exists.
+- The reader-facing commit and PR title for a runbook-family packet should follow the object class, not the source-log slice id.
+- Source-log IDs such as `S0G-3A` remain valid inside evidence, provenance, and planning text, but they should not be the primary label for the user-facing runbook-family packet once the packet is operating as a release/ledger/supplement/patch object.
+
+## Numbering
+
+- `S<n>`: Step.
+- `C<n>`: Cycle.
+
+**Commit / PR naming**:
+
+- Source-log work inside this lane still uses `S0G-3A/P<phase>-C<cycle>-S<steps>: <summary>`.
+- Runbook-family release packets should use `RUN-RELEASE: WORKFLOW-GITHUB-001 GitHub Issues full-auto pipeline / <summary>`.
+- Parent run-ledger packets should use `RUN-LEDGER-001: WORKFLOW-GITHUB-001 GitHub Issues full-auto pipeline / <summary>`.
+- Supplement run-ledger packets should use `RUN-LEDGER-SUP-001: WORKFLOW-GITHUB-001 GitHub Issues full-auto pipeline / <summary>`.
+- Patch run-ledger packets should use `RUN-LEDGER-PATCH-001: WORKFLOW-GITHUB-001 GitHub Issues full-auto pipeline / <summary>`.
+- PR titles should reuse the same object-first prefix grammar as the packet they represent; they should not invent a second naming system.
+
+**Branch convention**:
+
+- New runbook-family packets should normally open from a fresh `main`-based clean branch named for the bounded object or packet, rather than continuing on a long-lived mixed historical carrier branch.
+- Older polluted branches such as retrospective or cherry-pick-heavy carriers may remain as historical context, but they should not be the default base for discovering or publishing the next bounded packet.
+
+**Commit discipline (recommended)**:
+
+- Do not commit/push the current mixed workspace blindly under the new object-first grammar.
+- First classify each pending change as one of two buckets: `belongs to a defended runbook-family object now` or `still belongs to an evolution source-log lane`.
+- Only after that classification should the later commit/push work adopt `RUN-RELEASE` or `RUN-LEDGER-*` subjects; otherwise the repo will create another mixed-history packet under a cleaner name but with the same boundary error.
+
+## Plan (draft)
+
+### P1 (Naming and issue topology)
+
+- P1-C1-S1: fix release-issue concentration as the default issue topology for runbook-family work
+- P1-C1-S2: publish the object-first commit/PR naming grammar for release, ledger, supplement, and patch packets
+
+### P2 (Placement and branch boundary)
+
+- P2-C1-S1: record when older runbooks should move under `legacy`
+- P2-C1-S2: record the clean-branch rule for future bounded packets after polluted ancestry rounds
+
+### P3 (Next discussion step)
+
+- P3-C1-S1: classify the current mixed workspace into `runbook-family commit/push now` vs `still evolution-log lane`
+
+## Execution Checklist (unchecked)
+
+### P0 (Contract)
+
+- [x] `P0-C1-S1`: release issue concentration fixed
+- [x] `P0-C1-S2`: object boundary vs source-log boundary fixed
+
+### P1 (Naming and issue topology)
+
+- [x] `P1-C1-S1`: release-issue concentration written as the default topology
+- [x] `P1-C1-S2`: object-first commit/PR naming grammar written explicitly
+
+### P2 (Placement and branch boundary)
+
+- [x] `P2-C1-S1`: legacy runbook placement decision recorded
+- [x] `P2-C1-S2`: clean-branch rule recorded for future bounded packets
+
+### P3 (Next discussion step)
+
+- [x] `P3-C1-S1`: next classification step fixed explicitly
+
+## Current Status (recommended)
+
+- `S0G-3A` now fixes the missing governance layer between the existing runbook/ledger file naming contract and later commit/PR/issue practice.
+- The default issue topology is now intentionally concentrated onto one runbook release issue, with ledger, supplement, and patch PRs expected to attach back to that same release issue unless a later exception is justified explicitly.
+- The object-first naming grammar is now explicit for `RUN-RELEASE`, `RUN-LEDGER-001`, `RUN-LEDGER-SUP-001`, and `RUN-LEDGER-PATCH-001`.
+- The next step after this packet should be a discussion-driven classification of current workspace changes into `commit/push now under runbook-family naming` vs `still belongs to an evolution source-log lane`; that step should happen before any new naming-based commit burst.
+
+## Evidence (reserved)
+
+- Artifacts are the source of truth for evidence; this packet records the currently defended runbook and ledger surfaces that make the new naming and issue-topology rule necessary.
+
+### P0-C1-S1 (release issue concentration opened against the current runbook family | 2026-04-21)
+
+- headSha: `WORKTREE`
+- artifacts:
+  - `docs/runbook/run-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+- expected:
+  - the current runbook family should provide one stable release object that can act as the default issue anchor for later ledger-class PRs.
+- observed:
+  - `WORKFLOW-GITHUB-001` already exists as one defended runbook release with explicit parent, supplement, and patch ledger bindings, so one release issue is the simpler default topology.
+
+### P1-C1-S1 (parent run and patch packets already read as subordinate objects under one family | 2026-04-21)
+
+- headSha: `WORKTREE`
+- artifacts:
+  - `docs/runbook/support-only/ledger-run-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+  - `docs/runbook/support-only/ledger-run-PATCH-001-WORKFLOW-GITHUB-001-GitHub-Issues-full-auto-pipeline.md`
+- expected:
+  - the parent run ledger and patch ledger should read as subordinate objects under one runbook family rather than as separate issue families by default.
+- observed:
+  - both packets already bind back to the same `WORKFLOW-GITHUB-001` family and the same admitted run context, so separate per-packet issues would add routing noise without clarifying the object boundary.
+
+### P2-C1-S1 (legacy placement and clean-branch rule required by mixed ancestry history | 2026-04-21)
+
+- headSha: `WORKTREE`
+- artifacts:
+  - `docs/logs/log-S0G-docs-management-v7.md`
+  - `docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md`
+- expected:
+  - once newer runbook-family surfaces exist and older historical carriers remain mixed, the repo should record both a legacy placement rule and a fresh-branch rule for later bounded packets.
+- observed:
+  - the current `S0G` spine already records a retrospective mixed-history close-out origin, while the newer runbook-family and support-only ledgers now provide a clearer current-state surface; this makes the `legacy` and clean-branch decisions necessary before the next commit burst.
+
+## Recent changes (for traceability, optional)
+
+- 2026-04-21: opened `S0G-3A` to fix the missing governance rule for release-issue concentration, object-first commit/PR naming, legacy runbook placement, and clean-branch discipline after the first `WORKFLOW-GITHUB-001` admitted run.

--- a/docs/logs/log-S0G-docs-management-v7.md
+++ b/docs/logs/log-S0G-docs-management-v7.md
@@ -18,6 +18,9 @@
   **reference_log_2**: `docs/logs/log-S0F-8B-s0f-issue-pr-automation-inventory-and-per-series-rollout.md`
   **reference_log_3**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
   **phase_log_1**: `docs/logs/log-S0G-1A-workspace-backfill-branch-road-registration-and-full-auto-close-out.md`
+  **phase_log_2**: `docs/logs/log-S0G-2A-runbook-ledger-aware-operator-surface-and-execution-accounting.md`
+  **phase_log_3**: `docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md`
+  **phase_log_4**: `docs/logs/log-S0G-3A-runbook-release-issue-concentration-and-ledger-naming-governance.md`
 **issue_keyword**: `automation`
 **issue_top_labels**: `EVOLUTION`
 **issue_scope_labels**: `s0/knowledge system, sub/0`
@@ -35,7 +38,7 @@
 **pr_base**: `main`
 **pr_development_issue**: ``
 **created**: `2026-04-20`
-**updated**: `2026-04-20`
+**updated**: `2026-04-21`
 
 ---
 
@@ -119,6 +122,12 @@
 
 - `S0G-1A`（Phase 1）：workspace backfill, branch-road registration, and full-auto close-out
   - 详见：`docs/logs/log-S0G-1A-workspace-backfill-branch-road-registration-and-full-auto-close-out.md`
+- `S0G-2A`（Phase 2）：runbook ledger-aware operator surface and execution accounting
+  - 详见：`docs/logs/log-S0G-2A-runbook-ledger-aware-operator-surface-and-execution-accounting.md`
+- `S0G-2B`（Phase 2B）：support-only ledger placement and patch-ledger bridge
+  - 详见：`docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md`
+- `S0G-3A`（Phase 3）：runbook release issue concentration and ledger naming governance
+  - 详见：`docs/logs/log-S0G-3A-runbook-release-issue-concentration-and-ledger-naming-governance.md`
 
 ## Execution Checklist（当前骨架里程碑汇总）
 
@@ -129,9 +138,10 @@
 
 ## Current Status（进展摘要）
 
-- `S0G` opens already in `stable` state because it is a backfill spine for work that is already materially complete in the workspace.
-- The immediate operational follow-through is not design work; it is GitHub lifecycle materialization: create the parent issue, run the child issue / PR / conclusion flow, and leave the old mixed branch behind.
-- Future follow-up should happen in later `S0G-*` children only if new uncaptured workspace packets appear; this spine itself should remain a one-child close-out anchor unless the scope genuinely widens again.
+- `S0G` remains `stable` as the docs-management v7 successor spine, but it is no longer only a one-child retrospective close-out anchor.
+- `S0G-1A` records the initial workspace backfill and lifecycle materialization packet, while `S0G-2A` and `S0G-2B` now fix the ledger-aware runbook surface, support-only ledger placement, and patch-ledger bridge contract.
+- `S0G-3A` now fixes the next missing governance layer: release-issue concentration, object-first commit/PR naming, legacy runbook placement, and clean-branch discipline for later runbook-family packets.
+- The next concrete work under this spine should now classify the current mixed workspace into `runbook-family commit/push now` vs `still evolution-log lane` before opening the next naming-driven commit burst.
 
 ## Evidence（可选，聚合型记账）
 


### PR DESCRIPTION
## Summary
- align the S0G parent issue writeback with the current spine state
- carry the S0G-2B and S0G-3A governance log updates into main
- keep this PR in evolution-log naming rather than runbook-family naming

## Scope
- docs/issues/issue-S0G-parent-live.json
- docs/issues/issue-S0G-parent-live.md
- docs/logs/log-S0G-2B-support-only-ledger-placement-and-patch-ledger-bridge.md
- docs/logs/log-S0G-3A-runbook-release-issue-concentration-and-ledger-naming-governance.md
- docs/logs/log-S0G-docs-management-v7.md

## Notes
- this PR intentionally excludes the already-cherry-picked S0F content
- the original S0G-1A screenshot commits no longer produce a standalone diff on current main, so this PR carries the surviving non-S4F evolution delta