### PR TITLE
S4F/P4-C2-S1: fill explicit parent issue milestone

### DIFF
--- a/docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md
+++ b/docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md
@@ -26,7 +26,7 @@
 **issue_top_labels**: ``
 **issue_scope_labels**: ``
 **issue_module_labels**: ``
-**issue_milestone**: ``
+**issue_milestone**: `road-002-01: deployable runtime slice and cloud backed asset readiness`
 **issue_parent**: ``
 **issue_projects**: ``
 **roadmap_path**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`


### PR DESCRIPTION
## Summary

- Fill the explicit parent issue milestone on the top-level S4F source log so the live parent issue can be backfilled without changing parent/spine contract ownership.
- Keep the parent follow-up as a narrow metadata repair separate from the child issue conclusion replay work.

## Links

- Log: `docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md`
- Issue: `https://github.com/samuelhu324-dev/wordloom-v3/issues/518`
- Roadmap: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`

Refs #518
