### PR TITLE
S4F-2C/P4-C1-S1+P4-C1-S2+P4-C2-S1: write back live issue link; drop invalid evidence footer placeholder; fill explicit issue and PR milestone

### DIFF
--- a/docs/logs/log-S4F-2C-deployed-identity-admission-membership-truth-hardening.md
+++ b/docs/logs/log-S4F-2C-deployed-identity-admission-membership-truth-hardening.md
@@ -10,7 +10,7 @@
 **tags**: `EVOLUTION, AccessControl, Auth, CloudRuntime, CredibleSimulation, Drills, Evidence, epic/s4, sub/2c`
 **links**: ``
   **issue**: `https://github.com/samuelhu324-dev/wordloom-v3/issues/510`
-  **pr**: ``
+  **pr**: `https://github.com/samuelhu324-dev/wordloom-v3/pull/514`
   **runbook**: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
   **roadmap**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
   **parent_log**: `docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md`
@@ -25,7 +25,7 @@
 **issue_top_labels**: ``
 **issue_scope_labels**: ``
 **issue_module_labels**: ``
-**issue_milestone**: ``
+**issue_milestone**: `road-002-01: deployable runtime slice and cloud backed asset readiness`
 **issue_parent**: ``
 **issue_projects**: ``
 **roadmap_path**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md`
@@ -34,7 +34,7 @@
 **roadmap_bridge_refs**: `docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md#M2-P1, docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md#M2-P2, docs/roadmap/road-002-01-deployable-runtime-slice-and-cloud-backed-asset-readiness.md#M2-P3`
 **pr_labels**: ``
 **pr_projects**: ``
-**pr_milestone**: ``
+**pr_milestone**: `road-002-01: deployable runtime slice and cloud backed asset readiness`
 **pr_base**: `main`
 **pr_development_issue**: ``
 **created**: `2026-04-20`


### PR DESCRIPTION
## Metadata

- Requested ID: `S4F-2C`
- Base branch: `main`
- Candidate PR-prep branch: `pr-prep/s4f-2c-p4-follow-up`
- Source log: `docs/logs/log-S4F-2C-deployed-identity-admission-membership-truth-hardening.md`
- Labels: `drills`
- Development issue: #510

## Summary

- Tighten the deployed access/subscription slice so member/admin truth is backend-issued or persistence-backed rather than browser-local.
- Reuse the already-proven `S4F` cloud runtime path while replacing local-first credibility gaps with deployed server-side truth.
- Capture one deployed member flow and one deployed admin flow whose key state changes are replayable from backend/database-backed evidence.

## Execution Checklist

- [x] `P0-C1-S1`: credibility boundary fixed
- [x] `P0-C1-S2`: chosen truth-model boundary fixed
- [x] `P0-C1-S3`: realism evidence contract fixed
- [x] `P1-C1-S1`: one bounded deployed authority shift chosen and recorded
- [x] `P1-C1-S2`: minimal backend/database-backed truth changes landed
- [x] `P2-C1-S1`: deployed member flow retained against backend/database-backed truth
- [x] `P2-C1-S2`: deployed admin flow retained against backend/database-backed truth
- [x] `P3-C1-S1`: remaining transitional realism gap recorded explicitly

## Links

- Log: `docs/logs/log-S4F-2C-deployed-identity-admission-membership-truth-hardening.md`
- Runbook: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`
- Evidence artifact: ``

Closes #510
