### PR TITLE
RUN-LEDGER-PATCH-001/01: write back parent issue convergence

### DIFF
--- a/docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md
+++ b/docs/logs/log-S4F-access-subscription-deployable-runtime-cut.md
@@ -9,7 +9,7 @@
 **scope**: `S4`
 **tags**: `EVOLUTION, OpsRuntime, CloudRuntime, AccessControl, ReleaseOperations, epic/s4, epic/s4f`
 **links**: ``
-  **issue**: ``
+  **issue**: `https://github.com/samuelhu324-dev/wordloom-v3/issues/518`
   **pr**: ``
   **adr**: ``
   **runbook**: `docs/runbook/run-S4D-cloud-runtime-release-operations.md`


### PR DESCRIPTION
Resurrects the RUN-LEDGER-PATCH-001/S4F residue from S0G-docs-management-v7 onto main for review and merge. This adaptation keeps the stronger current canonical ledger structure.