### PR TITLE
S4G: add run-004 and patch-004 support ledgers

### DIFF
--- a/docs/runbook/support-only/ledger-run-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline.md
+++ b/docs/runbook/support-only/ledger-run-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline.md
@@ -1,0 +1,108 @@
+# ledger-run-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline
+
+```yaml
+runbook_run_ledger:
+  run_ledger_id: ledger-run-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline
+  ledger_kind: runbook-run-ledger
+  status: completed
+  owner_lane: S4G
+  runbook_family: WORKFLOW-GITHUB-ISSUES
+  runbook_release: 001
+  runbook_id: run-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline
+  runbook_ref: docs/runbook/run-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline.md
+  run_sequence: 004
+  governance_area: workflow
+  functional_domain: GitHub lifecycle automation
+  environment_class: local-plus-github
+  target_surface: S4G parent-log creation-only plus sequential full-auto child execution for S4G-1A, S4G-1B, S4G-1C, S4G-1D, S4G-1E, S4G-1F, S4G-2A, S4G-2B, and S4G-1G
+  created_at: 2026-04-28
+  reviewed_at: 2026-04-28
+  accepted_at: pending
+  workflow_profiles:
+    - parent-issue-light-lifecycle
+    - child-issue-full-lifecycle
+  strong_structure_status: chronology-target-stage-attempt-active
+  target_reading_goal: show the first S4G run with one parent-spine creation-only target and nine child logs executed sequentially through the WORKFLOW-GITHUB-ISSUES-001 runbook, while preserving any later SUP or PATCH follow-up explicitly.
+```
+
+## Decision Frame
+
+- `RUN-004` opens because the target set is materially new relative to `RUN-003`: this run is for the `S4G` spine and its current admitted child packets rather than the earlier `S0G` residual lifecycle set.
+- The parent spine `S4G` is intentionally narrower than its children in this run: it should enter only through `CREATION`, while child logs should proceed sequentially through `CREATION`, `PR_PENDING`, `PR_MERGED`, and `CONCLUSION` when fail-closed gates permit.
+- Later bounded repair or chronology-sharpening work for this same run should remain explicit through `PATCH` or `SUP`; do not hide them inside target-row prose.
+
+## Current Run Status Summary
+
+| run row id | operational convergence | accounting status | approval status | target convergence count | target partial count | target blocked count | latest chronology round | latest updated from packet | reader verdict | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `RUN-004` | `converged` | `completed_opened` | `pending` | `10/10` | `0` | `0` | `RUN-004-R02` | `RUN-004` | `S4G parent creation-only target and all nine admitted child targets reached the intended terminal state; PATCH-004 recorded the bounded milestone-resolution repair exposed during S4G-1A creation.` | `Parent target S4G stopped at issue creation as intended. Child targets S4G-1A through S4G-1G and S4G-2A through S4G-2B completed guarded relationship, PR, merge, conclusion, and final lifecycle audit with pass status.` |
+
+## Execution Round Table
+
+| execution round id | run row id | round sequence | entry packet id | entry packet kind | target scope | stage scope attempted | round started at | round completed at | round verdict | delta entry ref | crosswalk ref | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `RUN-004-R01` | `RUN-004` | `01` | `S4G` | `log` | `S4G, S4G-1A, S4G-1B, S4G-1C` | `parent creation-only plus child full lifecycle through conclusion` | `2026-04-28` | `2026-04-28` | `pass-with-patch` | `PATCH-004` | `S4G -> S4G-1A -> S4G-1B -> S4G-1C` | `This round opened parent issue #559, completed 1A through 1C, repaired shorthand milestone-to-live-milestone resolution in PATCH-004, corrected the 1B parent issue body, and stabilized merged PR evidence for 1B and 1C through explicit overrides.` |
+| `RUN-004-R02` | `RUN-004` | `02` | `S4G-1D` | `log` | `S4G-1D, S4G-1E, S4G-1F, S4G-2A, S4G-2B, S4G-1G` | `child full lifecycle through conclusion` | `2026-04-28` | `2026-04-28` | `pass` | `RUN-004` | `S4G-1D -> S4G-1E -> S4G-1F -> S4G-2A -> S4G-2B -> S4G-1G` | `This round completed the remaining six child targets, created the live GitHub label workflow to unblock 2A PR creation, repaired the missing PR summary source input for 2B, and closed 1G after explicit merged PR override evidence was written back.` |
+
+## Current Target Status Table
+
+| target row id | run row id | target ref key | target kind | workflow profile | first_seen_in_round | first_seen_from_packet | current_status | current_stage_completion | latest_updated_in_round | latest_updated_from_packet | latest delta ref | latest delta focus | latest_updated_at | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `RUN-004-T01` | `RUN-004` | `S4G` | `parent-log` | `parent-issue-light-lifecycle` | `RUN-004-R01` | `S4G` | `converged` | `creation-only-admitted` | `RUN-004-R01` | `S4G` | `issue-559` | `issue-created` | `2026-04-28` | `Parent spine stopped intentionally after issue creation. Live issue: #559.` |
+| `RUN-004-T02` | `RUN-004` | `S4G-1A` | `child-log` | `child-issue-full-lifecycle` | `RUN-004-R01` | `S4G-1A` | `converged` | `concluded-pass` | `RUN-004-R01` | `S4G-1A` | `issue-560-pr-561` | `creation repair then full lifecycle` | `2026-04-28` | `Issue #560 and PR #561 concluded with final lifecycle audit pass after PATCH-004 repaired milestone resolution.` |
+| `RUN-004-T03` | `RUN-004` | `S4G-1B` | `child-log` | `child-issue-full-lifecycle` | `RUN-004-R01` | `S4G-1B` | `converged` | `concluded-pass` | `RUN-004-R01` | `S4G-1B` | `issue-562-pr-563` | `full lifecycle` | `2026-04-28` | `Issue #562 and PR #563 concluded with final lifecycle audit pass after parent metadata was remediated to point to #560.` |
+| `RUN-004-T04` | `RUN-004` | `S4G-1C` | `child-log` | `child-issue-full-lifecycle` | `RUN-004-R01` | `S4G-1C` | `converged` | `concluded-pass` | `RUN-004-R01` | `S4G-1C` | `issue-564-pr-565` | `full lifecycle` | `2026-04-28` | `Issue #564 and PR #565 concluded with final lifecycle audit pass after source-log issue write-back was repaired and merged PR override evidence was retained.` |
+| `RUN-004-T05` | `RUN-004` | `S4G-1D` | `child-log` | `child-issue-full-lifecycle` | `RUN-004-R02` | `S4G-1D` | `converged` | `concluded-pass` | `RUN-004-R02` | `S4G-1D` | `issue-566-pr-567` | `full lifecycle` | `2026-04-28` | `Issue #566 and PR #567 concluded with final lifecycle audit pass.` |
+| `RUN-004-T06` | `RUN-004` | `S4G-1E` | `child-log` | `child-issue-full-lifecycle` | `RUN-004-R02` | `S4G-1E` | `converged` | `concluded-pass` | `RUN-004-R02` | `S4G-1E` | `issue-568-pr-569` | `full lifecycle` | `2026-04-28` | `Issue #568 and PR #569 concluded with final lifecycle audit pass.` |
+| `RUN-004-T07` | `RUN-004` | `S4G-1F` | `child-log` | `child-issue-full-lifecycle` | `RUN-004-R02` | `S4G-1F` | `converged` | `concluded-pass` | `RUN-004-R02` | `S4G-1F` | `issue-570-pr-571` | `full lifecycle` | `2026-04-28` | `Issue #570 and PR #571 concluded with final lifecycle audit pass.` |
+| `RUN-004-T08` | `RUN-004` | `S4G-2A` | `child-log` | `child-issue-full-lifecycle` | `RUN-004-R02` | `S4G-2A` | `converged` | `concluded-pass` | `RUN-004-R02` | `S4G-2A` | `issue-572-pr-573` | `label remediation then full lifecycle` | `2026-04-28` | `Issue #572 and PR #573 concluded with final lifecycle audit pass after the live PR label workflow was created.` |
+| `RUN-004-T09` | `RUN-004` | `S4G-2B` | `child-log` | `child-issue-full-lifecycle` | `RUN-004-R02` | `S4G-2B` | `converged` | `concluded-pass` | `RUN-004-R02` | `S4G-2B` | `issue-574-pr-575` | `summary repair then full lifecycle` | `2026-04-28` | `Issue #574 and PR #575 concluded with final lifecycle audit pass after source-log PR summary inputs were added to satisfy PR preview integrity.` |
+| `RUN-004-T10` | `RUN-004` | `S4G-1G` | `child-log` | `child-issue-full-lifecycle` | `RUN-004-R02` | `S4G-1G` | `converged` | `concluded-pass` | `RUN-004-R02` | `S4G-1G` | `issue-576-pr-577` | `full lifecycle` | `2026-04-28` | `Issue #576 and PR #577 concluded with final lifecycle audit pass after merged PR override evidence was written back post-merge.` |
+
+## Target Stage Attempt Table
+
+| attempt id | target row id | stage row id | stage name | round id | source packet id | source packet kind | attempt ordinal | started at | completed at | status | blocking reason | supersedes attempt id | current? | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `RUN-004-A01` | `RUN-004-T01` | `RUN-004-S01` | `creation-only` | `RUN-004-R01` | `S4G` | `log` | `1` | `2026-04-28` | `2026-04-28` | `pass` | `none` | `none` | `yes` | `Parent issue #559 created and intentionally left at the creation-only boundary.` |
+| `RUN-004-A02` | `RUN-004-T02` | `RUN-004-S02` | `creation` | `RUN-004-R01` | `S4G-1A` | `log` | `1` | `2026-04-28` | `2026-04-28` | `blocked` | `Milestone shorthand M2 did not resolve to a live GitHub milestone title during issue create validation.` | `none` | `no` | `This blocked attempt produced the bounded repair recorded in PATCH-004.` |
+| `RUN-004-A03` | `RUN-004-T02` | `RUN-004-S03` | `full-lifecycle-chain` | `RUN-004-R01` | `S4G-1A` | `log` | `2` | `2026-04-28` | `2026-04-28` | `pass` | `none` | `RUN-004-A02` | `yes` | `Issue #560, PR #561, guarded conclusion, and final lifecycle audit all passed after PATCH-004 landed.` |
+| `RUN-004-A04` | `RUN-004-T03` | `RUN-004-S04` | `full-lifecycle-chain` | `RUN-004-R01` | `S4G-1B` | `log` | `1` | `2026-04-28` | `2026-04-28` | `pass` | `none` | `none` | `yes` | `Issue #562 and PR #563 passed after live parent metadata was corrected to issue #560.` |
+| `RUN-004-A05` | `RUN-004-T04` | `RUN-004-S05` | `full-lifecycle-chain` | `RUN-004-R01` | `S4G-1C` | `log` | `1` | `2026-04-28` | `2026-04-28` | `pass` | `none` | `none` | `yes` | `Issue #564 and PR #565 passed after source-log issue write-back was repaired.` |
+| `RUN-004-A06` | `RUN-004-T05` | `RUN-004-S06` | `full-lifecycle-chain` | `RUN-004-R02` | `S4G-1D` | `log` | `1` | `2026-04-28` | `2026-04-28` | `pass` | `none` | `none` | `yes` | `Issue #566 and PR #567 passed through conclusion and final audit.` |
+| `RUN-004-A07` | `RUN-004-T06` | `RUN-004-S07` | `full-lifecycle-chain` | `RUN-004-R02` | `S4G-1E` | `log` | `1` | `2026-04-28` | `2026-04-28` | `pass` | `none` | `none` | `yes` | `Issue #568 and PR #569 passed through conclusion and final audit.` |
+| `RUN-004-A08` | `RUN-004-T07` | `RUN-004-S08` | `full-lifecycle-chain` | `RUN-004-R02` | `S4G-1F` | `log` | `1` | `2026-04-28` | `2026-04-28` | `pass` | `none` | `none` | `yes` | `Issue #570 and PR #571 passed through conclusion and final audit.` |
+| `RUN-004-A09` | `RUN-004-T08` | `RUN-004-S09` | `pr-preflight` | `RUN-004-R02` | `S4G-2A` | `log` | `1` | `2026-04-28` | `2026-04-28` | `blocked` | `Requested PR label workflow did not exist in the live repository.` | `none` | `no` | `The operator created the live workflow label and retried the target.` |
+| `RUN-004-A10` | `RUN-004-T08` | `RUN-004-S10` | `full-lifecycle-chain` | `RUN-004-R02` | `S4G-2A` | `log` | `2` | `2026-04-28` | `2026-04-28` | `pass` | `none` | `RUN-004-A09` | `yes` | `Issue #572 and PR #573 passed through conclusion and final audit after label remediation.` |
+| `RUN-004-A11` | `RUN-004-T09` | `RUN-004-S11` | `pr-preflight` | `RUN-004-R02` | `S4G-2B` | `log` | `1` | `2026-04-28` | `2026-04-28` | `blocked` | `PR preview integrity failed because the source log still used placeholder summary content.` | `none` | `no` | `The source log was repaired locally by adding PR Summary Inputs and summary bullets.` |
+| `RUN-004-A12` | `RUN-004-T09` | `RUN-004-S12` | `full-lifecycle-chain` | `RUN-004-R02` | `S4G-2B` | `log` | `2` | `2026-04-28` | `2026-04-28` | `pass` | `none` | `RUN-004-A11` | `yes` | `Issue #574 and PR #575 passed through conclusion and final audit after the source-log summary repair.` |
+| `RUN-004-A13` | `RUN-004-T10` | `RUN-004-S13` | `full-lifecycle-chain` | `RUN-004-R02` | `S4G-1G` | `log` | `1` | `2026-04-28` | `2026-04-28` | `pass` | `none` | `none` | `yes` | `Issue #576 and PR #577 passed through conclusion and final audit with explicit merged PR override evidence retained post-merge.` |
+
+## Evidence Extraction Table
+
+| evidence item id | run row id | target row id | target stage row id | artifact file | evidence type | extraction scope | admitted fields | verification status | used by | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `RUN-004-E01` | `RUN-004` | `—` | `—` | `docs/runbook/run-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline.md` | `md` | `full` | `runbook family, workflow profiles, ledger binding, minimum admitted fields` | `verified` | `run-004 opening` | `The active WORKFLOW-GITHUB-ISSUES-001 runbook is the governing operator surface for this run.` |
+| `RUN-004-E02` | `RUN-004` | `—` | `—` | `docs/logs/log-S4G-fallback-cells-and-failure-drills-asset-governance.md` | `md` | `partial` | `parent log identity, child packet routing, execution split between parent creation-only and child full-auto` | `verified` | `run-004 target set` | `This source log fixes the bounded S4G target set for RUN-004.` |
+| `RUN-004-E03` | `RUN-004` | `RUN-004-T02` | `RUN-004-S02` | `docs/runbook/support-only/ledger-run-PATCH-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline.md` | `md` | `full` | `bounded repair scope, failing create-time check, patch binding to RUN-004 and S4G-1A` | `verified` | `S4G-1A create-time repair` | `PATCH-004 records the milestone shorthand repair admitted during RUN-004.` |
+| `RUN-004-E04` | `RUN-004` | `RUN-004-T05` | `RUN-004-S06` | `docs/issues/lifecycle-audit-S4G-1D-live-plan.json` | `json` | `partial` | `issue 566, pr 567, concluded lifecycle stage, final audit pass` | `verified` | `round-02 final audit evidence` | `Representative child final audit evidence begins with S4G-1D and continues through later child-specific plan files.` |
+| `RUN-004-E05` | `RUN-004` | `RUN-004-T08` | `RUN-004-S10` | `docs/issues/lifecycle-audit-S4G-2A-live-plan.json` | `json` | `partial` | `issue 572, pr 573, label-remediation aftermath, final audit pass` | `verified` | `workflow lane unblock evidence` | `S4G-2A retains the workflow-label remediation evidence alongside its final pass state.` |
+| `RUN-004-E06` | `RUN-004` | `RUN-004-T09` | `RUN-004-S12` | `docs/issues/lifecycle-audit-S4G-2B-live-plan.json` | `json` | `partial` | `issue 574, pr 575, final audit pass after PR summary repair` | `verified` | `source-summary repair evidence` | `S4G-2B demonstrates the bounded source-log summary repair that unblocked PR publication.` |
+| `RUN-004-E07` | `RUN-004` | `RUN-004-T10` | `RUN-004-S13` | `docs/issues/lifecycle-audit-S4G-1G-live-plan.json` | `json` | `partial` | `issue 576, pr 577, final audit pass with merged_pr_overrides` | `verified` | `terminal child closure evidence` | `S4G-1G closes the run with deterministic merged PR evidence retained in the final audit manifest.` |
+
+## Actor and Provenance Review Table
+
+| row id | submitted by | evidence owner | reviewed by | verified by | verification method | approved by | approval state | approval basis | provenance note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `RUN-004` | `role:workflow-operator` | `role:runbook-maintainer` | `role:workflow-operator` | `role:evidence-verifier` | `direct artifact inspection across live issue JSON, PR create results, and lifecycle-audit plan files` | `pending` | `pending` | `The run completed against the defended runbook with explicit PATCH binding, guarded conclusion artifacts, and final lifecycle-audit pass evidence for every admitted child target.` | `This run began from the S4G working branch, admitted live GitHub issue and PR mutations sequentially, and finished with source-log write-back plus lifecycle-audit verification retained in docs/issues artifacts.` |
+
+## Optional Run Time Audit
+
+| run row id | run started at | run completed at | source recorded at | time precision | timezone note | notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `RUN-004` | `2026-04-28` | `2026-04-28` | `2026-04-28` | `day` | `Live GitHub timestamps are retained in the emitted JSON artifacts; the parent-ledger write-back was completed from the local operator session on the same date.` | `The run is complete: parent S4G remained creation-only, all nine child targets concluded, and PATCH-004 remains the only bounded repair ledger bound to this run.` |
+
+## Reader Notes
+
+- `RUN-004` remained the correct parent ledger because `S4G` is a materially new target family relative to `RUN-003`, and the run preserved the intended split between parent creation-only handling and child full-lifecycle handling.
+- `PATCH-004` is the only bounded repair admitted into the run ledger itself; later local repairs for `S4G-2A` and `S4G-2B` were retained directly in target attempt chronology because they did not require a separate run-level patch packet.
+- The terminal evidence surface for this run is the child-specific lifecycle-audit plan set in `docs/issues`, which confirms final pass state for `S4G-1A` through `S4G-1G` and `S4G-2A` through `S4G-2B`.

--- a/docs/runbook/support-only/ledger-run-PATCH-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline.md
+++ b/docs/runbook/support-only/ledger-run-PATCH-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline.md
@@ -1,0 +1,71 @@
+# ledger-run-PATCH-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline
+
+```yaml
+runbook_run_patch_ledger:
+  patch_ledger_id: ledger-run-PATCH-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline
+  patch_kind: runbook-run-ledger-patch
+  status: active
+  owner_lane: S4G-1A
+  parent_runbook_id: run-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline
+  parent_runbook_ref: docs/runbook/run-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline.md
+  parent_run_ledger_id: ledger-run-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline
+  parent_run_ledger_ref: docs/runbook/support-only/ledger-run-004-WORKFLOW-GITHUB-ISSUES-001-GitHub-Issues-full-auto-pipeline.md
+  parent_run_row_id: RUN-004
+  parent_target_row_id: RUN-004-T02
+  parent_target_stage_row_id: RUN-004-T02-STG-CREATION
+  parent_target_stage_attempt_id: RUN-004-T02-STG-CREATION-A01
+  target_ref_key: S4G-1A
+  target_ref_path: docs/logs/log-S4G-1A-s4-history-extraction-and-code-first-fallback-cells-assessment.md
+  patch_sequence: 004
+  created_at: 2026-04-28
+  reviewed_at: 2026-04-28
+  accepted_at: pending
+  writeback_started_at: 2026-04-28
+  writeback_completed_at: 2026-04-28
+  patch_scope: record the bounded create-surface repair that resolves exact roadmap-bridge milestone tokens to the live GitHub milestone title before create-time validation.
+  patch_reason_class: script-fix
+  approval_boundary: runbook-bound create-surface repairs must remain reviewable before they are treated as stable support-only evidence for later child-target execution under the same release.
+  target_reading_goal: show that the first RUN-004 child target exposed one bounded gen_issue_draft.py failure mode, that the repair preserved fail-closed milestone validation semantics, and that the repaired surface was immediately validated by successful live issue creation for S4G-1A.
+```
+
+## Decision Frame
+
+- This patch packet is bound to `RUN-004`, because the defect was first exposed by `S4G-1A` during the active `S4G` child execution sequence.
+- The repair is intentionally narrow: exact roadmap bridge metadata such as `roadmap_milestone: M1` should resolve to the one live GitHub milestone title governed by the roadmap id prefix rather than failing closed on the shorthand token itself.
+- No release bump is justified because the repair restores the defended milestone-resolution contract instead of widening feature scope or changing the admitted lifecycle model.
+
+## Patch Packet Summary
+
+| patch ledger id | patch sequence | parent run row id | repair scope | packet verdict | current release effect | admitted chronology effect | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `PATCH-004` | `004` | `RUN-004` | `roadmap bridge milestone resolution repair in issue draft generation` | `completed` | `no-release-bump` | `no-direct-chronology-change` | `The repair was validated immediately by re-running S4G-1A live issue creation to issue #560 with the milestone normalized to the live GitHub title.` |
+
+## Repair Delta Table
+
+| patch item id | target artifact or path | repair class | prior defect reading | new defended repair reading | effect on admitted chronology | requires paired SUP? | paired SUP ref | parent-ledger writeback | primary evidence ref | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `PATCH-004-I01` | `scripts/issues/gen_issue_draft.py` | `script-fix` | `exact roadmap bridge milestone tokens such as M1 were passed directly into create-time milestone validation, causing live issue creation to fail closed even when the repo contained the intended roadmap milestone under its canonical live title` | `derived roadmap bridge milestone tokens now resolve through roadmap_path metadata to the one live milestone title before validation, while still failing closed when no unique live title exists` | `no-direct-chronology-change` | `no` | `not-required` | `append-patch-ref` | `docs/issues/issue-S4G-1A-s4-history-extraction-and-code-first-fallback-cells-assessment.json` | `The repaired create path normalized the roadmap bridge token to the live milestone title and produced live issue #560 after the initial fail-closed attempt.` |
+
+## Patch Change Table
+
+| patch item id | parent run row id | target row id | target stage row id | target stage attempt id | target artifact or path | change class | evidence refs | verification status | approval status | effect on current runbook release | proposed parent-ledger action | downstream impact | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `PATCH-004-I01` | `RUN-004` | `RUN-004-T02` | `RUN-004-T02-STG-CREATION` | `RUN-004-T02-STG-CREATION-A01` | `scripts/issues/gen_issue_draft.py` | `script-fix` | `docs/issues/issue-S4G-1A-s4-history-extraction-and-code-first-fallback-cells-assessment.json` | `verified` | `pending` | `no-release-bump` | `append-patch-ref` | `unblock-run-004-creation-for-roadmap-bridge-milestone-targets` | `The fix keeps live milestone validation fail-closed while allowing exact roadmap bridge shorthand to resolve to the canonical GitHub milestone title.` |
+
+## Attachment Review Table
+
+| attachment id | patch item id | click-through asset ref | review status | approval basis | review note |
+| --- | --- | --- | --- | --- | --- |
+| `PATCH-004-I01-ATT-01` | `PATCH-004-I01` | `docs/issues/issue-S4G-1A-s4-history-extraction-and-code-first-fallback-cells-assessment.json` | `accepted-for-packet` | `The successful post-repair create artifact records the normalized live milestone title and shows issue #560 was created live under the defended metadata set.` | `Checked the repaired live create output for S4G-1A after roadmap bridge milestone resolution was restored.` |
+
+## Actor and Provenance Review Table
+
+| patch item id | run row id | target row id | target stage row id | submitted by | evidence owner | reviewed by | verified by | verification method | approved by | approval state | approval basis | provenance note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `PATCH-004-I01` | `RUN-004` | `RUN-004-T02` | `RUN-004-T02-STG-CREATION` | `role:workflow-operator` | `role:workflow-maintainer` | `pending` | `role:evidence-verifier` | `live-create-replay-after-roadmap-bridge-milestone-resolution-repair` | `pending` | `pending` | `The repair is bounded to issue-draft milestone derivation and was validated by the immediate successful live create replay for S4G-1A.` | `This row was opened when the first S4G-1A create attempt failed closed on shorthand milestone M1 even though the repo already contained the canonical roadmap milestone title.` |
+
+## Reader Notes
+
+- `PATCH-004` stays repair-first: it explains why `RUN-004-T02-STG-CREATION-A01` should read as `pass_after_recovery`, but it does not become its own chronology round.
+- If a later run-level reading needs sharpening because of this repair, that later admission should still land through a `SUP` packet rather than by overloading this patch ledger.
+- The defended contract outcome is narrow and reusable for later `S4G` child targets that derive milestones from the same roadmap bridge metadata family.


### PR DESCRIPTION
## Summary
- split the S4G support-only run ledgers out of the broader execution branch
- add the standalone RUN-004 parent ledger and PATCH-004 repair ledger for review

## Notes
- sourced from commit 416c48bbfb6b450b73b5ef55427cabcee82426ce
- excludes source-log write-backs and script changes from the broader S4G execution commit